### PR TITLE
collected data as code

### DIFF
--- a/.changeset/auto-collected-sentinel.md
+++ b/.changeset/auto-collected-sentinel.md
@@ -1,0 +1,6 @@
+---
+"@openpolicy/sdk": minor
+"@openpolicy/vite-auto-collect": minor
+---
+
+Add `autoCollected` sentinel to `@openpolicy/sdk` and new `@openpolicy/vite-auto-collect` Vite plugin that scans source files for `collecting()` calls and inlines the discovered categories into the sentinel at build time. Spread `autoCollected` into `dataCollected` in your `openpolicy.ts` — the plugin composes cleanly without requiring `@openpolicy/vite`.

--- a/.changeset/collecting-runtime-wrapper.md
+++ b/.changeset/collecting-runtime-wrapper.md
@@ -1,0 +1,5 @@
+---
+"@openpolicy/sdk": minor
+---
+
+Add `collecting()` runtime wrapper for declaring data collection at the point of storage

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,7 @@
 			"@openpolicy/sdk",
 			"@openpolicy/core",
 			"@openpolicy/vite",
+			"@openpolicy/vite-auto-collect",
 			"@openpolicy/cli",
 			"@openpolicy/astro",
 			"@openpolicy/react",

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -1,3 +1,3 @@
-@import 'tailwindcss';
-@import 'fumadocs-ui/css/neutral.css';
-@import 'fumadocs-ui/css/preset.css';
+@import "tailwindcss";
+@import "fumadocs-ui/css/neutral.css";
+@import "fumadocs-ui/css/preset.css";

--- a/apps/www/src/components/header.astro
+++ b/apps/www/src/components/header.astro
@@ -1,5 +1,5 @@
 ---
-import LogoWide from "../assets/logo-wide.svg"
+import LogoWide from "../assets/logo-wide.svg";
 ---
 
 <header>

--- a/apps/www/src/components/nav.astro
+++ b/apps/www/src/components/nav.astro
@@ -1,13 +1,16 @@
 ---
 let stars: number | null = null;
 try {
-  const res = await fetch("https://api.github.com/repos/jamiedavenport/openpolicy", {
-    headers: { Accept: "application/vnd.github+json" },
-  });
-  if (res.ok) {
-    const data = await res.json();
-    stars = data.stargazers_count;
-  }
+	const res = await fetch(
+		"https://api.github.com/repos/jamiedavenport/openpolicy",
+		{
+			headers: { Accept: "application/vnd.github+json" },
+		},
+	);
+	if (res.ok) {
+		const data = await res.json();
+		stars = data.stargazers_count;
+	}
 } catch {}
 ---
 

--- a/apps/www/src/layouts/BaseLayout.astro
+++ b/apps/www/src/layouts/BaseLayout.astro
@@ -7,21 +7,21 @@ import Nav from "../components/nav.astro";
 import { Icon } from "astro-icon/components";
 
 interface Props {
-  title: string;
-  description: string;
-  ogUrl?: string;
-  ogImage?: string;
-  ctaHref?: string;
-  ctaText?: string;
+	title: string;
+	description: string;
+	ogUrl?: string;
+	ogImage?: string;
+	ctaHref?: string;
+	ctaText?: string;
 }
 
 const {
-  title,
-  description,
-  ogUrl = "https://openpolicy.sh",
-  ogImage = "https://openpolicy.sh/og.png",
-  ctaHref = "https://docs.openpolicy.sh",
-  ctaText = "Documentation",
+	title,
+	description,
+	ogUrl = "https://openpolicy.sh",
+	ogImage = "https://openpolicy.sh/og.png",
+	ctaHref = "https://docs.openpolicy.sh",
+	ctaText = "Documentation",
 } = Astro.props;
 ---
 

--- a/apps/www/src/pages/404.astro
+++ b/apps/www/src/pages/404.astro
@@ -1,5 +1,5 @@
 ---
-import '../styles/global.css';
+import "../styles/global.css";
 import { Font } from "astro:assets";
 ---
 

--- a/apps/www/src/pages/blog.astro
+++ b/apps/www/src/pages/blog.astro
@@ -3,7 +3,7 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const posts = (await getCollection("blog")).sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
 ---
 

--- a/apps/www/src/pages/blog/[slug].astro
+++ b/apps/www/src/pages/blog/[slug].astro
@@ -4,8 +4,11 @@ import { Icon } from "astro-icon/components";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog");
-  return posts.map((post) => ({ params: { slug: post.slug }, props: { post } }));
+	const posts = await getCollection("blog");
+	return posts.map((post) => ({
+		params: { slug: post.slug },
+		props: { post },
+	}));
 }
 
 const { post } = Astro.props;

--- a/apps/www/src/pages/examples.astro
+++ b/apps/www/src/pages/examples.astro
@@ -2,24 +2,27 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const examples = [
-  {
-    name: "Astro",
-    description: "Static site using the Astro integration. Generates Markdown and HTML policy files at build time.",
-    href: "https://github.com/jamiedavenport/openpolicy/tree/main/examples/astro",
-    packages: ["@openpolicy/sdk", "@openpolicy/astro"],
-  },
-  {
-    name: "Next.js",
-    description: "Next.js App Router app rendering policies at runtime via @openpolicy/react. Includes the \"use client\" provider pattern required for App Router.",
-    href: "https://github.com/jamiedavenport/openpolicy/tree/main/examples/nextjs",
-    packages: ["@openpolicy/sdk", "@openpolicy/react"],
-  },
-  {
-    name: "TanStack Start",
-    description: "Vite + React app using the Vite plugin alongside TanStack Start. Policies are served as dedicated routes.",
-    href: "https://github.com/jamiedavenport/openpolicy/tree/main/examples/tanstack",
-    packages: ["@openpolicy/sdk", "@openpolicy/vite"],
-  },
+	{
+		name: "Astro",
+		description:
+			"Static site using the Astro integration. Generates Markdown and HTML policy files at build time.",
+		href: "https://github.com/jamiedavenport/openpolicy/tree/main/examples/astro",
+		packages: ["@openpolicy/sdk", "@openpolicy/astro"],
+	},
+	{
+		name: "Next.js",
+		description:
+			'Next.js App Router app rendering policies at runtime via @openpolicy/react. Includes the "use client" provider pattern required for App Router.',
+		href: "https://github.com/jamiedavenport/openpolicy/tree/main/examples/nextjs",
+		packages: ["@openpolicy/sdk", "@openpolicy/react"],
+	},
+	{
+		name: "TanStack Start",
+		description:
+			"Vite + React app using the Vite plugin alongside TanStack Start. Policies are served as dedicated routes.",
+		href: "https://github.com/jamiedavenport/openpolicy/tree/main/examples/tanstack",
+		packages: ["@openpolicy/sdk", "@openpolicy/vite"],
+	},
 ];
 ---
 

