### PR TITLE
Fix empty dataCollected in SSR builds by bundling SDK

### DIFF
--- a/.changeset/op-170-ssr-noexternal-sdk.md
+++ b/.changeset/op-170-ssr-noexternal-sdk.md
@@ -1,0 +1,10 @@
+---
+"@openpolicy/vite-auto-collect": patch
+---
+
+Fix `dataCollected` / `thirdParties` being empty in SSR builds (e.g. TanStack Start + Nitro).
+The plugin now pins `@openpolicy/sdk` to `ssr.noExternal` so Vite bundles the SDK into the
+server build and the plugin's `resolveId` / `load` interception of `./auto-collected.js`
+fires server-side the same way it already does on the client. Resolves empty config passed
+to `@openpolicy/plus`'s `client.consent()` from server functions and the flash of empty
+privacy data during hydration (OP-170).

--- a/packages/vite-auto-collect/src/index.test.ts
+++ b/packages/vite-auto-collect/src/index.test.ts
@@ -334,12 +334,15 @@ test("resolveId ignores specifiers other than ./auto-collected", async () => {
 	expect(result).toBeNull();
 });
 
-test("config hook excludes @openpolicy/sdk from dep pre-bundling (client + ssr)", () => {
+test("config hook excludes @openpolicy/sdk from dep pre-bundling and pins it to ssr.noExternal", () => {
 	const plugin = autoCollect();
 	const configHook = plugin.config as unknown as
 		| (() => {
 				optimizeDeps?: { exclude?: string[] };
-				ssr?: { optimizeDeps?: { exclude?: string[] } };
+				ssr?: {
+					optimizeDeps?: { exclude?: string[] };
+					noExternal?: string[] | true;
+				};
 		  } | void)
 		| undefined;
 	if (!configHook) throw new Error("plugin has no config hook");
@@ -347,6 +350,7 @@ test("config hook excludes @openpolicy/sdk from dep pre-bundling (client + ssr)"
 	const result = configHook();
 	expect(result?.optimizeDeps?.exclude).toContain("@openpolicy/sdk");
 	expect(result?.ssr?.optimizeDeps?.exclude).toContain("@openpolicy/sdk");
+	expect(result?.ssr?.noExternal).toContain("@openpolicy/sdk");
 });
 
 test("configureServer adds resolvedSrcDir to the chokidar watch set", async () => {

--- a/packages/vite-auto-collect/src/index.ts
+++ b/packages/vite-auto-collect/src/index.ts
@@ -197,11 +197,26 @@ export function autoCollect(options: AutoCollectOptions = {}): Plugin {
 		 * own, so excluding it from pre-bundling is cheap. Applied to both the
 		 * browser and the SSR dep optimizer for frameworks like TanStack Start /
 		 * Nitro (see `examples/tanstack/vite.config.ts`).
+		 *
+		 * Also pin the SDK to `ssr.noExternal` so Vite bundles it into the SSR
+		 * output instead of externalising it. Workspace packages resolved from
+		 * `node_modules` are externalised by default in SSR builds; Node's ESM
+		 * loader then resolves the SDK's internal `./auto-collected.js` to the
+		 * empty fallback at runtime, bypassing the plugin's `resolveId` hook
+		 * entirely. That asymmetry caused `dataCollected` / `thirdParties` to
+		 * arrive empty for server-side consumers such as `@openpolicy/plus`'s
+		 * `client.consent()` called from server functions, and produced a
+		 * hydration flash of empty privacy data (OP-170). Bundling the SDK
+		 * server-side routes its internal imports through the plugin pipeline
+		 * the same way they already go through it on the client.
 		 */
 		config() {
 			return {
 				optimizeDeps: { exclude: ["@openpolicy/sdk"] },
-				ssr: { optimizeDeps: { exclude: ["@openpolicy/sdk"] } },
+				ssr: {
+					optimizeDeps: { exclude: ["@openpolicy/sdk"] },
+					noExternal: ["@openpolicy/sdk"],
+				},
 			};
 		},
 		configResolved(config) {


### PR DESCRIPTION
## Summary

Fixes `dataCollected` / `thirdParties` being empty in SSR builds (e.g. TanStack Start + Nitro). The plugin now pins `@openpolicy/sdk` to `ssr.noExternal` so Vite bundles the SDK into the server build instead of externalizing it. This ensures the plugin's `resolveId` / `load` interception of `./auto-collected.js` fires server-side the same way it already does on the client, resolving empty config passed to `@openpolicy/plus`'s `client.consent()` from server functions and the hydration flash of empty privacy data (OP-170).

## Changes

- Added `noExternal: ["@openpolicy/sdk"]` to the `ssr` config in the `config()` hook to force bundling of the SDK in SSR builds
- Updated test to verify the SDK is pinned to `ssr.noExternal`
- Added detailed comments explaining why this is necessary for SSR builds

## Testing

- `bun test` passes with updated test coverage for the new `ssr.noExternal` configuration

## Checklist

- [x] `bun test` passes
- [x] Changeset added for user-facing change

https://claude.ai/code/session_01USvmHNcB7b5agX2y1rQfDd