--- a/apps/www/src/pages/framework/[slug].astro
+++ b/apps/www/src/pages/framework/[slug].astro
@@ -4,8 +4,11 @@ import { Icon } from "astro-icon/components";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
-  const guides = await getCollection("frameworks");
-  return guides.map((guide) => ({ params: { slug: guide.slug }, props: { guide } }));
+	const guides = await getCollection("frameworks");
+	return guides.map((guide) => ({
+		params: { slug: guide.slug },
+		props: { guide },
+	}));
 }
 
 const { guide } = Astro.props;

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -2,9 +2,9 @@
 @plugin "@tailwindcss/typography";
 
 @theme inline {
-    --font-mono: var(--font-geist-mono);
+	--font-mono: var(--font-geist-mono);
 }
 
 code {
-    font-size: inherit;
+	font-size: inherit;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -149,7 +149,7 @@
       },
       "devDependencies": {
         "@openpolicy/sdk": "workspace:*",
-        "@openpolicy/vite": "workspace:*",
+        "@openpolicy/vite-auto-collect": "workspace:*",
         "@playwright/test": "^1.53.2",
         "@tailwindcss/vite": "^4.2.1",
         "@types/node": "^25.3.5",
@@ -257,6 +257,21 @@
         "@openpolicy/renderers": "workspace:*",
         "@openpolicy/tooling": "workspace:*",
         "vite": "^5.0.0",
+      },
+      "peerDependencies": {
+        "vite": ">=4.0.0",
+      },
+    },
+    "packages/vite-auto-collect": {
+      "name": "@openpolicy/vite-auto-collect",
+      "version": "0.0.17",
+      "dependencies": {
+        "oxc-parser": "^0.124.0",
+      },
+      "devDependencies": {
+        "@openpolicy/sdk": "workspace:*",
+        "@openpolicy/tooling": "workspace:*",
+        "vite": "catalog:",
       },
       "peerDependencies": {
         "vite": ">=4.0.0",
@@ -688,6 +703,8 @@
 
     "@openpolicy/vite": ["@openpolicy/vite@workspace:packages/vite"],
 
+    "@openpolicy/vite-auto-collect": ["@openpolicy/vite-auto-collect@workspace:packages/vite-auto-collect"],
+
     "@openpolicy/vue": ["@openpolicy/vue@workspace:packages/vue"],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
@@ -695,6 +712,46 @@
     "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.124.0", "", { "os": "android", "cpu": "arm" }, "sha512-+R9zCafSL8ovjokdPtorUp3sXrh8zQ2AC2L0ivXNvlLR0WS+5WdPkNVrnENq5UvzagM4Xgl0NPsJKz3Hv9+y8g=="],
+
+    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.124.0", "", { "os": "android", "cpu": "arm64" }, "sha512-ULHC/gVZ+nP4pd3kNNQTYaQ/e066BW/KuY5qUsvwkVWwOUQGDg+WpfyVOmQ4xfxoue6cMlkKkJ+ntdzfDXpNlg=="],
+
+    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.124.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fGJ2hw7bnbUYn6UvTjp0m4WJ9zXz3cohgcwcgeo7gUZehpPNpvcVEVeIVHNmHnAuAw/ysf4YJR8DA1E+xCA4Lw=="],
+
+    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.124.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-j0+re9pgps5BH2Tk3fm59Hi3QuLP3C4KhqXi6A+wRHHHJWDFR8mc/KI9mBrfk2JRT+15doGo+zv1eN75/9DuOw=="],
+
+    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.124.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-0k5mS0npnrhKy72UfF51lpOZ2ESoPWn6gdFw+RdeRWcokraDW1O2kSx3laQ+yk7cCEavQdJSpWCYS/GvBbUCXQ=="],
+
+    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.124.0", "", { "os": "linux", "cpu": "arm" }, "sha512-P/i4eguRWvAUfGdfhQYg1jpwYkyUV6D3gefIH7HhmRl1Ph6P4IqTIEVcyJr1i/3vr1V5OHU4wonH6/ue/Qzvrw=="],
+
+    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.124.0", "", { "os": "linux", "cpu": "arm" }, "sha512-/ameqFQH5fFP+66Atr8Ynv/2rYe4utcU7L4MoWS5JtrFLVO78g4qDLavyIlJxa6caSwYOvG/eO3c/DXqY5/6Rw=="],
+
+    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.124.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-gNeyEcXTtfrRCbj2EfxWU85Fs0wIX3p44Y3twnvuMfkWlLrb9M1Z25AYNSKjJM+fdAjeeQCjw0on47zFuBYwQw=="],
+
+    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.124.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-uvG7v4Tz9S8/PVqY0SP0DLHxo4hZGe+Pv2tGVnwcsjKCCUPjplbrFVvDzXq+kOaEoUkiCY0Kt1hlZ6FDJ1LKNQ=="],
+
+    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.124.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-t7KZaaUhfp2au0MRpoENEFqwLKYDdptEry6V7pTAVdPEcFG4P6ii8yeGU9m6p5vb+b8WEKmdpGMNXBEYy7iJdw=="],
+
+    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.124.0", "", { "os": "linux", "cpu": "none" }, "sha512-eurGGaxHZiIQ+fBSageS8TAkRqZgdOiBeqNrWAqAPup9hXBTmQ0WcBjwsLElf+3jvDL9NhnX0dOgOqPfsjSjdg=="],
+
+    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.124.0", "", { "os": "linux", "cpu": "none" }, "sha512-d1V7/ll1i/LhqE/gZy6Wbz6evlk0egh2XKkwMI3epiojtbtUwQSLIER0Y3yDBBocPuWOjJdvmjtEmPTTLXje/w=="],
+
+    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.124.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-w1+cBvriUteOpox6ATqCFVkpGL47PFdcfCPGmgUZbd78Fw44U0gQkc+kVGvAOTvGrptMYgwomD1c6OTVvkrpGg=="],
+
+    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.124.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RRB1evQiXRtMCsQQiAh9U0H3HzguLpE0ytfStuhRgmOj7tqUCOVxkHsvM9geZjAax6NqVRj7VXx32qjjkZPsBw=="],
+
+    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.124.0", "", { "os": "linux", "cpu": "x64" }, "sha512-asVYN0qmSHlCU8H9Q47SmeJ/Z5EG4IWCC+QGxkfFboI5qh15aLlJnHmnrV61MwQRPXGnVC/sC3qKhrUyqGxUqw=="],
+
+    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.124.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nhwuxm6B8pn9lzAzMUfa571L5hCXYwQo8C8cx5aGOuHWCzruR8gPJnRRXGBci+uGaIIQEZDyU/U6HDgrSp/JlQ=="],
+
+    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.124.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.2" }, "cpu": "none" }, "sha512-LWuq4Dl9tff7n+HjJcqoBjDlVCtruc0shgtdtGM+rTUIE9aFxHA/P+wCYR+aWMjN8m9vNaRME/sKXErmhmeKrA=="],
+
+    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.124.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-aOh3Lf3AeH0dgzT4yBXcArFZ8VhqNXwZ/xlN0GqBtgVaGoHOOqL2YHlcVIgT+ghsXPVR2PTtYgBiQ1CNK7jp5A=="],
+
+    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.124.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-sib5xC0nz/+SCpaETBuHBz4SXS02KuG5HtyOcHsO/SK5ZvLRGhOZx0elDKawjb6adFkD7dQCqpXUS25wY6ELKQ=="],
+
+    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.124.0", "", { "os": "win32", "cpu": "x64" }, "sha512-UgojtjGUgZgAZQYt7SC6VO65OVdxEkRe2q+2vbHJO//18qw3Hrk6UvHGQKldsQKgbVcIBT/YBrt85YberiYIPQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
 
@@ -2342,6 +2399,8 @@
 
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
 
+    "oxc-parser": ["oxc-parser@0.124.0", "", { "dependencies": { "@oxc-project/types": "^0.124.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.124.0", "@oxc-parser/binding-android-arm64": "0.124.0", "@oxc-parser/binding-darwin-arm64": "0.124.0", "@oxc-parser/binding-darwin-x64": "0.124.0", "@oxc-parser/binding-freebsd-x64": "0.124.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.124.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.124.0", "@oxc-parser/binding-linux-arm64-gnu": "0.124.0", "@oxc-parser/binding-linux-arm64-musl": "0.124.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.124.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.124.0", "@oxc-parser/binding-linux-riscv64-musl": "0.124.0", "@oxc-parser/binding-linux-s390x-gnu": "0.124.0", "@oxc-parser/binding-linux-x64-gnu": "0.124.0", "@oxc-parser/binding-linux-x64-musl": "0.124.0", "@oxc-parser/binding-openharmony-arm64": "0.124.0", "@oxc-parser/binding-wasm32-wasi": "0.124.0", "@oxc-parser/binding-win32-arm64-msvc": "0.124.0", "@oxc-parser/binding-win32-ia32-msvc": "0.124.0", "@oxc-parser/binding-win32-x64-msvc": "0.124.0" } }, "sha512-h07SFj/tp2U3cf3+LFX6MmOguQiM9ahwpGs0ZK5CGhgL8p4kk24etrJKsEzhXAvo7mfvoKTZooZ5MLKAPRmJ1g=="],
+
     "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
@@ -3028,6 +3087,8 @@
 
     "@mapbox/node-pre-gyp/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
+    "@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
+
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
@@ -3235,6 +3296,8 @@
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ora/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "oxc-parser/@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 

--- a/examples/astro/src/pages/index.astro
+++ b/examples/astro/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
 import "../styles/site.css";
-
 ---
 
 <html lang="en">

--- a/examples/astro/src/styles/site.css
+++ b/examples/astro/src/styles/site.css
@@ -1,5 +1,6 @@
 body {
-	font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	font-family:
+		system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 	margin: 0;
 	background: #f8fafc;
 	color: #0f172a;

--- a/examples/sveltekit/src/routes/+layout.svelte
+++ b/examples/sveltekit/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	let { children } = $props();
+let { children } = $props();
 </script>
 
 {@render children()}

--- a/examples/sveltekit/src/routes/cookie/+page.svelte
+++ b/examples/sveltekit/src/routes/cookie/+page.svelte
@@ -3,7 +3,7 @@
 </svelte:head>
 
 <script lang="ts">
-	import policy from '$lib/policies/cookie-policy.html?raw';
+import policy from "$lib/policies/cookie-policy.html?raw";
 </script>
 
 <main>

--- a/examples/sveltekit/src/routes/privacy/+page.svelte
+++ b/examples/sveltekit/src/routes/privacy/+page.svelte
@@ -3,7 +3,7 @@
 </svelte:head>
 
 <script lang="ts">
-	import policy from '$lib/policies/privacy-policy.html?raw';
+import policy from "$lib/policies/privacy-policy.html?raw";
 </script>
 
 <main>

--- a/examples/sveltekit/src/routes/terms/+page.svelte
+++ b/examples/sveltekit/src/routes/terms/+page.svelte
@@ -3,7 +3,7 @@
 </svelte:head>
 
 <script lang="ts">
-	import policy from '$lib/policies/terms-of-service.html?raw';
+import policy from "$lib/policies/terms-of-service.html?raw";
 </script>
 
 <main>

--- a/examples/tanstack/package.json
+++ b/examples/tanstack/package.json
@@ -25,7 +25,7 @@
 	"devDependencies": {
 		"@playwright/test": "^1.53.2",
 		"@openpolicy/sdk": "workspace:*",
-		"@openpolicy/vite": "workspace:*",
+		"@openpolicy/vite-auto-collect": "workspace:*",
 		"@tailwindcss/vite": "^4.2.1",
 		"@types/node": "^25.3.5",
 		"@types/react": "^19.2.14",

--- a/examples/tanstack/src/lib/collection.ts
+++ b/examples/tanstack/src/lib/collection.ts
@@ -7,15 +7,23 @@ import { collecting } from "@openpolicy/sdk";
  * `value` argument unchanged, so it's safe to drop in at any write site.
  */
 export function fakeCreateUser(name: string, email: string) {
-	return collecting("Account Information", { name, email }, (v) => ({
-		Name: v.name,
-		"Email address": v.email,
-	}));
+	return collecting(
+		"Account Information",
+		{ name, email },
+		{
+			name: "Name",
+			email: "Email",
+		},
+	);
 }
 
 export function fakeRecordPageView(path: string, userAgent: string) {
-	return collecting("Usage Data", { path, userAgent }, (v) => ({
-		"Pages visited": v.path,
-		"Browser type": v.userAgent,
-	}));
+	return collecting(
+		"Usage Data",
+		{ path, userAgent },
+		{
+			path: "Pages visited",
+			userAgent: "Browser type",
+		},
+	);
 }

--- a/examples/tanstack/src/lib/collection.ts
+++ b/examples/tanstack/src/lib/collection.ts
@@ -1,0 +1,21 @@
+import { collecting } from "@openpolicy/sdk";
+
+/**
+ * Placeholder ORM call sites that exist purely so `@openpolicy/vite-auto-collect`
+ * has something to discover during this example's build. Replace with real
+ * `db.insert(...)` code in a production app — `collecting()` returns its
+ * `value` argument unchanged, so it's safe to drop in at any write site.
+ */
+export function fakeCreateUser(name: string, email: string) {
+	return collecting("Account Information", { name, email }, (v) => ({
+		Name: v.name,
+		"Email address": v.email,
+	}));
+}
+
+export function fakeRecordPageView(path: string, userAgent: string) {
+	return collecting("Usage Data", { path, userAgent }, (v) => ({
+		"Pages visited": v.path,
+		"Browser type": v.userAgent,
+	}));
+}

--- a/examples/tanstack/src/openpolicy.ts
+++ b/examples/tanstack/src/openpolicy.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "@openpolicy/sdk";
+import { autoCollected, defineConfig } from "@openpolicy/sdk";
 
 export default defineConfig({
 	company: {
@@ -10,10 +10,11 @@ export default defineConfig({
 	privacy: {
 		effectiveDate: "2026-03-03",
 		dataCollected: {
-			"Account Information": ["Name", "Email address"],
+			...autoCollected,
+			// Static entries are still allowed alongside scanned ones:
 			"Usage Data": ["Pages visited", "Browser type", "IP address"],
 		},
-		legalBasis: "Legitimate interests and consent",
+		legalBasis: "legitimate_interests",
 		retention: {
 			"Account data": "Until account deletion",
 			"Usage logs": "90 days",

--- a/examples/tanstack/src/openpolicy.ts
+++ b/examples/tanstack/src/openpolicy.ts
@@ -1,4 +1,4 @@
-import { autoCollected, defineConfig } from "@openpolicy/sdk";
+import { dataCollected, defineConfig } from "@openpolicy/sdk";
 
 export default defineConfig({
 	company: {
@@ -10,7 +10,7 @@ export default defineConfig({
 	privacy: {
 		effectiveDate: "2026-03-03",
 		dataCollected: {
-			...autoCollected,
+			...dataCollected,
 			// Static entries are still allowed alongside scanned ones:
 			"Usage Data": ["Pages visited", "Browser type", "IP address"],
 		},

--- a/examples/tanstack/src/routes/index.tsx
+++ b/examples/tanstack/src/routes/index.tsx
@@ -56,7 +56,6 @@ const demos = [
 function RouteComponent() {
 	return (
 		<main className="mx-auto max-w-6xl px-6 py-16">
-			{/* Hero */}
 			<div className="mb-16 max-w-2xl">
 				<div className="mb-4 inline-flex items-center gap-2 rounded-full border bg-muted/50 px-3 py-1 text-xs text-muted-foreground">
 					<span className="size-1.5 rounded-full bg-green-500" />

--- a/examples/tanstack/src/styles.css
+++ b/examples/tanstack/src/styles.css
@@ -6,124 +6,124 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.809 0.105 251.813);
-    --chart-2: oklch(0.623 0.214 259.815);
-    --chart-3: oklch(0.546 0.245 262.881);
-    --chart-4: oklch(0.488 0.243 264.376);
-    --chart-5: oklch(0.424 0.199 265.638);
-    --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+	--background: oklch(1 0 0);
+	--foreground: oklch(0.145 0 0);
+	--card: oklch(1 0 0);
+	--card-foreground: oklch(0.145 0 0);
+	--popover: oklch(1 0 0);
+	--popover-foreground: oklch(0.145 0 0);
+	--primary: oklch(0.205 0 0);
+	--primary-foreground: oklch(0.985 0 0);
+	--secondary: oklch(0.97 0 0);
+	--secondary-foreground: oklch(0.205 0 0);
+	--muted: oklch(0.97 0 0);
+	--muted-foreground: oklch(0.556 0 0);
+	--accent: oklch(0.97 0 0);
+	--accent-foreground: oklch(0.205 0 0);
+	--destructive: oklch(0.577 0.245 27.325);
+	--border: oklch(0.922 0 0);
+	--input: oklch(0.922 0 0);
+	--ring: oklch(0.708 0 0);
+	--chart-1: oklch(0.809 0.105 251.813);
+	--chart-2: oklch(0.623 0.214 259.815);
+	--chart-3: oklch(0.546 0.245 262.881);
+	--chart-4: oklch(0.488 0.243 264.376);
+	--chart-5: oklch(0.424 0.199 265.638);
+	--radius: 0.625rem;
+	--sidebar: oklch(0.985 0 0);
+	--sidebar-foreground: oklch(0.145 0 0);
+	--sidebar-primary: oklch(0.205 0 0);
+	--sidebar-primary-foreground: oklch(0.985 0 0);
+	--sidebar-accent: oklch(0.97 0 0);
+	--sidebar-accent-foreground: oklch(0.205 0 0);
+	--sidebar-border: oklch(0.922 0 0);
+	--sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.809 0.105 251.813);
-    --chart-2: oklch(0.623 0.214 259.815);
-    --chart-3: oklch(0.546 0.245 262.881);
-    --chart-4: oklch(0.488 0.243 264.376);
-    --chart-5: oklch(0.424 0.199 265.638);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+	--background: oklch(0.145 0 0);
+	--foreground: oklch(0.985 0 0);
+	--card: oklch(0.205 0 0);
+	--card-foreground: oklch(0.985 0 0);
+	--popover: oklch(0.205 0 0);
+	--popover-foreground: oklch(0.985 0 0);
+	--primary: oklch(0.922 0 0);
+	--primary-foreground: oklch(0.205 0 0);
+	--secondary: oklch(0.269 0 0);
+	--secondary-foreground: oklch(0.985 0 0);
+	--muted: oklch(0.269 0 0);
+	--muted-foreground: oklch(0.708 0 0);
+	--accent: oklch(0.269 0 0);
+	--accent-foreground: oklch(0.985 0 0);
+	--destructive: oklch(0.704 0.191 22.216);
+	--border: oklch(1 0 0 / 10%);
+	--input: oklch(1 0 0 / 15%);
+	--ring: oklch(0.556 0 0);
+	--chart-1: oklch(0.809 0.105 251.813);
+	--chart-2: oklch(0.623 0.214 259.815);
+	--chart-3: oklch(0.546 0.245 262.881);
+	--chart-4: oklch(0.488 0.243 264.376);
+	--chart-5: oklch(0.424 0.199 265.638);
+	--sidebar: oklch(0.205 0 0);
+	--sidebar-foreground: oklch(0.985 0 0);
+	--sidebar-primary: oklch(0.488 0.243 264.376);
+	--sidebar-primary-foreground: oklch(0.985 0 0);
+	--sidebar-accent: oklch(0.269 0 0);
+	--sidebar-accent-foreground: oklch(0.985 0 0);
+	--sidebar-border: oklch(1 0 0 / 10%);
+	--sidebar-ring: oklch(0.556 0 0);
 }
 
 @theme inline {
-    --font-sans: 'Geist Variable', sans-serif;
-    --color-sidebar-ring: var(--sidebar-ring);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar: var(--sidebar);
-    --color-chart-5: var(--chart-5);
-    --color-chart-4: var(--chart-4);
-    --color-chart-3: var(--chart-3);
-    --color-chart-2: var(--chart-2);
-    --color-chart-1: var(--chart-1);
-    --color-ring: var(--ring);
-    --color-input: var(--input);
-    --color-border: var(--border);
-    --color-destructive: var(--destructive);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-accent: var(--accent);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-muted: var(--muted);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-secondary: var(--secondary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-primary: var(--primary);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-popover: var(--popover);
-    --color-card-foreground: var(--card-foreground);
-    --color-card: var(--card);
-    --color-foreground: var(--foreground);
-    --color-background: var(--background);
-    --radius-sm: calc(var(--radius) * 0.6);
-    --radius-md: calc(var(--radius) * 0.8);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) * 1.4);
-    --radius-2xl: calc(var(--radius) * 1.8);
-    --radius-3xl: calc(var(--radius) * 2.2);
-    --radius-4xl: calc(var(--radius) * 2.6);
+	--font-sans: "Geist Variable", sans-serif;
+	--color-sidebar-ring: var(--sidebar-ring);
+	--color-sidebar-border: var(--sidebar-border);
+	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+	--color-sidebar-accent: var(--sidebar-accent);
+	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+	--color-sidebar-primary: var(--sidebar-primary);
+	--color-sidebar-foreground: var(--sidebar-foreground);
+	--color-sidebar: var(--sidebar);
+	--color-chart-5: var(--chart-5);
+	--color-chart-4: var(--chart-4);
+	--color-chart-3: var(--chart-3);
+	--color-chart-2: var(--chart-2);
+	--color-chart-1: var(--chart-1);
+	--color-ring: var(--ring);
+	--color-input: var(--input);
+	--color-border: var(--border);
+	--color-destructive: var(--destructive);
+	--color-accent-foreground: var(--accent-foreground);
+	--color-accent: var(--accent);
+	--color-muted-foreground: var(--muted-foreground);
+	--color-muted: var(--muted);
+	--color-secondary-foreground: var(--secondary-foreground);
+	--color-secondary: var(--secondary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-primary: var(--primary);
+	--color-popover-foreground: var(--popover-foreground);
+	--color-popover: var(--popover);
+	--color-card-foreground: var(--card-foreground);
+	--color-card: var(--card);
+	--color-foreground: var(--foreground);
+	--color-background: var(--background);
+	--radius-sm: calc(var(--radius) * 0.6);
+	--radius-md: calc(var(--radius) * 0.8);
+	--radius-lg: var(--radius);
+	--radius-xl: calc(var(--radius) * 1.4);
+	--radius-2xl: calc(var(--radius) * 1.8);
+	--radius-3xl: calc(var(--radius) * 2.2);
+	--radius-4xl: calc(var(--radius) * 2.6);
 }
 
 @layer base {
-  * {
-    @apply border-border outline-ring/50;
-    }
-  body {
-    @apply bg-background text-foreground;
-    }
-  html {
-    @apply font-sans;
-    }
+	* {
+		@apply border-border outline-ring/50;
+	}
+	body {
+		@apply bg-background text-foreground;
+	}
+	html {
+		@apply font-sans;
+	}
 }

--- a/examples/tanstack/vite.config.ts
+++ b/examples/tanstack/vite.config.ts
@@ -1,4 +1,4 @@
-import { openPolicy } from "@openpolicy/vite";
+import { autoCollect } from "@openpolicy/vite-auto-collect";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
@@ -14,11 +14,7 @@ export default defineConfig({
 	plugins: [
 		tailwindcss(),
 		tsConfigPaths(),
-		openPolicy({
-			configPath: "./src/openpolicy.ts",
-			formats: ["html"],
-			outDir: "src/policies",
-		}),
+		autoCollect({ srcDir: "./src" }),
 		tanstackStart(),
 		nitro(),
 		// react's vite plugin must come after start's vite plugin

--- a/packages/react/styles.css
+++ b/packages/react/styles.css
@@ -1,30 +1,30 @@
 /* @openpolicy/react/styles.css — opt-in default styles */
 :root {
-  --op-font-family: system-ui, sans-serif;
-  --op-font-size-body: 1rem;
-  --op-font-size-heading: 1.25rem;
-  --op-heading-color: #111;
-  --op-body-color: #444;
-  --op-section-gap: 2rem;
-  --op-border-color: #e5e5e5;
-  --op-border-radius: 0.25rem;
-  --op-line-height: 1.6;
+	--op-font-family: system-ui, sans-serif;
+	--op-font-size-body: 1rem;
+	--op-font-size-heading: 1.25rem;
+	--op-heading-color: #111;
+	--op-body-color: #444;
+	--op-section-gap: 2rem;
+	--op-border-color: #e5e5e5;
+	--op-border-radius: 0.25rem;
+	--op-line-height: 1.6;
 }
 
 [data-op-policy] {
-  font-family: var(--op-font-family);
-  color: var(--op-body-color);
+	font-family: var(--op-font-family);
+	color: var(--op-body-color);
 }
 
 [data-op-section] {
-  margin-bottom: var(--op-section-gap);
+	margin-bottom: var(--op-section-gap);
 }
 
 [data-op-heading] {
-  color: var(--op-heading-color);
-  font-size: var(--op-font-size-heading);
+	color: var(--op-heading-color);
+	font-size: var(--op-font-size-heading);
 }
 
 [data-op-body] {
-  line-height: var(--op-line-height);
+	line-height: var(--op-line-height);
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,7 +20,7 @@
 		}
 	},
 	"scripts": {
-		"dev": "rolldown -c --watch",
+		"dev": "rolldown --watch -c",
 		"build": "rolldown -c",
 		"check-types": "tsc --noEmit",
 		"test": "bun test"

--- a/packages/sdk/rolldown.config.ts
+++ b/packages/sdk/rolldown.config.ts
@@ -1,16 +1,29 @@
 import { defineConfig } from "rolldown";
 import { dts } from "rolldown-plugin-dts";
 
+// Two entry points on purpose: `./auto-collected` is kept as a separate
+// chunk so the `dist/index.js` bundle references it via a relative
+// `./auto-collected.js` import instead of inlining its contents. That
+// relative import is what `@openpolicy/vite-auto-collect`'s `resolveId`
+// hook intercepts to inline scanned categories at consumer build time.
+const input = {
+	index: "./src/index.ts",
+	"auto-collected": "./src/auto-collected.ts",
+};
+
+const external = (id: string): boolean =>
+	id !== "@openpolicy/core" && /^[^./]/.test(id);
+
 export default defineConfig([
 	{
-		input: "./src/index.ts",
-		external: (id) => id !== "@openpolicy/core" && /^[^./]/.test(id),
+		input,
+		external,
 		output: { format: "esm", dir: "dist" },
 	},
 	{
-		input: "./src/index.ts",
+		input,
 		plugins: [dts()],
-		external: (id) => id !== "@openpolicy/core" && /^[^./]/.test(id),
+		external,
 		output: { format: "esm", dir: "dist" },
 	},
 ]);

--- a/packages/sdk/src/auto-collected.test.ts
+++ b/packages/sdk/src/auto-collected.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+import { autoCollected } from "./auto-collected";
+
+test("autoCollected is an empty object when no plugin is active", () => {
+	// At runtime (without the vite-auto-collect plugin intercepting this
+	// module's resolution) the sentinel is a plain empty record, so spreading
+	// it into `dataCollected` is a no-op.
+	expect(autoCollected).toEqual({});
+});

--- a/packages/sdk/src/auto-collected.test.ts
+++ b/packages/sdk/src/auto-collected.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
-import { autoCollected } from "./auto-collected";
+import { dataCollected } from "./auto-collected";
 
-test("autoCollected is an empty object when no plugin is active", () => {
+test("dataCollected is an empty object when no plugin is active", () => {
 	// At runtime (without the vite-auto-collect plugin intercepting this
 	// module's resolution) the sentinel is a plain empty record, so spreading
 	// it into `dataCollected` is a no-op.
-	expect(autoCollected).toEqual({});
+	expect(dataCollected).toEqual({});
 });

--- a/packages/sdk/src/auto-collected.ts
+++ b/packages/sdk/src/auto-collected.ts
@@ -1,0 +1,22 @@
+/**
+ * Placeholder populated by `@openpolicy/vite-auto-collect` during a Vite
+ * build. The plugin intercepts this module's resolution and replaces it with
+ * the scanned categories, so the literal default below is only used as a
+ * fallback when no auto-collect plugin is active — in which case spreading
+ * it into `dataCollected` is a no-op.
+ *
+ * @example
+ * ```ts
+ * import { autoCollected, defineConfig } from "@openpolicy/sdk";
+ *
+ * export default defineConfig({
+ *   privacy: {
+ *     dataCollected: {
+ *       ...autoCollected,
+ *       "Manually-tracked Category": ["Field A"],
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export const autoCollected: Record<string, string[]> = {};

--- a/packages/sdk/src/auto-collected.ts
+++ b/packages/sdk/src/auto-collected.ts
@@ -7,16 +7,16 @@
  *
  * @example
  * ```ts
- * import { autoCollected, defineConfig } from "@openpolicy/sdk";
+ * import { dataCollected, defineConfig } from "@openpolicy/sdk";
  *
  * export default defineConfig({
  *   privacy: {
  *     dataCollected: {
- *       ...autoCollected,
+ *       ...dataCollected,
  *       "Manually-tracked Category": ["Field A"],
  *     },
  *   },
  * });
  * ```
  */
-export const autoCollected: Record<string, string[]> = {};
+export const dataCollected: Record<string, string[]> = {};

--- a/packages/sdk/src/collecting.test.ts
+++ b/packages/sdk/src/collecting.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import { collecting } from "./collecting";
+
+test("returns the exact same reference as value", () => {
+	const value = { name: "Ada", email: "ada@example.com" };
+	const result = collecting("Account Information", value, (v) => ({
+		Name: v.name,
+		"Email address": v.email,
+	}));
+	expect(result).toBe(value);
+});
+
+test("preserves heterogeneous value types", () => {
+	const str = collecting("Strings", "hello", () => ({ Text: "hello" }));
+	expect(str).toBe("hello");
+
+	const num = collecting("Numbers", 42, () => ({ Count: 42 }));
+	expect(num).toBe(42);
+
+	const date = new Date("2026-01-01");
+	const dateResult = collecting("Dates", date, (v) => ({ When: v }));
+	expect(dateResult).toBe(date);
+
+	const nil = collecting<null>("Nulls", null, () => ({ Nothing: null }));
+	expect(nil).toBeNull();
+
+	const nested = { outer: { inner: { leaf: 1 } } };
+	const nestedResult = collecting("Nested", nested, (v) => ({
+		Leaf: v.outer.inner.leaf,
+	}));
+	expect(nestedResult).toBe(nested);
+});
+
+test("label function is never invoked at runtime", () => {
+	let called = false;
+	const value = { name: "Ada" };
+	const result = collecting("Account Information", value, (v) => {
+		called = true;
+		return { Name: v.name };
+	});
+	expect(called).toBe(false);
+	expect(result).toBe(value);
+});
+
+test("returns value even when label function would throw", () => {
+	const value = { name: "Ada" };
+	const result = collecting("Account Information", value, () => {
+		throw new Error("should never run");
+	});
+	expect(result).toBe(value);
+});
+
+test("works when value is an empty object", () => {
+	const value = {};
+	const result = collecting("Empty", value, () => ({}));
+	expect(result).toBe(value);
+});
+
+test("preserves branded/opaque row types without degrading inference", () => {
+	type UserRow = { readonly __brand: "UserRow"; name: string; email: string };
+	const row = {
+		__brand: "UserRow",
+		name: "Ada",
+		email: "ada@example.com",
+	} as unknown as UserRow;
+
+	// Compile-time check: the generic should infer `UserRow` so the label
+	// callback sees the branded fields and the return type is `UserRow`.
+	const result: UserRow = collecting("Account Information", row, (v) => ({
+		Name: v.name,
+		"Email address": v.email,
+	}));
+	expect(result).toBe(row);
+});

--- a/packages/sdk/src/collecting.test.ts
+++ b/packages/sdk/src/collecting.test.ts
@@ -3,56 +3,51 @@ import { collecting } from "./collecting";
 
 test("returns the exact same reference as value", () => {
 	const value = { name: "Ada", email: "ada@example.com" };
-	const result = collecting("Account Information", value, (v) => ({
-		Name: v.name,
-		"Email address": v.email,
-	}));
+	const result = collecting("Account Information", value, {
+		name: "Name",
+		email: "Email address",
+	});
 	expect(result).toBe(value);
 });
 
 test("preserves heterogeneous value types", () => {
-	const str = collecting("Strings", "hello", () => ({ Text: "hello" }));
+	const str = collecting("Strings", "hello", { text: "Text" });
 	expect(str).toBe("hello");
 
-	const num = collecting("Numbers", 42, () => ({ Count: 42 }));
+	const num = collecting("Numbers", 42, { count: "Count" });
 	expect(num).toBe(42);
 
 	const date = new Date("2026-01-01");
-	const dateResult = collecting("Dates", date, (v) => ({ When: v }));
+	const dateResult = collecting("Dates", date, { when: "When" });
 	expect(dateResult).toBe(date);
 
-	const nil = collecting<null>("Nulls", null, () => ({ Nothing: null }));
+	const nil = collecting<null>("Nulls", null, { nothing: "Nothing" });
 	expect(nil).toBeNull();
 
 	const nested = { outer: { inner: { leaf: 1 } } };
-	const nestedResult = collecting("Nested", nested, (v) => ({
-		Leaf: v.outer.inner.leaf,
-	}));
+	const nestedResult = collecting("Nested", nested, { leaf: "Leaf" });
 	expect(nestedResult).toBe(nested);
 });
 
-test("label function is never invoked at runtime", () => {
-	let called = false;
+test("label object is never evaluated at runtime", () => {
+	// The object literal is provided but collecting() must return value unchanged
+	// without any side effects from evaluating labels.
 	const value = { name: "Ada" };
-	const result = collecting("Account Information", value, (v) => {
-		called = true;
-		return { Name: v.name };
-	});
-	expect(called).toBe(false);
+	const result = collecting("Account Information", value, { name: "Name" });
 	expect(result).toBe(value);
 });
 
-test("returns value even when label function would throw", () => {
+test("returns value even when label object has non-string values", () => {
 	const value = { name: "Ada" };
-	const result = collecting("Account Information", value, () => {
-		throw new Error("should never run");
+	const result = collecting("Account Information", value, {
+		name: 42 as unknown as string,
 	});
 	expect(result).toBe(value);
 });
 
 test("works when value is an empty object", () => {
 	const value = {};
-	const result = collecting("Empty", value, () => ({}));
+	const result = collecting("Empty", value, {});
 	expect(result).toBe(value);
 });
 
@@ -64,11 +59,11 @@ test("preserves branded/opaque row types without degrading inference", () => {
 		email: "ada@example.com",
 	} as unknown as UserRow;
 
-	// Compile-time check: the generic should infer `UserRow` so the label
-	// callback sees the branded fields and the return type is `UserRow`.
-	const result: UserRow = collecting("Account Information", row, (v) => ({
-		Name: v.name,
-		"Email address": v.email,
-	}));
+	// Compile-time check: the generic should infer `UserRow` so the return
+	// type is `UserRow`.
+	const result: UserRow = collecting("Account Information", row, {
+		name: "Name",
+		email: "Email address",
+	});
 	expect(result).toBe(row);
 });

--- a/packages/sdk/src/collecting.test.ts
+++ b/packages/sdk/src/collecting.test.ts
@@ -10,25 +10,6 @@ test("returns the exact same reference as value", () => {
 	expect(result).toBe(value);
 });
 
-test("preserves heterogeneous value types", () => {
-	const str = collecting("Strings", "hello", { text: "Text" });
-	expect(str).toBe("hello");
-
-	const num = collecting("Numbers", 42, { count: "Count" });
-	expect(num).toBe(42);
-
-	const date = new Date("2026-01-01");
-	const dateResult = collecting("Dates", date, { when: "When" });
-	expect(dateResult).toBe(date);
-
-	const nil = collecting<null>("Nulls", null, { nothing: "Nothing" });
-	expect(nil).toBeNull();
-
-	const nested = { outer: { inner: { leaf: 1 } } };
-	const nestedResult = collecting("Nested", nested, { leaf: "Leaf" });
-	expect(nestedResult).toBe(nested);
-});
-
 test("label object is never evaluated at runtime", () => {
 	// The object literal is provided but collecting() must return value unchanged
 	// without any side effects from evaluating labels.

--- a/packages/sdk/src/collecting.ts
+++ b/packages/sdk/src/collecting.ts
@@ -1,0 +1,43 @@
+/**
+ * Declares data collected at the point of storage. Returns `value` unchanged
+ * at runtime — the Vite plugin / CLI static analyser (OP-152) will scan calls
+ * to `collecting()` at build time and merge the declarations into the
+ * compiled privacy policy.
+ *
+ * The third argument is a label function mapping the stored value to a
+ * record whose **keys** describe what each field represents in
+ * human-readable terms. Only those keys are used by the analyser; the
+ * function body is never executed at runtime. This shape lets you:
+ *   - keep `value` matching your ORM/table schema exactly,
+ *   - describe fields with friendly labels for the policy,
+ *   - omit fields from the policy by leaving them out of the label record
+ *     (e.g. `hashedPassword`).
+ *
+ * The category argument and the keys of the label record must be string
+ * literals — dynamic values are silently skipped by the analyser.
+ *
+ * @example
+ * ```ts
+ * import { collecting } from "@openpolicy/sdk";
+ *
+ * export async function createUser(name: string, email: string) {
+ *   return db.insert(users).values(
+ *     collecting(
+ *       "Account Information",
+ *       { name, email }, // real ORM columns — returned unchanged
+ *       (v) => ({
+ *         Name: v.name,
+ *         "Email address": v.email,
+ *       }),
+ *     ),
+ *   );
+ * }
+ * ```
+ */
+export function collecting<T>(
+	_category: string,
+	value: T,
+	_label: (v: T) => Record<string, unknown>,
+): T {
+	return value;
+}

--- a/packages/sdk/src/collecting.ts
+++ b/packages/sdk/src/collecting.ts
@@ -4,17 +4,18 @@
  * to `collecting()` at build time and merge the declarations into the
  * compiled privacy policy.
  *
- * The third argument is a label function mapping the stored value to a
- * record whose **keys** describe what each field represents in
- * human-readable terms. Only those keys are used by the analyser; the
- * function body is never executed at runtime. This shape lets you:
+ * The third argument is a plain object literal whose **keys** are field names
+ * matching your stored value (for convenient access without a typed callback)
+ * and whose **values** are the human-readable labels used in the compiled
+ * policy. Only the string values are used by the analyser; the object is
+ * never evaluated at runtime. This shape lets you:
  *   - keep `value` matching your ORM/table schema exactly,
  *   - describe fields with friendly labels for the policy,
  *   - omit fields from the policy by leaving them out of the label record
  *     (e.g. `hashedPassword`).
  *
- * The category argument and the keys of the label record must be string
- * literals — dynamic values are silently skipped by the analyser.
+ * The category argument and the string values of the label record must be
+ * string literals — dynamic values are silently skipped by the analyser.
  *
  * @example
  * ```ts
@@ -25,10 +26,7 @@
  *     collecting(
  *       "Account Information",
  *       { name, email }, // real ORM columns — returned unchanged
- *       (v) => ({
- *         Name: v.name,
- *         "Email address": v.email,
- *       }),
+ *       { name: "Name", email: "Email address" },
  *     ),
  *   );
  * }
@@ -37,7 +35,7 @@
 export function collecting<T>(
 	_category: string,
 	value: T,
-	_label: (v: T) => Record<string, unknown>,
+	_label: Partial<Record<keyof T, string>>,
 ): T {
 	return value;
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,6 +9,7 @@ export type {
 	UserRight,
 } from "@openpolicy/core";
 
+export { autoCollected } from "./auto-collected";
 export { collecting } from "./collecting";
 export { Compliance } from "./compliance";
 export { DataCategories, LegalBases, Retention, Rights } from "./data";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,7 +9,7 @@ export type {
 	UserRight,
 } from "@openpolicy/core";
 
-export { autoCollected } from "./auto-collected";
+export { dataCollected } from "./auto-collected";
 export { collecting } from "./collecting";
 export { Compliance } from "./compliance";
 export { DataCategories, LegalBases, Retention, Rights } from "./data";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,6 +9,7 @@ export type {
 	UserRight,
 } from "@openpolicy/core";
 
+export { collecting } from "./collecting";
 export { Compliance } from "./compliance";
 export { DataCategories, LegalBases, Retention, Rights } from "./data";
 export { Providers } from "./providers";

--- a/packages/vite-auto-collect/package.json
+++ b/packages/vite-auto-collect/package.json
@@ -1,15 +1,17 @@
 {
-	"name": "@openpolicy/core",
+	"name": "@openpolicy/vite-auto-collect",
 	"version": "0.0.17",
 	"type": "module",
-	"description": "Core package for OpenPolicy",
+	"description": "Vite plugin that scans source files for @openpolicy/sdk collecting() calls and populates autoCollected() at build time",
 	"license": "GPL-3.0-only",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/jamiedavenport/openpolicy",
-		"directory": "packages/core"
+		"directory": "packages/vite-auto-collect"
 	},
-	"sideEffects": false,
+	"keywords": [
+		"vite-plugin"
+	],
 	"files": [
 		"dist",
 		"README.md"
@@ -26,7 +28,15 @@
 		"check-types": "tsc --noEmit",
 		"test": "bun test"
 	},
+	"peerDependencies": {
+		"vite": ">=4.0.0"
+	},
+	"dependencies": {
+		"oxc-parser": "^0.124.0"
+	},
 	"devDependencies": {
-		"@openpolicy/tooling": "workspace:*"
+		"@openpolicy/sdk": "workspace:*",
+		"@openpolicy/tooling": "workspace:*",
+		"vite": "catalog:"
 	}
 }

--- a/packages/vite-auto-collect/rolldown.config.ts
+++ b/packages/vite-auto-collect/rolldown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "rolldown";
+import { dts } from "rolldown-plugin-dts";
+
+export default defineConfig({
+	input: "./src/index.ts",
+	plugins: [dts()],
+	platform: "node",
+	external: (id) => /^node:/.test(id) || /^[^./]/.test(id),
+	output: { format: "esm", dir: "dist" },
+});

--- a/packages/vite-auto-collect/src/analyse.test.ts
+++ b/packages/vite-auto-collect/src/analyse.test.ts
@@ -1,0 +1,162 @@
+import { expect, test } from "bun:test";
+import { extractCollecting } from "./analyse";
+
+test("canonical case: string-literal keys in concise arrow body", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Account Information", { name, email }, (v) => ({
+			"Name": v.name,
+			"Email address": v.email,
+		}));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({
+		"Account Information": ["Name", "Email address"],
+	});
+});
+
+test("shorthand / unquoted identifier keys", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Cat", v, (v) => ({ Name: v.a, Email: v.b }));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({
+		Cat: ["Name", "Email"],
+	});
+});
+
+test("renamed import", () => {
+	const code = `
+		import { collecting as col } from "@openpolicy/sdk";
+		col("Cat", v, (v) => ({ Name: v.a }));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["Name"] });
+});
+
+test("block-body arrow function with explicit return", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Cat", v, (v) => {
+			return { "Name": v.a };
+		});
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["Name"] });
+});
+
+test("ignores collecting imported from a non-SDK module", () => {
+	const code = `
+		import { collecting } from "./local-collecting";
+		collecting("Cat", v, (v) => ({ Name: v.a }));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({});
+});
+
+test("ignores local `collecting` not imported from anywhere", () => {
+	const code = `
+		function collecting(a, b, c) { return b; }
+		collecting("Cat", v, (v) => ({ Name: v.a }));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({});
+});
+
+test("ignores type-only imports", () => {
+	const code = `
+		import type { collecting } from "@openpolicy/sdk";
+		collecting("Cat", v, (v) => ({ Name: v.a }));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({});
+});
+
+test("skips template-literal category silently", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		collecting(\`Cat\`, v, (v) => ({ Name: v.a }));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({});
+});
+
+test("drops computed and spread keys but keeps the rest", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		const KEY = "X";
+		const rest = {};
+		collecting("Cat", v, (v) => ({
+			[KEY]: v.a,
+			...rest,
+			Kept: v.b,
+		}));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["Kept"] });
+});
+
+test("malformed source returns {} without throwing", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Cat", v, (v) => ({ Name: v.a }
+	`;
+	const originalWarn = console.warn;
+	console.warn = () => {}; // suppress expected parse-error log
+	try {
+		expect(() => extractCollecting("a.ts", code)).not.toThrow();
+		// Parser still produces a partial AST that may or may not contain the
+		// call, but the function must never throw and must return an object.
+		const out = extractCollecting("a.ts", code);
+		expect(typeof out).toBe("object");
+	} finally {
+		console.warn = originalWarn;
+	}
+});
+
+test("merges multiple calls with the same category", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Cat", v, (v) => ({ A: v.a }));
+		collecting("Cat", w, (w) => ({ B: w.b, A: w.a2 }));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["A", "B"] });
+});
+
+test("deduplicates repeated labels across and within calls", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Cat", v, (v) => ({ A: v.a, A: v.a2 }));
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["A"] });
+});
+
+test("skips calls with fewer than three arguments", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Cat", v);
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({});
+});
+
+test("skips calls whose third arg is not an arrow function", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		const fn = (v) => ({ Name: v.a });
+		collecting("Cat", v, fn);
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({});
+});
+
+test("empty source returns {}", () => {
+	expect(extractCollecting("a.ts", "")).toEqual({});
+});
+
+test("calls nested inside other functions are still extracted", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		export function createUser(name: string, email: string) {
+			return db.insert(users).values(
+				collecting("Account Information", { name, email }, (v) => ({
+					Name: v.name,
+					"Email address": v.email,
+				})),
+			);
+		}
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({
+		"Account Information": ["Name", "Email address"],
+	});
+});

--- a/packages/vite-auto-collect/src/analyse.test.ts
+++ b/packages/vite-auto-collect/src/analyse.test.ts
@@ -1,43 +1,23 @@
 import { expect, test } from "bun:test";
 import { extractCollecting } from "./analyse";
 
-test("canonical case: string-literal keys in concise arrow body", () => {
+test("canonical case: string literal values in object literal", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Account Information", { name, email }, (v) => ({
-			"Name": v.name,
-			"Email address": v.email,
-		}));
+		collecting("Account Information", { name, email }, {
+			name: "Name",
+			email: "Email address",
+		});
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({
 		"Account Information": ["Name", "Email address"],
 	});
 });
 
-test("shorthand / unquoted identifier keys", () => {
-	const code = `
-		import { collecting } from "@openpolicy/sdk";
-		collecting("Cat", v, (v) => ({ Name: v.a, Email: v.b }));
-	`;
-	expect(extractCollecting("a.ts", code)).toEqual({
-		Cat: ["Name", "Email"],
-	});
-});
-
 test("renamed import", () => {
 	const code = `
 		import { collecting as col } from "@openpolicy/sdk";
-		col("Cat", v, (v) => ({ Name: v.a }));
-	`;
-	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["Name"] });
-});
-
-test("block-body arrow function with explicit return", () => {
-	const code = `
-		import { collecting } from "@openpolicy/sdk";
-		collecting("Cat", v, (v) => {
-			return { "Name": v.a };
-		});
+		col("Cat", v, { a: "Name" });
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["Name"] });
 });
@@ -45,7 +25,7 @@ test("block-body arrow function with explicit return", () => {
 test("ignores collecting imported from a non-SDK module", () => {
 	const code = `
 		import { collecting } from "./local-collecting";
-		collecting("Cat", v, (v) => ({ Name: v.a }));
+		collecting("Cat", v, { a: "Name" });
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({});
 });
@@ -53,7 +33,7 @@ test("ignores collecting imported from a non-SDK module", () => {
 test("ignores local `collecting` not imported from anywhere", () => {
 	const code = `
 		function collecting(a, b, c) { return b; }
-		collecting("Cat", v, (v) => ({ Name: v.a }));
+		collecting("Cat", v, { a: "Name" });
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({});
 });
@@ -61,7 +41,7 @@ test("ignores local `collecting` not imported from anywhere", () => {
 test("ignores type-only imports", () => {
 	const code = `
 		import type { collecting } from "@openpolicy/sdk";
-		collecting("Cat", v, (v) => ({ Name: v.a }));
+		collecting("Cat", v, { a: "Name" });
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({});
 });
@@ -69,21 +49,24 @@ test("ignores type-only imports", () => {
 test("skips template-literal category silently", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
-		collecting(\`Cat\`, v, (v) => ({ Name: v.a }));
+		collecting(\`Cat\`, v, { a: "Name" });
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({});
 });
 
-test("drops computed and spread keys but keeps the rest", () => {
+test("non-string values skipped silently, string values kept", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
-		const KEY = "X";
+		collecting("Cat", v, { a: 42, b: "Kept", c: true });
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["Kept"] });
+});
+
+test("spread elements skipped silently", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
 		const rest = {};
-		collecting("Cat", v, (v) => ({
-			[KEY]: v.a,
-			...rest,
-			Kept: v.b,
-		}));
+		collecting("Cat", v, { ...rest, b: "Kept" });
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["Kept"] });
 });
@@ -91,7 +74,7 @@ test("drops computed and spread keys but keeps the rest", () => {
 test("malformed source returns {} without throwing", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Cat", v, (v) => ({ Name: v.a }
+		collecting("Cat", v, { a: "Name"
 	`;
 	const originalWarn = console.warn;
 	console.warn = () => {}; // suppress expected parse-error log
@@ -109,16 +92,16 @@ test("malformed source returns {} without throwing", () => {
 test("merges multiple calls with the same category", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Cat", v, (v) => ({ A: v.a }));
-		collecting("Cat", w, (w) => ({ B: w.b, A: w.a2 }));
+		collecting("Cat", v, { a: "A" });
+		collecting("Cat", w, { b: "B", a2: "A" });
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["A", "B"] });
 });
 
-test("deduplicates repeated labels across and within calls", () => {
+test("deduplicates repeated label values across and within calls", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Cat", v, (v) => ({ A: v.a, A: v.a2 }));
+		collecting("Cat", v, { a: "A", a2: "A" });
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({ Cat: ["A"] });
 });
@@ -131,11 +114,19 @@ test("skips calls with fewer than three arguments", () => {
 	expect(extractCollecting("a.ts", code)).toEqual({});
 });
 
-test("skips calls whose third arg is not an arrow function", () => {
+test("skips calls whose third arg is a variable reference", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
-		const fn = (v) => ({ Name: v.a });
-		collecting("Cat", v, fn);
+		const labels = { a: "Name" };
+		collecting("Cat", v, labels);
+	`;
+	expect(extractCollecting("a.ts", code)).toEqual({});
+});
+
+test("skips calls whose third arg is an arrow function", () => {
+	const code = `
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Cat", v, (v) => ({ Name: v.a }));
 	`;
 	expect(extractCollecting("a.ts", code)).toEqual({});
 });
@@ -149,10 +140,10 @@ test("calls nested inside other functions are still extracted", () => {
 		import { collecting } from "@openpolicy/sdk";
 		export function createUser(name: string, email: string) {
 			return db.insert(users).values(
-				collecting("Account Information", { name, email }, (v) => ({
-					Name: v.name,
-					"Email address": v.email,
-				})),
+				collecting("Account Information", { name, email }, {
+					name: "Name",
+					email: "Email address",
+				}),
 			);
 		}
 	`;

--- a/packages/vite-auto-collect/src/analyse.ts
+++ b/packages/vite-auto-collect/src/analyse.ts
@@ -126,48 +126,25 @@ function extractStringLiteral(node: AnyNode | undefined): string | null {
 }
 
 /**
- * Extract the keys from a `(v) => ({ ... })` or `(v) => { return { ... } }`
- * arrow function body. Returns an array of key names, deduped while
+ * Extract the string values from a plain `{ fieldName: "Human Label" }`
+ * object literal. Returns an array of label strings, deduped while
  * preserving insertion order. Returns `null` if the shape doesn't match.
  */
 function extractLabelKeys(node: AnyNode | undefined): string[] | null {
-	if (!node || node.type !== "ArrowFunctionExpression") return null;
-	let body = node.body as AnyNode | undefined;
-	// Unwrap oxc's ParenthesizedExpression around concise-return arrow bodies.
-	while (body && body.type === "ParenthesizedExpression") {
-		body = body.expression as AnyNode | undefined;
-	}
-	if (body && body.type === "BlockStatement") {
-		const statements = body.body as AnyNode[] | undefined;
-		if (!statements) return null;
-		const ret = statements.find((s) => s.type === "ReturnStatement");
-		if (!ret) return null;
-		body = ret.argument as AnyNode | undefined;
-		while (body && body.type === "ParenthesizedExpression") {
-			body = body.expression as AnyNode | undefined;
-		}
-	}
-	if (!body || body.type !== "ObjectExpression") return null;
-	const properties = body.properties as AnyNode[] | undefined;
+	if (!node || node.type !== "ObjectExpression") return null;
+	const properties = node.properties as AnyNode[] | undefined;
 	if (!properties) return null;
 
 	const labels: string[] = [];
 	const seen = new Set<string>();
 	for (const prop of properties) {
 		if (prop.type !== "Property") continue; // drop SpreadElement silently
-		if (prop.computed === true) continue; // drop computed keys
-		const key = prop.key as AnyNode | undefined;
-		if (!key) continue;
-		let label: string | undefined;
-		if (key.type === "Identifier") {
-			label = key.name as string;
-		} else if (key.type === "Literal" && typeof key.value === "string") {
-			label = key.value;
-		}
-		if (label === undefined) continue;
-		if (seen.has(label)) continue;
-		seen.add(label);
-		labels.push(label);
+		const val = prop.value as AnyNode | undefined;
+		if (!val || val.type !== "Literal" || typeof val.value !== "string")
+			continue;
+		if (seen.has(val.value)) continue;
+		seen.add(val.value);
+		labels.push(val.value);
 	}
 	return labels;
 }

--- a/packages/vite-auto-collect/src/analyse.ts
+++ b/packages/vite-auto-collect/src/analyse.ts
@@ -1,0 +1,198 @@
+import { parseSync } from "oxc-parser";
+
+const SDK_SPECIFIER = "@openpolicy/sdk";
+const COLLECTING_NAME = "collecting";
+
+type AnyNode = { type: string; [key: string]: unknown };
+
+/**
+ * Extract `collecting()` call metadata from a single source file.
+ *
+ * Returns a `Record<category, labels[]>` for every detected call whose
+ * arguments match the analysable shape. Files with no matching calls — or
+ * that fail to parse — return `{}`.
+ *
+ * The analyser runs in two phases:
+ * 1. Collect local names bound to `collecting` imported from `@openpolicy/sdk`
+ *    (handles renamed imports, skips type-only imports, ignores look-alikes
+ *    imported from other modules).
+ * 2. Walk the program body and inspect every `CallExpression` whose callee
+ *    is one of those tracked local names.
+ */
+export function extractCollecting(
+	filename: string,
+	code: string,
+): Record<string, string[]> {
+	let result: ReturnType<typeof parseSync>;
+	try {
+		result = parseSync(filename, code);
+	} catch {
+		console.warn(`[openpolicy-auto-collect] parse error in ${filename}`);
+		return {};
+	}
+
+	if (result.errors.length > 0) {
+		// Hard parse failures only — oxc reports recoverable errors but still
+		// produces a usable AST, so we keep going and let the walker decide.
+		const fatal = result.errors.some((e) => e.severity === ("Error" as never));
+		if (fatal) {
+			console.warn(`[openpolicy-auto-collect] parse error in ${filename}`);
+			return {};
+		}
+	}
+
+	const program = result.program as unknown as AnyNode;
+	const localNames = collectSdkCollectingBindings(program);
+	if (localNames.size === 0) return {};
+
+	const out: Record<string, string[]> = {};
+	walk(program, (node) => {
+		if (node.type !== "CallExpression") return;
+		const callee = node.callee as AnyNode | undefined;
+		if (!callee || callee.type !== "Identifier") return;
+		if (!localNames.has(callee.name as string)) return;
+
+		const args = node.arguments as AnyNode[] | undefined;
+		if (!args || args.length < 3) return;
+
+		const category = extractStringLiteral(args[0]);
+		if (category === null) return;
+
+		const labels = extractLabelKeys(args[2]);
+		if (labels === null) return;
+
+		const existing = out[category] ?? [];
+		const seen = new Set(existing);
+		for (const label of labels) {
+			if (!seen.has(label)) {
+				existing.push(label);
+				seen.add(label);
+			}
+		}
+		out[category] = existing;
+	});
+	return out;
+}
+
+/**
+ * Walk `ImportDeclaration` nodes and return the local names bound to
+ * `collecting` imported from `@openpolicy/sdk`. Skips type-only imports and
+ * specifiers whose imported name isn't literally `collecting`.
+ */
+function collectSdkCollectingBindings(program: AnyNode): Set<string> {
+	const names = new Set<string>();
+	const body = program.body as AnyNode[] | undefined;
+	if (!body) return names;
+	for (const node of body) {
+		if (node.type !== "ImportDeclaration") continue;
+		if ((node.importKind as string | undefined) === "type") continue;
+		const source = node.source as AnyNode | undefined;
+		if (!source || source.value !== SDK_SPECIFIER) continue;
+		const specifiers = node.specifiers as AnyNode[] | undefined;
+		if (!specifiers) continue;
+		for (const spec of specifiers) {
+			if (spec.type !== "ImportSpecifier") continue;
+			if ((spec.importKind as string | undefined) === "type") continue;
+			const imported = spec.imported as AnyNode | undefined;
+			if (!imported) continue;
+			// ESTree allows either an Identifier (name) or a string Literal (value)
+			// for the imported binding (e.g. `import { "foo" as bar }`).
+			const importedName =
+				imported.type === "Identifier"
+					? (imported.name as string | undefined)
+					: imported.type === "Literal"
+						? typeof imported.value === "string"
+							? imported.value
+							: undefined
+						: undefined;
+			if (importedName !== COLLECTING_NAME) continue;
+			const local = spec.local as AnyNode | undefined;
+			if (!local || local.type !== "Identifier") continue;
+			names.add(local.name as string);
+		}
+	}
+	return names;
+}
+
+/**
+ * If `node` is a string `Literal`, return its string value. Otherwise
+ * return `null` so the caller silently skips the call.
+ */
+function extractStringLiteral(node: AnyNode | undefined): string | null {
+	if (!node) return null;
+	if (node.type !== "Literal") return null;
+	if (typeof node.value !== "string") return null;
+	return node.value;
+}
+
+/**
+ * Extract the keys from a `(v) => ({ ... })` or `(v) => { return { ... } }`
+ * arrow function body. Returns an array of key names, deduped while
+ * preserving insertion order. Returns `null` if the shape doesn't match.
+ */
+function extractLabelKeys(node: AnyNode | undefined): string[] | null {
+	if (!node || node.type !== "ArrowFunctionExpression") return null;
+	let body = node.body as AnyNode | undefined;
+	// Unwrap oxc's ParenthesizedExpression around concise-return arrow bodies.
+	while (body && body.type === "ParenthesizedExpression") {
+		body = body.expression as AnyNode | undefined;
+	}
+	if (body && body.type === "BlockStatement") {
+		const statements = body.body as AnyNode[] | undefined;
+		if (!statements) return null;
+		const ret = statements.find((s) => s.type === "ReturnStatement");
+		if (!ret) return null;
+		body = ret.argument as AnyNode | undefined;
+		while (body && body.type === "ParenthesizedExpression") {
+			body = body.expression as AnyNode | undefined;
+		}
+	}
+	if (!body || body.type !== "ObjectExpression") return null;
+	const properties = body.properties as AnyNode[] | undefined;
+	if (!properties) return null;
+
+	const labels: string[] = [];
+	const seen = new Set<string>();
+	for (const prop of properties) {
+		if (prop.type !== "Property") continue; // drop SpreadElement silently
+		if (prop.computed === true) continue; // drop computed keys
+		const key = prop.key as AnyNode | undefined;
+		if (!key) continue;
+		let label: string | undefined;
+		if (key.type === "Identifier") {
+			label = key.name as string;
+		} else if (key.type === "Literal" && typeof key.value === "string") {
+			label = key.value;
+		}
+		if (label === undefined) continue;
+		if (seen.has(label)) continue;
+		seen.add(label);
+		labels.push(label);
+	}
+	return labels;
+}
+
+/**
+ * Recursive AST walker. Visits every `AnyNode` (depth-first) reachable
+ * through array / nested-object children and invokes `visit` on each.
+ */
+function walk(node: AnyNode, visit: (node: AnyNode) => void): void {
+	visit(node);
+	for (const key of Object.keys(node)) {
+		if (key === "parent") continue;
+		const value = node[key];
+		if (Array.isArray(value)) {
+			for (const item of value) {
+				if (item && typeof item === "object" && typeof item.type === "string") {
+					walk(item as AnyNode, visit);
+				}
+			}
+		} else if (
+			value &&
+			typeof value === "object" &&
+			typeof (value as { type?: unknown }).type === "string"
+		) {
+			walk(value as AnyNode, visit);
+		}
+	}
+}

--- a/packages/vite-auto-collect/src/index.test.ts
+++ b/packages/vite-auto-collect/src/index.test.ts
@@ -1,0 +1,506 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { autoCollect } from "./index";
+
+/**
+ * Must match the private constant inside `./index.ts`. Duplicated here so the
+ * test doesn't reach into the plugin's internals.
+ */
+const RESOLVED_VIRTUAL_ID = "\0virtual:openpolicy/auto-collected";
+
+type PluginInstance = ReturnType<typeof autoCollect>;
+
+let tmp: string;
+
+beforeEach(async () => {
+	tmp = await mkdtemp(join(tmpdir(), "openpolicy-autocollect-"));
+});
+
+afterEach(async () => {
+	await rm(tmp, { recursive: true, force: true });
+});
+
+async function touch(rel: string, content: string): Promise<void> {
+	const full = join(tmp, rel);
+	await mkdir(dirname(full), { recursive: true });
+	await writeFile(full, content, "utf8");
+}
+
+/**
+ * Invokes `configResolved` and `buildStart` in the order Vite would, so the
+ * plugin's internal `scanned` state is populated.
+ */
+async function runPluginBuildStart(
+	plugin: PluginInstance,
+	root: string,
+): Promise<void> {
+	const configResolved = plugin.configResolved as
+		| ((config: { root: string }) => void | Promise<void>)
+		| undefined;
+	if (configResolved) await configResolved({ root });
+	const buildStart = plugin.buildStart as
+		| (() => void | Promise<void>)
+		| undefined;
+	if (buildStart) await buildStart.call({});
+}
+
+/**
+ * Calls the plugin's `load` hook with the virtual ID and parses the scanned
+ * object out of the emitted JS source. Going through `JSON.parse` means the
+ * assertions don't depend on the serialiser's output format.
+ */
+function loadScanned(plugin: PluginInstance): Record<string, string[]> {
+	const load = plugin.load as
+		| ((id: string) => string | null | undefined)
+		| undefined;
+	if (!load) throw new Error("plugin has no load hook");
+	const source = load.call({}, RESOLVED_VIRTUAL_ID);
+	if (!source) throw new Error("load returned falsy");
+	const match = source.match(/= (\{[\s\S]*?\});/);
+	if (!match?.[1]) throw new Error(`could not parse load output: ${source}`);
+	return JSON.parse(match[1]);
+}
+
+type WatcherEvent = "change" | "add" | "unlink";
+type WatcherHandler = (file: string) => void | Promise<void>;
+
+type StubServer = {
+	watcherAdded: string[];
+	invalidatedIds: string[];
+	sentMessages: Array<{ type: string }>;
+	loggedErrors: string[];
+	runHandler: (event: WatcherEvent, file: string) => Promise<void>;
+	// biome-ignore lint/suspicious/noExplicitAny: ad-hoc ViteDevServer stub.
+	server: any;
+};
+
+/**
+ * Builds a minimal stand-in for `ViteDevServer` that captures everything the
+ * plugin touches: watcher registrations, module-graph invalidations, WS
+ * messages, and logger errors. `runHandler` invokes a registered watcher
+ * listener and awaits its async body so tests can assert post-state without
+ * a sleep or a microtask dance.
+ */
+function createStubServer(): StubServer {
+	const handlers: Record<WatcherEvent, WatcherHandler[]> = {
+		change: [],
+		add: [],
+		unlink: [],
+	};
+	const watcherAdded: string[] = [];
+	const invalidatedIds: string[] = [];
+	const sentMessages: Array<{ type: string }> = [];
+	const loggedErrors: string[] = [];
+
+	// biome-ignore lint/suspicious/noExplicitAny: see StubServer.
+	const server: any = {
+		watcher: {
+			add(path: string): void {
+				watcherAdded.push(path);
+			},
+			on(event: WatcherEvent, cb: WatcherHandler): void {
+				handlers[event].push(cb);
+			},
+		},
+		moduleGraph: {
+			getModuleById(id: string): { id: string } {
+				return { id };
+			},
+			invalidateModule(mod: { id: string }): void {
+				invalidatedIds.push(mod.id);
+			},
+		},
+		ws: {
+			send(msg: { type: string }): void {
+				sentMessages.push(msg);
+			},
+		},
+		config: {
+			logger: {
+				error(msg: string): void {
+					loggedErrors.push(msg);
+				},
+			},
+		},
+	};
+
+	async function runHandler(event: WatcherEvent, file: string): Promise<void> {
+		for (const cb of handlers[event]) {
+			await cb(file);
+		}
+	}
+
+	return {
+		watcherAdded,
+		invalidatedIds,
+		sentMessages,
+		loggedErrors,
+		runHandler,
+		server,
+	};
+}
+
+/**
+ * Invokes the plugin's `configureServer` hook with the given stub. Handles
+ * both the plain-function and object-hook shapes that Vite allows.
+ */
+function runConfigureServer(
+	plugin: PluginInstance,
+	// biome-ignore lint/suspicious/noExplicitAny: see StubServer.
+	server: any,
+): void | Promise<void> {
+	const hook = plugin.configureServer as unknown;
+	if (typeof hook === "function") {
+		return (hook as (s: unknown) => void | Promise<void>)(server);
+	}
+	if (hook && typeof (hook as { handler?: unknown }).handler === "function") {
+		return (hook as { handler: (s: unknown) => void | Promise<void> }).handler(
+			server,
+		);
+	}
+	throw new Error("plugin has no configureServer hook");
+}
+
+/**
+ * Calls the plugin's `resolveId` hook with a stubbed Vite context whose
+ * `this.resolve` returns a fixed fake resolution.
+ */
+async function callResolveId(
+	plugin: PluginInstance,
+	source: string,
+	importer: string | undefined,
+	fakeResolved: { id: string } | null,
+): Promise<string | null> {
+	const hook = plugin.resolveId as unknown as (
+		this: { resolve: () => Promise<{ id: string } | null> },
+		source: string,
+		importer: string | undefined,
+		options: Record<string, unknown>,
+	) => Promise<string | null>;
+	const context = {
+		async resolve(): Promise<{ id: string } | null> {
+			return fakeResolved;
+		},
+	};
+	return hook.call(context, source, importer, {});
+}
+
+test("load hook returns scanned categories after buildStart", async () => {
+	await touch(
+		"src/lib/db.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		export function createUser(name: string, email: string) {
+			return collecting("Account Information", { name, email }, (v) => ({
+				Name: v.name,
+				"Email address": v.email,
+			}));
+		}
+		`,
+	);
+
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	expect(loadScanned(plugin)).toEqual({
+		"Account Information": ["Name", "Email address"],
+	});
+});
+
+test("merges calls across multiple files", async () => {
+	// Files are walked in sorted order, so `a-users.ts` runs before
+	// `b-pages.ts`. Label order reflects first-seen insertion.
+	await touch(
+		"src/a-users.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Account Information", v, (v) => ({ Name: v.a, Email: v.b }));
+		`,
+	);
+	await touch(
+		"src/b-pages.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Usage Data", v, (v) => ({ "Pages visited": v.p }));
+		collecting("Account Information", v, (v) => ({ Phone: v.c }));
+		`,
+	);
+
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	expect(loadScanned(plugin)).toEqual({
+		"Account Information": ["Name", "Email", "Phone"],
+		"Usage Data": ["Pages visited"],
+	});
+});
+
+test("ignores files outside the configured srcDir", async () => {
+	await touch(
+		"src/ok.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("In", v, (v) => ({ X: v.x }));
+		`,
+	);
+	await touch(
+		"other/nope.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Out", v, (v) => ({ X: v.x }));
+		`,
+	);
+
+	const plugin = autoCollect({ srcDir: "src" });
+	await runPluginBuildStart(plugin, tmp);
+
+	expect(loadScanned(plugin)).toEqual({ In: ["X"] });
+});
+
+test("respects a custom srcDir", async () => {
+	await touch(
+		"app/foo.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Cat", v, (v) => ({ X: v.x }));
+		`,
+	);
+
+	const plugin = autoCollect({ srcDir: "app" });
+	await runPluginBuildStart(plugin, tmp);
+
+	expect(loadScanned(plugin)).toEqual({ Cat: ["X"] });
+});
+
+test("emits an empty object when srcDir contains no collecting() calls", async () => {
+	await touch("src/noop.ts", `export const x = 1;\n`);
+
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	expect(loadScanned(plugin)).toEqual({});
+});
+
+test("emits an empty object when srcDir is missing entirely", async () => {
+	const plugin = autoCollect({ srcDir: "missing" });
+	await runPluginBuildStart(plugin, tmp);
+
+	expect(loadScanned(plugin)).toEqual({});
+});
+
+test("scans .tsx files by default", async () => {
+	await touch(
+		"src/Widget.tsx",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		export function Widget() {
+			collecting("Widget", v, (v) => ({ X: v.x }));
+			return null;
+		}
+		`,
+	);
+
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	expect(loadScanned(plugin)).toEqual({ Widget: ["X"] });
+});
+
+test("resolveId redirects ./auto-collected when importer is inside @openpolicy/sdk", async () => {
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	// Published install layout uses the dist `./auto-collected.js` specifier.
+	const nodeModulesResult = await callResolveId(
+		plugin,
+		"./auto-collected.js",
+		"/app/node_modules/@openpolicy/sdk/dist/index.js",
+		{ id: "/app/node_modules/@openpolicy/sdk/dist/auto-collected.js" },
+	);
+	expect(nodeModulesResult).toBe(RESOLVED_VIRTUAL_ID);
+
+	// Workspace source layout uses the bare `./auto-collected` specifier.
+	const workspaceResult = await callResolveId(
+		plugin,
+		"./auto-collected",
+		"/repo/packages/sdk/src/index.ts",
+		{ id: "/repo/packages/sdk/src/auto-collected.ts" },
+	);
+	expect(workspaceResult).toBe(RESOLVED_VIRTUAL_ID);
+});
+
+test("resolveId leaves unrelated ./auto-collected imports alone", async () => {
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	const result = await callResolveId(
+		plugin,
+		"./auto-collected",
+		"/some/other/package/index.js",
+		{ id: "/some/other/package/auto-collected.js" },
+	);
+	expect(result).toBeNull();
+});
+
+test("resolveId ignores specifiers other than ./auto-collected", async () => {
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	const result = await callResolveId(
+		plugin,
+		"./something-else",
+		"/repo/packages/sdk/src/index.ts",
+		{ id: "/repo/packages/sdk/src/something-else.ts" },
+	);
+	expect(result).toBeNull();
+});
+
+test("configureServer adds resolvedSrcDir to the chokidar watch set", async () => {
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	const stub = createStubServer();
+	await runConfigureServer(plugin, stub.server);
+
+	expect(stub.watcherAdded).toContain(join(tmp, "src"));
+});
+
+test("dev watcher re-scans and triggers a full reload when a tracked file changes", async () => {
+	await touch(
+		"src/lib/db.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Initial", v, (v) => ({ X: v.x }));
+		`,
+	);
+
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+	expect(loadScanned(plugin)).toEqual({ Initial: ["X"] });
+
+	const stub = createStubServer();
+	await runConfigureServer(plugin, stub.server);
+
+	// User adds a second collecting() call — simulate both the file write
+	// and the watcher event chokidar would emit.
+	await touch(
+		"src/lib/db.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Initial", v, (v) => ({ X: v.x }));
+		collecting("Added", v, (v) => ({ Y: v.y }));
+		`,
+	);
+	await stub.runHandler("change", join(tmp, "src/lib/db.ts"));
+
+	expect(loadScanned(plugin)).toEqual({
+		Initial: ["X"],
+		Added: ["Y"],
+	});
+	expect(stub.invalidatedIds).toContain(RESOLVED_VIRTUAL_ID);
+	expect(stub.sentMessages).toContainEqual({ type: "full-reload" });
+});
+
+test("dev watcher picks up newly-created source files", async () => {
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+	expect(loadScanned(plugin)).toEqual({});
+
+	const stub = createStubServer();
+	await runConfigureServer(plugin, stub.server);
+
+	await touch(
+		"src/new.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Brand New", v, (v) => ({ Z: v.z }));
+		`,
+	);
+	await stub.runHandler("add", join(tmp, "src/new.ts"));
+
+	expect(loadScanned(plugin)).toEqual({ "Brand New": ["Z"] });
+	expect(stub.sentMessages).toContainEqual({ type: "full-reload" });
+});
+
+test("dev watcher drops categories when a file is deleted", async () => {
+	await touch(
+		"src/gone.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Temporary", v, (v) => ({ X: v.x }));
+		`,
+	);
+
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+	expect(loadScanned(plugin)).toEqual({ Temporary: ["X"] });
+
+	const stub = createStubServer();
+	await runConfigureServer(plugin, stub.server);
+
+	await rm(join(tmp, "src/gone.ts"));
+	await stub.runHandler("unlink", join(tmp, "src/gone.ts"));
+
+	expect(loadScanned(plugin)).toEqual({});
+	expect(stub.sentMessages).toContainEqual({ type: "full-reload" });
+});
+
+test("dev watcher ignores events for files outside srcDir", async () => {
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	const stub = createStubServer();
+	await runConfigureServer(plugin, stub.server);
+
+	await touch("other/x.ts", `export const x = 1;\n`);
+	await stub.runHandler("change", join(tmp, "other/x.ts"));
+
+	expect(stub.invalidatedIds).toHaveLength(0);
+	expect(stub.sentMessages).toHaveLength(0);
+});
+
+test("dev watcher ignores events for files with untracked extensions", async () => {
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	const stub = createStubServer();
+	await runConfigureServer(plugin, stub.server);
+
+	await touch("src/README.md", `# hello\n`);
+	await stub.runHandler("change", join(tmp, "src/README.md"));
+
+	expect(stub.invalidatedIds).toHaveLength(0);
+	expect(stub.sentMessages).toHaveLength(0);
+});
+
+test("dev watcher skips invalidation when the scan output is unchanged", async () => {
+	await touch(
+		"src/a.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("A", v, (v) => ({ X: v.x }));
+		`,
+	);
+
+	const plugin = autoCollect();
+	await runPluginBuildStart(plugin, tmp);
+
+	const stub = createStubServer();
+	await runConfigureServer(plugin, stub.server);
+
+	// Touch the file with a harmless edit that preserves collecting() shape.
+	await touch(
+		"src/a.ts",
+		`
+		// comment added
+		import { collecting } from "@openpolicy/sdk";
+		collecting("A", v, (v) => ({ X: v.x }));
+		`,
+	);
+	await stub.runHandler("change", join(tmp, "src/a.ts"));
+
+	expect(stub.invalidatedIds).toHaveLength(0);
+	expect(stub.sentMessages).toHaveLength(0);
+});

--- a/packages/vite-auto-collect/src/index.test.ts
+++ b/packages/vite-auto-collect/src/index.test.ts
@@ -142,61 +142,16 @@ function createStubServer(): StubServer {
 	};
 }
 
-/**
- * Invokes the plugin's `configureServer` hook with the given stub. Handles
- * both the plain-function and object-hook shapes that Vite allows.
- */
-function runConfigureServer(
-	plugin: PluginInstance,
-	// biome-ignore lint/suspicious/noExplicitAny: see StubServer.
-	server: any,
-): void | Promise<void> {
-	const hook = plugin.configureServer as unknown;
-	if (typeof hook === "function") {
-		return (hook as (s: unknown) => void | Promise<void>)(server);
-	}
-	if (hook && typeof (hook as { handler?: unknown }).handler === "function") {
-		return (hook as { handler: (s: unknown) => void | Promise<void> }).handler(
-			server,
-		);
-	}
-	throw new Error("plugin has no configureServer hook");
-}
-
-/**
- * Calls the plugin's `resolveId` hook with a stubbed Vite context whose
- * `this.resolve` returns a fixed fake resolution.
- */
-async function callResolveId(
-	plugin: PluginInstance,
-	source: string,
-	importer: string | undefined,
-	fakeResolved: { id: string } | null,
-): Promise<string | null> {
-	const hook = plugin.resolveId as unknown as (
-		this: { resolve: () => Promise<{ id: string } | null> },
-		source: string,
-		importer: string | undefined,
-		options: Record<string, unknown>,
-	) => Promise<string | null>;
-	const context = {
-		async resolve(): Promise<{ id: string } | null> {
-			return fakeResolved;
-		},
-	};
-	return hook.call(context, source, importer, {});
-}
-
 test("load hook returns scanned categories after buildStart", async () => {
 	await touch(
 		"src/lib/db.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
 		export function createUser(name: string, email: string) {
-			return collecting("Account Information", { name, email }, (v) => ({
-				Name: v.name,
-				"Email address": v.email,
-			}));
+			return collecting("Account Information", { name, email }, {
+				name: "Name",
+				email: "Email address",
+			});
 		}
 		`,
 	);
@@ -216,15 +171,15 @@ test("merges calls across multiple files", async () => {
 		"src/a-users.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Account Information", v, (v) => ({ Name: v.a, Email: v.b }));
+		collecting("Account Information", v, { a: "Name", b: "Email" });
 		`,
 	);
 	await touch(
 		"src/b-pages.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Usage Data", v, (v) => ({ "Pages visited": v.p }));
-		collecting("Account Information", v, (v) => ({ Phone: v.c }));
+		collecting("Usage Data", v, { p: "Pages visited" });
+		collecting("Account Information", v, { c: "Phone" });
 		`,
 	);
 
@@ -242,14 +197,14 @@ test("ignores files outside the configured srcDir", async () => {
 		"src/ok.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("In", v, (v) => ({ X: v.x }));
+		collecting("In", v, { x: "X" });
 		`,
 	);
 	await touch(
 		"other/nope.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Out", v, (v) => ({ X: v.x }));
+		collecting("Out", v, { x: "X" });
 		`,
 	);
 
@@ -264,7 +219,7 @@ test("respects a custom srcDir", async () => {
 		"app/foo.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Cat", v, (v) => ({ X: v.x }));
+		collecting("Cat", v, { x: "X" });
 		`,
 	);
 
@@ -296,7 +251,7 @@ test("scans .tsx files by default", async () => {
 		`
 		import { collecting } from "@openpolicy/sdk";
 		export function Widget() {
-			collecting("Widget", v, (v) => ({ X: v.x }));
+			collecting("Widget", v, { x: "X" });
 			return null;
 		}
 		`,
@@ -372,7 +327,7 @@ test("dev watcher re-scans and triggers a full reload when a tracked file change
 		"src/lib/db.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Initial", v, (v) => ({ X: v.x }));
+		collecting("Initial", v, { x: "X" });
 		`,
 	);
 
@@ -389,8 +344,8 @@ test("dev watcher re-scans and triggers a full reload when a tracked file change
 		"src/lib/db.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Initial", v, (v) => ({ X: v.x }));
-		collecting("Added", v, (v) => ({ Y: v.y }));
+		collecting("Initial", v, { x: "X" });
+		collecting("Added", v, { y: "Y" });
 		`,
 	);
 	await stub.runHandler("change", join(tmp, "src/lib/db.ts"));
@@ -415,7 +370,7 @@ test("dev watcher picks up newly-created source files", async () => {
 		"src/new.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Brand New", v, (v) => ({ Z: v.z }));
+		collecting("Brand New", v, { z: "Z" });
 		`,
 	);
 	await stub.runHandler("add", join(tmp, "src/new.ts"));
@@ -429,7 +384,7 @@ test("dev watcher drops categories when a file is deleted", async () => {
 		"src/gone.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("Temporary", v, (v) => ({ X: v.x }));
+		collecting("Temporary", v, { x: "X" });
 		`,
 	);
 
@@ -480,7 +435,7 @@ test("dev watcher skips invalidation when the scan output is unchanged", async (
 		"src/a.ts",
 		`
 		import { collecting } from "@openpolicy/sdk";
-		collecting("A", v, (v) => ({ X: v.x }));
+		collecting("A", v, { x: "X" });
 		`,
 	);
 
@@ -496,7 +451,7 @@ test("dev watcher skips invalidation when the scan output is unchanged", async (
 		`
 		// comment added
 		import { collecting } from "@openpolicy/sdk";
-		collecting("A", v, (v) => ({ X: v.x }));
+		collecting("A", v, { x: "X" });
 		`,
 	);
 	await stub.runHandler("change", join(tmp, "src/a.ts"));
@@ -504,3 +459,48 @@ test("dev watcher skips invalidation when the scan output is unchanged", async (
 	expect(stub.invalidatedIds).toHaveLength(0);
 	expect(stub.sentMessages).toHaveLength(0);
 });
+
+/**
+ * Calls the plugin's `resolveId` hook with a stubbed Vite context whose
+ * `this.resolve` returns a fixed fake resolution.
+ */
+async function callResolveId(
+	plugin: PluginInstance,
+	source: string,
+	importer: string | undefined,
+	fakeResolved: { id: string } | null,
+): Promise<string | null> {
+	const hook = plugin.resolveId as unknown as (
+		this: { resolve: () => Promise<{ id: string } | null> },
+		source: string,
+		importer: string | undefined,
+		options: Record<string, unknown>,
+	) => Promise<string | null>;
+	const context = {
+		async resolve(): Promise<{ id: string } | null> {
+			return fakeResolved;
+		},
+	};
+	return hook.call(context, source, importer, {});
+}
+
+/**
+ * Invokes the plugin's `configureServer` hook with the given stub. Handles
+ * both the plain-function and object-hook shapes that Vite allows.
+ */
+function runConfigureServer(
+	plugin: PluginInstance,
+	// biome-ignore lint/suspicious/noExplicitAny: see StubServer.
+	server: any,
+): void | Promise<void> {
+	const hook = plugin.configureServer as unknown;
+	if (typeof hook === "function") {
+		return (hook as (s: unknown) => void | Promise<void>)(server);
+	}
+	if (hook && typeof (hook as { handler?: unknown }).handler === "function") {
+		return (hook as { handler: (s: unknown) => void | Promise<void> }).handler(
+			server,
+		);
+	}
+	throw new Error("plugin has no configureServer hook");
+}

--- a/packages/vite-auto-collect/src/index.ts
+++ b/packages/vite-auto-collect/src/index.ts
@@ -1,0 +1,172 @@
+import { readFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import type { Plugin, ViteDevServer } from "vite";
+import { extractCollecting } from "./analyse";
+import { walkSources } from "./scan";
+
+export type AutoCollectOptions = {
+	/**
+	 * Directory walked for `collecting()` calls. Resolved relative to the
+	 * Vite project root. Defaults to `"src"`.
+	 */
+	srcDir?: string;
+	/**
+	 * File extensions scanned. Defaults to `[".ts", ".tsx"]`.
+	 */
+	extensions?: string[];
+	/**
+	 * Extra directory names skipped during the walk. Appended to the built-in
+	 * defaults (`node_modules`, `dist`, `.git`, `.next`, `.output`,
+	 * `.svelte-kit`, `.cache`).
+	 */
+	ignore?: string[];
+};
+
+/**
+ * Marker returned from `resolveId` so `load` can recognise a hit. The leading
+ * NUL prefix is the Rollup/Vite convention for virtual IDs so other plugins
+ * leave it alone.
+ */
+const RESOLVED_VIRTUAL_ID = "\0virtual:openpolicy/auto-collected";
+
+/**
+ * Matches any path that lives inside the `@openpolicy/sdk` package, whether
+ * it's resolved via a workspace symlink (`.../packages/sdk/...`) or a
+ * published `node_modules` install (`.../@openpolicy/sdk/...`). Used to scope
+ * the `./auto-collected` relative-import interception to the SDK itself.
+ */
+const SDK_PATH_PATTERN = /[\\/](?:@openpolicy[\\/]sdk|packages[\\/]sdk)[\\/]/;
+
+/**
+ * Matches the relative specifier the SDK uses for its own internal
+ * `./auto-collected` import. Both the source form (`./auto-collected`) and
+ * the published dist form (`./auto-collected.js`) need to be intercepted:
+ * the former applies when consumers resolve the SDK via its workspace
+ * source, the latter when resolving against `dist/` with the separate
+ * `auto-collected.js` chunk.
+ */
+const AUTO_COLLECTED_SPECIFIER = /^\.\/auto-collected(?:\.js)?$/;
+
+/**
+ * Vite plugin that scans source files for `@openpolicy/sdk` `collecting()`
+ * calls at the start of each build and inlines the discovered categories into
+ * the SDK's `autoCollected` sentinel.
+ *
+ * Internally the plugin intercepts `@openpolicy/sdk`'s own relative import of
+ * `./auto-collected` and redirects it to a virtual module whose body is a
+ * literal `export const autoCollected = { ... }`. Because the replacement
+ * becomes part of the consumer's own module graph, the scanned data survives
+ * any downstream bundler boundary (e.g. nitro's SSR output), which a shared
+ * module-level registry would not.
+ */
+export function autoCollect(options: AutoCollectOptions = {}): Plugin {
+	const srcDirOpt = options.srcDir ?? "src";
+	const extensions = options.extensions ?? [".ts", ".tsx"];
+	const ignore = options.ignore ?? [];
+	let resolvedSrcDir: string;
+	let scanned: Record<string, string[]> = {};
+
+	async function scanAndMerge(): Promise<Record<string, string[]>> {
+		const files = await walkSources(resolvedSrcDir, extensions, ignore);
+		const merged: Record<string, string[]> = {};
+		for (const file of files) {
+			let code: string;
+			try {
+				code = await readFile(file, "utf8");
+			} catch {
+				continue;
+			}
+			const extracted = extractCollecting(file, code);
+			for (const [category, labels] of Object.entries(extracted)) {
+				const existing = merged[category] ?? [];
+				const seen = new Set(existing);
+				for (const label of labels) {
+					if (!seen.has(label)) {
+						existing.push(label);
+						seen.add(label);
+					}
+				}
+				merged[category] = existing;
+			}
+		}
+		return merged;
+	}
+
+	/**
+	 * Returns true when `file` lives inside `resolvedSrcDir` and has one of
+	 * the tracked extensions. Used by the dev-server watcher to skip events
+	 * for unrelated files (configs, public assets, other packages, etc.).
+	 */
+	function isTrackedSource(file: string): boolean {
+		const rel = relative(resolvedSrcDir, file);
+		if (!rel || rel.startsWith("..")) return false;
+		return extensions.some((ext) => file.endsWith(ext));
+	}
+
+	/**
+	 * Re-runs the scan and, if anything changed, invalidates the virtual
+	 * module and triggers a full page reload. A full reload is used because
+	 * `autoCollected` is spread into `dataCollected` at module-evaluation
+	 * time and the result is captured by the React tree as a prop — there's
+	 * no clean way to hot-swap it in place.
+	 */
+	async function rescanAndRefresh(server: ViteDevServer): Promise<void> {
+		const next = await scanAndMerge();
+		if (JSON.stringify(next) === JSON.stringify(scanned)) return;
+		scanned = next;
+		const mod = server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_ID);
+		if (mod) server.moduleGraph.invalidateModule(mod);
+		server.ws.send({ type: "full-reload" });
+	}
+
+	return {
+		name: "openpolicy-auto-collect",
+		enforce: "pre",
+		configResolved(config) {
+			resolvedSrcDir = resolve(config.root, srcDirOpt);
+		},
+		async buildStart() {
+			scanned = await scanAndMerge();
+		},
+		configureServer(server) {
+			// Make sure chokidar watches the whole src tree, not just files
+			// already in the module graph. Without this, creating a brand-new
+			// source file that nothing imports yet wouldn't fire a watcher
+			// event — the very case we most need to re-scan on.
+			server.watcher.add(resolvedSrcDir);
+
+			const handler = async (file: string): Promise<void> => {
+				if (!isTrackedSource(file)) return;
+				// Surface errors via the logger but don't rethrow — an
+				// unhandled rejection would crash the watcher process.
+				try {
+					await rescanAndRefresh(server);
+				} catch (error) {
+					server.config.logger.error(
+						`[openpolicy-auto-collect] rescan failed: ${error}`,
+					);
+				}
+			};
+
+			server.watcher.on("change", handler);
+			server.watcher.on("add", handler);
+			server.watcher.on("unlink", handler);
+		},
+		async resolveId(source, importer, resolveOptions) {
+			if (!importer || !AUTO_COLLECTED_SPECIFIER.test(source)) return null;
+			// Defer to Vite's resolver first so we only redirect when the
+			// relative specifier actually points inside @openpolicy/sdk.
+			const resolved = await this.resolve(source, importer, {
+				...resolveOptions,
+				skipSelf: true,
+			});
+			if (!resolved) return null;
+			if (!SDK_PATH_PATTERN.test(resolved.id)) return null;
+			return RESOLVED_VIRTUAL_ID;
+		},
+		load(id) {
+			if (id !== RESOLVED_VIRTUAL_ID) return null;
+			return `export const autoCollected = ${JSON.stringify(scanned)};\n`;
+		},
+	};
+}

--- a/packages/vite-auto-collect/src/index.ts
+++ b/packages/vite-auto-collect/src/index.ts
@@ -50,11 +50,11 @@ const AUTO_COLLECTED_SPECIFIER = /^\.\/auto-collected(?:\.js)?$/;
 /**
  * Vite plugin that scans source files for `@openpolicy/sdk` `collecting()`
  * calls at the start of each build and inlines the discovered categories into
- * the SDK's `autoCollected` sentinel.
+ * the SDK's `dataCollected` sentinel.
  *
  * Internally the plugin intercepts `@openpolicy/sdk`'s own relative import of
  * `./auto-collected` and redirects it to a virtual module whose body is a
- * literal `export const autoCollected = { ... }`. Because the replacement
+ * literal `export const dataCollected = { ... }`. Because the replacement
  * becomes part of the consumer's own module graph, the scanned data survives
  * any downstream bundler boundary (e.g. nitro's SSR output), which a shared
  * module-level registry would not.
@@ -106,7 +106,7 @@ export function autoCollect(options: AutoCollectOptions = {}): Plugin {
 	/**
 	 * Re-runs the scan and, if anything changed, invalidates the virtual
 	 * module and triggers a full page reload. A full reload is used because
-	 * `autoCollected` is spread into `dataCollected` at module-evaluation
+	 * `dataCollected` is spread into the policy config at module-evaluation
 	 * time and the result is captured by the React tree as a prop — there's
 	 * no clean way to hot-swap it in place.
 	 */
@@ -166,7 +166,7 @@ export function autoCollect(options: AutoCollectOptions = {}): Plugin {
 		},
 		load(id) {
 			if (id !== RESOLVED_VIRTUAL_ID) return null;
-			return `export const autoCollected = ${JSON.stringify(scanned)};\n`;
+			return `export const dataCollected = ${JSON.stringify(scanned)};\n`;
 		},
 	};
 }

--- a/packages/vite-auto-collect/src/scan.test.ts
+++ b/packages/vite-auto-collect/src/scan.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { walkSources } from "./scan";
+
+let tmp: string;
+
+beforeEach(async () => {
+	tmp = await mkdtemp(join(tmpdir(), "openpolicy-scan-"));
+});
+
+afterEach(async () => {
+	await rm(tmp, { recursive: true, force: true });
+});
+
+async function touch(rel: string, content = ""): Promise<void> {
+	const full = join(tmp, rel);
+	const dir = full.slice(0, full.lastIndexOf("/"));
+	await mkdir(dir, { recursive: true });
+	await writeFile(full, content, "utf8");
+}
+
+test("returns empty array when root does not exist", async () => {
+	const files = await walkSources(join(tmp, "missing"), [".ts"]);
+	expect(files).toEqual([]);
+});
+
+test("returns empty array when root is empty", async () => {
+	const files = await walkSources(tmp, [".ts"]);
+	expect(files).toEqual([]);
+});
+
+test("walks nested directories", async () => {
+	await touch("a.ts", "");
+	await touch("nested/b.ts", "");
+	await touch("nested/deep/c.ts", "");
+
+	const files = await walkSources(tmp, [".ts"]);
+	expect(files.map((f) => relative(tmp, f))).toEqual([
+		"a.ts",
+		"nested/b.ts",
+		"nested/deep/c.ts",
+	]);
+});
+
+test("filters by extension", async () => {
+	await touch("a.ts", "");
+	await touch("b.tsx", "");
+	await touch("c.js", "");
+	await touch("d.json", "");
+
+	const files = await walkSources(tmp, [".ts", ".tsx"]);
+	expect(files.map((f) => relative(tmp, f)).sort()).toEqual(["a.ts", "b.tsx"]);
+});
+
+test("skips node_modules and other default ignores", async () => {
+	await touch("src/a.ts", "");
+	await touch("node_modules/pkg/b.ts", "");
+	await touch("dist/c.ts", "");
+	await touch(".git/hooks/d.ts", "");
+	await touch(".next/server/e.ts", "");
+
+	const files = await walkSources(tmp, [".ts"]);
+	expect(files.map((f) => relative(tmp, f))).toEqual(["src/a.ts"]);
+});
+
+test("honours extra user ignores", async () => {
+	await touch("src/a.ts", "");
+	await touch("generated/b.ts", "");
+
+	const files = await walkSources(tmp, [".ts"], ["generated"]);
+	expect(files.map((f) => relative(tmp, f))).toEqual(["src/a.ts"]);
+});
+
+test("returns absolute paths", async () => {
+	await touch("a.ts", "");
+
+	const files = await walkSources(tmp, [".ts"]);
+	expect(files).toHaveLength(1);
+	expect(files[0]?.startsWith("/")).toBe(true);
+});

--- a/packages/vite-auto-collect/src/scan.ts
+++ b/packages/vite-auto-collect/src/scan.ts
@@ -1,0 +1,56 @@
+import type { Dirent } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { extname, join } from "node:path";
+
+const DEFAULT_IGNORES: ReadonlySet<string> = new Set([
+	"node_modules",
+	"dist",
+	".git",
+	".next",
+	".output",
+	".svelte-kit",
+	".cache",
+]);
+
+/**
+ * Recursively walks `root`, returning absolute paths of every regular file
+ * whose extension is in `extensions`. Directories whose basename appears in
+ * the built-in ignore list (or the extra `ignore` argument) are skipped
+ * entirely.
+ *
+ * Missing roots resolve to an empty array — the plugin must not throw if the
+ * user's `srcDir` hasn't been created yet.
+ */
+export async function walkSources(
+	root: string,
+	extensions: readonly string[],
+	ignore: readonly string[] = [],
+): Promise<string[]> {
+	const ignored = new Set<string>([...DEFAULT_IGNORES, ...ignore]);
+	const exts = new Set(extensions);
+	const results: string[] = [];
+
+	async function walk(dir: string): Promise<void> {
+		let entries: Dirent[];
+		try {
+			entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === "ENOENT" || code === "ENOTDIR") return;
+			throw err;
+		}
+		for (const entry of entries) {
+			if (ignored.has(entry.name)) continue;
+			const full = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				await walk(full);
+			} else if (entry.isFile() && exts.has(extname(entry.name))) {
+				results.push(full);
+			}
+		}
+	}
+
+	await walk(root);
+	results.sort();
+	return results;
+}

--- a/packages/vite-auto-collect/tsconfig.json
+++ b/packages/vite-auto-collect/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@openpolicy/tooling/base",
+	"include": ["src"],
+	"compilerOptions": {
+		"outDir": "dist"
+	}
+}

--- a/packages/vue/src/components/CookiePolicy.ts
+++ b/packages/vue/src/components/CookiePolicy.ts
@@ -5,7 +5,13 @@ import {
 	isOpenPolicyConfig,
 	type OpenPolicyConfig,
 } from "@openpolicy/core";
-import { defineComponent, h, inject, type CSSProperties, type PropType } from "vue";
+import {
+	type CSSProperties,
+	defineComponent,
+	h,
+	inject,
+	type PropType,
+} from "vue";
 import { OpenPolicyContextKey } from "../context";
 import { renderDocument } from "../render";
 import type { PolicyComponents } from "../types";

--- a/packages/vue/src/components/PrivacyPolicy.ts
+++ b/packages/vue/src/components/PrivacyPolicy.ts
@@ -5,7 +5,13 @@ import {
 	type OpenPolicyConfig,
 	type PrivacyPolicyConfig,
 } from "@openpolicy/core";
-import { defineComponent, h, inject, type CSSProperties, type PropType } from "vue";
+import {
+	type CSSProperties,
+	defineComponent,
+	h,
+	inject,
+	type PropType,
+} from "vue";
 import { OpenPolicyContextKey } from "../context";
 import { renderDocument } from "../render";
 import type { PolicyComponents } from "../types";

--- a/packages/vue/src/components/TermsOfService.ts
+++ b/packages/vue/src/components/TermsOfService.ts
@@ -5,7 +5,13 @@ import {
 	type OpenPolicyConfig,
 	type TermsOfServiceConfig,
 } from "@openpolicy/core";
-import { defineComponent, h, inject, type CSSProperties, type PropType } from "vue";
+import {
+	type CSSProperties,
+	defineComponent,
+	h,
+	inject,
+	type PropType,
+} from "vue";
 import { OpenPolicyContextKey } from "../context";
 import { renderDocument } from "../render";
 import type { PolicyComponents } from "../types";

--- a/packages/vue/src/components/defaults.ts
+++ b/packages/vue/src/components/defaults.ts
@@ -75,7 +75,11 @@ export function DefaultList({
 	children?: VNodeChild;
 }) {
 	const tag = node.ordered ? "ol" : "ul";
-	return h(tag, { "data-op-list": "", class: "op-list" }, children ?? undefined);
+	return h(
+		tag,
+		{ "data-op-list": "", class: "op-list" },
+		children ?? undefined,
+	);
 }
 
 export function renderNode(
@@ -85,7 +89,9 @@ export function renderNode(
 ): VNodeChild {
 	switch (node.type) {
 		case "document":
-			return node.sections.map((section, i) => renderNode(section, components, i));
+			return node.sections.map((section, i) =>
+				renderNode(section, components, i),
+			);
 
 		case "section": {
 			const SectionComp = components.Section ?? DefaultSection;
@@ -105,7 +111,9 @@ export function renderNode(
 		}
 
 		case "paragraph": {
-			const children = node.children.map((n, i) => renderNode(n, components, i));
+			const children = node.children.map((n, i) =>
+				renderNode(n, components, i),
+			);
 			if (components.Paragraph) {
 				return h(
 					components.Paragraph,
@@ -115,11 +123,17 @@ export function renderNode(
 					},
 				);
 			}
-			return h("p", { key, "data-op-paragraph": "", class: "op-paragraph" }, children);
+			return h(
+				"p",
+				{ key, "data-op-paragraph": "", class: "op-paragraph" },
+				children,
+			);
 		}
 
 		case "list": {
-			const children = node.items.map((item, i) => renderNode(item, components, i));
+			const children = node.items.map((item, i) =>
+				renderNode(item, components, i),
+			);
 			if (components.List) {
 				return h(
 					components.List,
@@ -130,7 +144,11 @@ export function renderNode(
 				);
 			}
 			const ListTag = node.ordered ? "ol" : "ul";
-			return h(ListTag, { key, "data-op-list": "", class: "op-list" }, children);
+			return h(
+				ListTag,
+				{ key, "data-op-list": "", class: "op-list" },
+				children,
+			);
 		}
 
 		case "listItem":

--- a/packages/vue/styles.css
+++ b/packages/vue/styles.css
@@ -1,30 +1,30 @@
 /* @openpolicy/vue/styles.css — opt-in default styles */
 :root {
-  --op-font-family: system-ui, sans-serif;
-  --op-font-size-body: 1rem;
-  --op-font-size-heading: 1.25rem;
-  --op-heading-color: #111;
-  --op-body-color: #444;
-  --op-section-gap: 2rem;
-  --op-border-color: #e5e5e5;
-  --op-border-radius: 0.25rem;
-  --op-line-height: 1.6;
+	--op-font-family: system-ui, sans-serif;
+	--op-font-size-body: 1rem;
+	--op-font-size-heading: 1.25rem;
+	--op-heading-color: #111;
+	--op-body-color: #444;
+	--op-section-gap: 2rem;
+	--op-border-color: #e5e5e5;
+	--op-border-radius: 0.25rem;
+	--op-line-height: 1.6;
 }
 
 [data-op-policy] {
-  font-family: var(--op-font-family);
-  color: var(--op-body-color);
+	font-family: var(--op-font-family);
+	color: var(--op-body-color);
 }
 
 [data-op-section] {
-  margin-bottom: var(--op-section-gap);
+	margin-bottom: var(--op-section-gap);
 }
 
 [data-op-heading] {
-  color: var(--op-heading-color);
-  font-size: var(--op-font-size-heading);
+	color: var(--op-heading-color);
+	font-size: var(--op-font-size-heading);
 }
 
 [data-op-body] {
-  line-height: var(--op-line-height);
+	line-height: var(--op-line-height);
 }


### PR DESCRIPTION
## Summary

This PR sets up `dataCollected` and `collecting` to automatically configure the OpenPolicy config

## Changes

- Adds the `dataCollected` API
- Adds the `collect` API
- Adds the Vite Auto Collect plugin

## Testing

How was this tested? (e.g. `bun test`, manual CLI run, Vite build)

## Checklist

- [ ] `bun test` passes
- [ ] `bun run check-types` passes
- [ ] Changeset added (`bun run changeset`) for any user-facing change to a published package
