### PR TITLE
feat(vite): located diagnostic for every skipped recognized scanner c…

### DIFF
--- a/packages/vite/src/analyse.test.ts
+++ b/packages/vite/src/analyse.test.ts
@@ -33,7 +33,10 @@ test("ignores collecting imported from a non-SDK module", () => {
 		import { collecting } from "./local-collecting";
 		collecting("Cat", v, { a: "Name" });
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({});
+	// Not a recognized call — must stay silent (scope boundary).
+	expect(result.diagnostics).toEqual([]);
 });
 
 test("ignores local `collecting` not imported from anywhere", () => {
@@ -41,7 +44,9 @@ test("ignores local `collecting` not imported from anywhere", () => {
 		function collecting(a, b, c) { return b; }
 		collecting("Cat", v, { a: "Name" });
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({});
+	expect(result.diagnostics).toEqual([]);
 });
 
 test("ignores type-only imports", () => {
@@ -49,36 +54,71 @@ test("ignores type-only imports", () => {
 		import type { collecting } from "@openpolicy/sdk";
 		collecting("Cat", v, { a: "Name" });
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({});
+	expect(result.diagnostics).toEqual([]);
 });
 
-test("skips template-literal category silently", () => {
+test("template-literal category is dropped with a located diagnostic", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
 		collecting(\`Cat\`, v, { a: "Name" });
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({});
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-argument",
+			message: "collecting() category must be a string literal",
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+	]);
 });
 
-test("non-string values skipped silently, string values kept", () => {
+test("non-string label values diagnosed individually, string values kept", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
 		collecting("Cat", v, { a: 42, b: "Kept", c: true });
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({
-		Cat: ["Kept"],
-	});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({ Cat: ["Kept"] });
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-label-value",
+			message: 'collecting() label "a" value must be a string literal or Ignore',
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+		{
+			code: "non-literal-label-value",
+			message: 'collecting() label "c" value must be a string literal or Ignore',
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+	]);
 });
 
-test("spread elements skipped silently", () => {
+test("spread in the label object is dropped with a diagnostic, string values kept", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
 		const rest = {};
 		collecting("Cat", v, { ...rest, b: "Kept" });
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({
-		Cat: ["Kept"],
-	});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({ Cat: ["Kept"] });
+	expect(result.diagnostics).toEqual([
+		{
+			code: "spread-in-label-map",
+			message: "collecting() label object uses a spread; spread labels can't be read statically",
+			file: "a.ts",
+			line: 4,
+			column: 3,
+		},
+	]);
 });
 
 test("malformed source returns empty without throwing", () => {
@@ -110,37 +150,69 @@ test("merges multiple calls with the same category", () => {
 	});
 });
 
-test("deduplicates repeated label values across and within calls", () => {
+test("deduplicates repeated label values — intentional dedup, no diagnostic", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
 		collecting("Cat", v, { a: "A", a2: "A" });
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({ Cat: ["A"] });
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({ Cat: ["A"] });
+	expect(result.diagnostics).toEqual([]);
 });
 
-test("skips calls with fewer than three arguments", () => {
+test("collecting with fewer than three arguments is diagnosed", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
 		collecting("Cat", v);
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({});
+	expect(result.diagnostics).toEqual([
+		{
+			code: "missing-arguments",
+			message: "collecting() requires 3 arguments (category, value, labels)",
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+	]);
 });
 
-test("skips calls whose third arg is a variable reference", () => {
+test("collecting whose third arg is a variable reference is diagnosed", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
 		const labels = { a: "Name" };
 		collecting("Cat", v, labels);
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({});
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-object-label-map",
+			message: "collecting() labels (3rd argument) must be an object literal",
+			file: "a.ts",
+			line: 4,
+			column: 3,
+		},
+	]);
 });
 
-test("skips calls whose third arg is an arrow function", () => {
+test("collecting whose third arg is an arrow function is diagnosed", () => {
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
 		collecting("Cat", v, (v) => ({ Name: v.a }));
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({});
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-object-label-map",
+			message: "collecting() labels (3rd argument) must be an object literal",
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+	]);
 });
 
 test("empty source returns empty", () => {
@@ -149,7 +221,7 @@ test("empty source returns empty", () => {
 	expect(result.thirdParties).toEqual([]);
 });
 
-test("Ignore sentinel omits the field but keeps other string-literal labels", () => {
+test("Ignore sentinel omits the field, keeps other labels, emits no diagnostic", () => {
 	const code = `
 		import { collecting, Ignore } from "@openpolicy/sdk";
 		collecting("Account Information", { name, hashedPassword }, {
@@ -157,12 +229,13 @@ test("Ignore sentinel omits the field but keeps other string-literal labels", ()
 			hashedPassword: Ignore,
 		});
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({
-		"Account Information": ["Name"],
-	});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({ "Account Information": ["Name"] });
+	// Ignore is an explicit, intentional opt-out — not data loss.
+	expect(result.diagnostics).toEqual([]);
 });
 
-test("Ignore recognised under a renamed import", () => {
+test("Ignore recognised under a renamed import emits no diagnostic", () => {
 	const code = `
 		import { collecting, Ignore as Skip } from "@openpolicy/sdk";
 		collecting("Cat", v, {
@@ -170,15 +243,15 @@ test("Ignore recognised under a renamed import", () => {
 			b: Skip,
 		});
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({
-		Cat: ["Name"],
-	});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({ Cat: ["Name"] });
+	expect(result.diagnostics).toEqual([]);
 });
 
-test("Ignore imported from a non-SDK module is not recognised", () => {
-	// The local `Ignore` here is unrelated to the SDK sentinel; its Identifier
-	// value falls through the conservative silent-skip path so the field is
-	// absent from labels (same observable result, but no special treatment).
+test("Ignore imported from a non-SDK module is diagnosed (not the sentinel)", () => {
+	// The local `Ignore` here is unrelated to the SDK sentinel, so its value
+	// is genuinely unreadable — that's ambiguous data loss and must surface a
+	// located diagnostic rather than vanish.
 	const code = `
 		import { collecting } from "@openpolicy/sdk";
 		import { Ignore } from "./somewhere-else";
@@ -187,12 +260,20 @@ test("Ignore imported from a non-SDK module is not recognised", () => {
 			b: Ignore,
 		});
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({
-		Cat: ["Name"],
-	});
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({ Cat: ["Name"] });
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-label-value",
+			message: 'collecting() label "b" value must be a string literal or Ignore',
+			file: "a.ts",
+			line: 4,
+			column: 3,
+		},
+	]);
 });
 
-test("all properties marked Ignore yields an empty label array for the category", () => {
+test("all properties marked Ignore yields an empty label array, no diagnostic", () => {
 	const code = `
 		import { collecting, Ignore } from "@openpolicy/sdk";
 		collecting("Cat", v, {
@@ -200,7 +281,9 @@ test("all properties marked Ignore yields an empty label array for the category"
 			b: Ignore,
 		});
 	`;
-	expect(extractFromFile("a.ts", code).dataCollected).toEqual({ Cat: [] });
+	const result = extractFromFile("a.ts", code);
+	expect(result.dataCollected).toEqual({ Cat: [] });
+	expect(result.diagnostics).toEqual([]);
 });
 
 test("calls nested inside other functions are still extracted", () => {
@@ -260,52 +343,95 @@ test("thirdParty: ignored if imported from non-SDK module", () => {
 	expect(extractFromFile("a.ts", code).thirdParties).toEqual([]);
 });
 
-test("thirdParty: ignored if fewer than 3 args", () => {
+test("thirdParty with fewer than 3 args is diagnosed", () => {
 	const code = `
 		import { thirdParty } from "@openpolicy/sdk";
 		thirdParty("Stripe", "Payments");
 	`;
-	expect(extractFromFile("a.ts", code).thirdParties).toEqual([]);
+	const result = extractFromFile("a.ts", code);
+	expect(result.thirdParties).toEqual([]);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "missing-arguments",
+			message: "thirdParty() requires 3 arguments (name, purpose, policyUrl)",
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+	]);
 });
 
-test("thirdParty: ignored if first arg is non-literal", () => {
+test("thirdParty with a non-literal name is diagnosed", () => {
 	const code = `
 		import { thirdParty } from "@openpolicy/sdk";
 		const name = "Stripe";
 		thirdParty(name, "Payments", "https://stripe.com/privacy");
 	`;
-	expect(extractFromFile("a.ts", code).thirdParties).toEqual([]);
+	const result = extractFromFile("a.ts", code);
+	expect(result.thirdParties).toEqual([]);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-argument",
+			message: "thirdParty() name must be a string literal",
+			file: "a.ts",
+			line: 4,
+			column: 3,
+		},
+	]);
 });
 
-test("thirdParty: ignored if second arg is non-literal", () => {
+test("thirdParty with a non-literal purpose is diagnosed", () => {
 	const code = `
 		import { thirdParty } from "@openpolicy/sdk";
 		thirdParty("Stripe", getPurpose(), "https://stripe.com/privacy");
 	`;
-	expect(extractFromFile("a.ts", code).thirdParties).toEqual([]);
+	const result = extractFromFile("a.ts", code);
+	expect(result.thirdParties).toEqual([]);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-argument",
+			message: "thirdParty() purpose must be a string literal",
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+	]);
 });
 
-test("thirdParty: ignored if third arg is non-literal", () => {
+test("thirdParty with a non-literal policyUrl is diagnosed", () => {
 	const code = `
 		import { thirdParty } from "@openpolicy/sdk";
 		thirdParty("Stripe", "Payments", STRIPE_POLICY_URL);
 	`;
-	expect(extractFromFile("a.ts", code).thirdParties).toEqual([]);
+	const result = extractFromFile("a.ts", code);
+	expect(result.thirdParties).toEqual([]);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-argument",
+			message: "thirdParty() policyUrl must be a string literal",
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+	]);
 });
 
-test("thirdParty: deduplication — same name in same file appears once", () => {
+test("thirdParty: deduplication — same name in same file appears once, no diagnostic", () => {
 	const code = `
 		import { thirdParty } from "@openpolicy/sdk";
 		thirdParty("Stripe", "Payments", "https://stripe.com/privacy");
 		thirdParty("Stripe", "Billing", "https://stripe.com/other");
 	`;
-	expect(extractFromFile("a.ts", code).thirdParties).toEqual([
+	const result = extractFromFile("a.ts", code);
+	expect(result.thirdParties).toEqual([
 		{
 			name: "Stripe",
 			purpose: "Payments",
 			policyUrl: "https://stripe.com/privacy",
 		},
 	]);
+	// Within-file duplicate is intentional dedup, not data loss.
+	expect(result.diagnostics).toEqual([]);
 });
 
 test("thirdParty: multiple distinct entries", () => {
@@ -366,13 +492,15 @@ test("defineCookie: multiple distinct categories collected in insertion order", 
 	expect(extractFromFile("a.ts", code).cookies).toEqual(["analytics", "marketing"]);
 });
 
-test("defineCookie: duplicate categories deduped", () => {
+test("defineCookie: duplicate categories deduped, no diagnostic", () => {
 	const code = `
 		import { defineCookie } from "@openpolicy/sdk";
 		defineCookie("analytics");
 		defineCookie("analytics");
 	`;
-	expect(extractFromFile("a.ts", code).cookies).toEqual(["analytics"]);
+	const result = extractFromFile("a.ts", code);
+	expect(result.cookies).toEqual(["analytics"]);
+	expect(result.diagnostics).toEqual([]);
 });
 
 test("defineCookie: renamed import recognised", () => {
@@ -399,13 +527,23 @@ test("defineCookie: ignored for type-only imports", () => {
 	expect(extractFromFile("a.ts", code).cookies).toEqual([]);
 });
 
-test("defineCookie: non-literal argument skipped silently", () => {
+test("defineCookie with a non-literal argument is diagnosed", () => {
 	const code = `
 		import { defineCookie } from "@openpolicy/sdk";
 		const cat = "analytics";
 		defineCookie(cat);
 	`;
-	expect(extractFromFile("a.ts", code).cookies).toEqual([]);
+	const result = extractFromFile("a.ts", code);
+	expect(result.cookies).toEqual([]);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-argument",
+			message: "defineCookie() category must be a string literal",
+			file: "a.ts",
+			line: 4,
+			column: 3,
+		},
+	]);
 });
 
 test("cookies + collecting + thirdParty coexist in one file", () => {
@@ -420,4 +558,63 @@ test("cookies + collecting + thirdParty coexist in one file", () => {
 	expect(result.dataCollected).toEqual({ "Account Information": ["Name"] });
 	expect(result.thirdParties).toHaveLength(1);
 	expect(result.cookies.sort()).toEqual(["analytics", "marketing"]);
+	expect(result.diagnostics).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// diagnostic location + aggregation
+// ---------------------------------------------------------------------------
+
+test("diagnostic location is the 1-based line:column of the call expression", () => {
+	// Built without a leading newline so the line/column math is unambiguous:
+	// line 1 = import, line 2 = const, line 3 = the call indented 3 spaces.
+	const code =
+		'import { collecting } from "@openpolicy/sdk";\n' +
+		"const x = 1;\n" +
+		'   collecting(cat, v, { a: "Name" });\n';
+	const result = extractFromFile("src/x.ts", code);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-argument",
+			message: "collecting() category must be a string literal",
+			file: "src/x.ts",
+			line: 3,
+			column: 4,
+		},
+	]);
+});
+
+test("canonical valid calls produce zero diagnostics", () => {
+	const code = `
+		import { collecting, thirdParty, defineCookie } from "@openpolicy/sdk";
+		collecting("Account Information", { name }, { name: "Name" });
+		thirdParty("Stripe", "Payments", "https://stripe.com/privacy");
+		defineCookie("analytics");
+	`;
+	expect(extractFromFile("a.ts", code).diagnostics).toEqual([]);
+});
+
+test("multiple skipped calls each produce their own located diagnostic", () => {
+	const code = `
+		import { collecting, defineCookie } from "@openpolicy/sdk";
+		collecting(catA, v, { a: "Name" });
+		defineCookie(catB);
+	`;
+	const result = extractFromFile("a.ts", code);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-argument",
+			message: "collecting() category must be a string literal",
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+		{
+			code: "non-literal-argument",
+			message: "defineCookie() category must be a string literal",
+			file: "a.ts",
+			line: 4,
+			column: 3,
+		},
+	]);
 });

--- a/packages/vite/src/analyse.ts
+++ b/packages/vite/src/analyse.ts
@@ -14,10 +14,38 @@ export type ThirdPartyEntry = {
 	policyUrl: string;
 };
 
+/**
+ * Reason a *recognized* `collecting` / `thirdParty` / `defineCookie` call was
+ * skipped instead of contributing data. These codes surface in build/dev logs
+ * and are public API at 1.0 — keep the union narrow and the meanings stable.
+ */
+export type ScannerSkipCode =
+	| "missing-arguments" //        call has fewer args than the SDK function requires
+	| "non-literal-argument" //     a string-literal-expected arg isn't a string literal
+	| "non-object-label-map" //     collecting() 3rd arg isn't an object literal
+	| "spread-in-label-map" //      spread element inside collecting()'s label object
+	| "non-literal-label-value"; // a label value is neither a string literal nor Ignore
+
+/**
+ * A located build warning emitted for a recognized-but-unreadable call, so
+ * statically invisible privacy data never disappears silently. `line` and
+ * `column` are 1-based and point at the call expression.
+ */
+export type ScannerDiagnostic = {
+	code: ScannerSkipCode;
+	message: string;
+	file: string;
+	line: number;
+	column: number;
+};
+
+type RecordFn = (code: ScannerSkipCode, message: string, node: AnyNode | undefined) => void;
+
 type ExtractResult = {
 	dataCollected: Record<string, string[]>;
 	thirdParties: ThirdPartyEntry[];
 	cookies: string[];
+	diagnostics: ScannerDiagnostic[];
 };
 
 /**
@@ -25,9 +53,11 @@ type ExtractResult = {
  * from a single source file.
  *
  * Returns an `ExtractResult` with `dataCollected` (category → labels),
- * `thirdParties` (array of third-party entries), and `cookies` (array of
- * category names). Files with no matching calls — or that fail to parse —
- * return empty defaults.
+ * `thirdParties` (array of third-party entries), `cookies` (array of
+ * category names), and `diagnostics` — one located warning for every
+ * recognized call that couldn't be read statically (so no recognized call is
+ * ever dropped silently). Files with no matching calls — or that fail to
+ * parse — return empty defaults.
  *
  * The analyser runs in two phases:
  * 1. Collect local names bound to `collecting` / `thirdParty` / `defineCookie`
@@ -41,6 +71,7 @@ export function extractFromFile(filename: string, code: string): ExtractResult {
 		dataCollected: {},
 		thirdParties: [],
 		cookies: [],
+		diagnostics: [],
 	};
 	let result: ReturnType<typeof parseSync>;
 	try {
@@ -72,6 +103,13 @@ export function extractFromFile(filename: string, code: string): ExtractResult {
 	const thirdParties: ThirdPartyEntry[] = [];
 	const seenThirdParties = new Set<string>();
 	const cookieSet = new Set<string>();
+	const diagnostics: ScannerDiagnostic[] = [];
+	const locate = makeLineLocator(code);
+	const record: RecordFn = (skipCode, message, node) => {
+		const offset = node && typeof node.start === "number" ? (node.start as number) : 0;
+		const { line, column } = locate(offset);
+		diagnostics.push({ code: skipCode, message, file: filename, line, column });
+	};
 
 	walk(program, (node) => {
 		if (node.type !== "CallExpression") return;
@@ -82,11 +120,28 @@ export function extractFromFile(filename: string, code: string): ExtractResult {
 		const calleeName = callee.name as string;
 
 		if (collectingNames.has(calleeName)) {
-			if (!args || args.length < 3) return;
+			if (!args || args.length < 3) {
+				record(
+					"missing-arguments",
+					"collecting() requires 3 arguments (category, value, labels)",
+					node,
+				);
+				return;
+			}
 			const category = extractStringLiteral(args[0]);
-			if (category === null) return;
-			const labels = extractLabelKeys(args[2], ignoreNames);
-			if (labels === null) return;
+			if (category === null) {
+				record("non-literal-argument", "collecting() category must be a string literal", node);
+				return;
+			}
+			const labels = extractLabelKeys(args[2], ignoreNames, node, record);
+			if (labels === null) {
+				record(
+					"non-object-label-map",
+					"collecting() labels (3rd argument) must be an object literal",
+					node,
+				);
+				return;
+			}
 			const existing = dataCollected[category] ?? [];
 			const seen = new Set(existing);
 			for (const label of labels) {
@@ -100,13 +155,31 @@ export function extractFromFile(filename: string, code: string): ExtractResult {
 		}
 
 		if (thirdPartyNames.has(calleeName)) {
-			if (!args || args.length < 3) return;
+			if (!args || args.length < 3) {
+				record(
+					"missing-arguments",
+					"thirdParty() requires 3 arguments (name, purpose, policyUrl)",
+					node,
+				);
+				return;
+			}
 			const name = extractStringLiteral(args[0]);
-			if (name === null) return;
+			if (name === null) {
+				record("non-literal-argument", "thirdParty() name must be a string literal", node);
+				return;
+			}
 			const purpose = extractStringLiteral(args[1]);
-			if (purpose === null) return;
+			if (purpose === null) {
+				record("non-literal-argument", "thirdParty() purpose must be a string literal", node);
+				return;
+			}
 			const policyUrl = extractStringLiteral(args[2]);
-			if (policyUrl === null) return;
+			if (policyUrl === null) {
+				record("non-literal-argument", "thirdParty() policyUrl must be a string literal", node);
+				return;
+			}
+			// Within-file duplicate of an already-captured entry — intentional
+			// dedup, the data is not lost, so no diagnostic.
 			if (seenThirdParties.has(name)) return;
 			seenThirdParties.add(name);
 			thirdParties.push({ name, purpose, policyUrl });
@@ -114,14 +187,20 @@ export function extractFromFile(filename: string, code: string): ExtractResult {
 		}
 
 		if (defineCookieNames.has(calleeName)) {
-			if (!args || args.length < 1) return;
+			if (!args || args.length < 1) {
+				record("missing-arguments", "defineCookie() requires 1 argument (category)", node);
+				return;
+			}
 			const category = extractStringLiteral(args[0]);
-			if (category === null) return;
+			if (category === null) {
+				record("non-literal-argument", "defineCookie() category must be a string literal", node);
+				return;
+			}
 			cookieSet.add(category);
 		}
 	});
 
-	return { dataCollected, thirdParties, cookies: [...cookieSet] };
+	return { dataCollected, thirdParties, cookies: [...cookieSet], diagnostics };
 }
 
 /**
@@ -164,7 +243,7 @@ function collectBindings(program: AnyNode, moduleName: string, exportName: strin
 
 /**
  * If `node` is a string `Literal`, return its string value. Otherwise
- * return `null` so the caller silently skips the call.
+ * return `null` so the caller can record a diagnostic and skip the call.
  */
 function extractStringLiteral(node: AnyNode | undefined): string | null {
 	if (!node) return null;
@@ -174,16 +253,35 @@ function extractStringLiteral(node: AnyNode | undefined): string | null {
 }
 
 /**
+ * Best-effort property key name (`{ name: ... }` → `"name"`) for diagnostic
+ * messages. Returns `null` for computed/non-trivial keys.
+ */
+function propKeyName(prop: AnyNode): string | null {
+	const key = prop.key as AnyNode | undefined;
+	if (!key) return null;
+	if (key.type === "Identifier" && typeof key.name === "string") return key.name;
+	if (key.type === "Literal" && typeof key.value === "string") return key.value;
+	return null;
+}
+
+/**
  * Extract the string values from a plain `{ fieldName: "Human Label" }`
  * object literal. Returns an array of label strings, deduped while
- * preserving insertion order. Returns `null` if the shape doesn't match.
+ * preserving insertion order. Returns `null` if the node isn't an object
+ * literal so the caller can report `non-object-label-map`.
  *
- * Properties whose value is an `Identifier` matching a tracked local name
- * bound to the SDK's `Ignore` export are treated as explicit opt-outs and
- * skipped silently — producing the same observable result as omitting the
- * field from the record did before.
+ * Properties whose value is an `Identifier` bound to the SDK's `Ignore`
+ * export are explicit opt-outs and skipped without a diagnostic. Spread
+ * elements and any other non-string-literal value are *recognized but
+ * unreadable*, so each records a located diagnostic (`spread-in-label-map`
+ * / `non-literal-label-value`) against the call before being dropped.
  */
-function extractLabelKeys(node: AnyNode | undefined, ignoreNames: Set<string>): string[] | null {
+function extractLabelKeys(
+	node: AnyNode | undefined,
+	ignoreNames: Set<string>,
+	callNode: AnyNode,
+	record: RecordFn,
+): string[] | null {
 	if (!node || node.type !== "ObjectExpression") return null;
 	const properties = node.properties as AnyNode[] | undefined;
 	if (!properties) return null;
@@ -191,10 +289,19 @@ function extractLabelKeys(node: AnyNode | undefined, ignoreNames: Set<string>): 
 	const labels: string[] = [];
 	const seen = new Set<string>();
 	for (const prop of properties) {
-		if (prop.type !== "Property") continue; // drop SpreadElement silently
+		if (prop.type !== "Property") {
+			// SpreadElement: the labels behind the spread can't be read statically.
+			record(
+				"spread-in-label-map",
+				"collecting() label object uses a spread; spread labels can't be read statically",
+				callNode,
+			);
+			continue;
+		}
 		const val = prop.value as AnyNode | undefined;
 		if (!val) continue;
 		if (val.type === "Literal" && typeof val.value === "string") {
+			// Duplicate label string — already captured, intentional dedup.
 			if (seen.has(val.value)) continue;
 			seen.add(val.value);
 			labels.push(val.value);
@@ -205,9 +312,46 @@ function extractLabelKeys(node: AnyNode | undefined, ignoreNames: Set<string>): 
 			typeof val.name === "string" &&
 			ignoreNames.has(val.name as string)
 		) {
+			// Explicit `Ignore` opt-out — intentional, not data loss.
+			continue;
 		}
+		const field = propKeyName(prop);
+		record(
+			"non-literal-label-value",
+			`collecting() label ${field ? `"${field}" ` : ""}value must be a string literal or Ignore`,
+			callNode,
+		);
 	}
 	return labels;
+}
+
+/**
+ * Build a memoized offset → 1-based `{ line, column }` resolver for `code`.
+ * The newline index is computed once on first use (diagnostics are rare, so
+ * files with no skipped calls never pay for it).
+ */
+function makeLineLocator(code: string): (offset: number) => { line: number; column: number } {
+	let cached: number[] | null = null;
+	const lineStartsFor = (): number[] => {
+		if (cached) return cached;
+		const starts = [0];
+		for (let i = 0; i < code.length; i++) {
+			if (code.charCodeAt(i) === 10 /* \n */) starts.push(i + 1);
+		}
+		cached = starts;
+		return starts;
+	};
+	return (offset) => {
+		const starts = lineStartsFor();
+		let lo = 0;
+		let hi = starts.length - 1;
+		while (lo < hi) {
+			const mid = (lo + hi + 1) >> 1;
+			if ((starts[mid] ?? 0) <= offset) lo = mid;
+			else hi = mid - 1;
+		}
+		return { line: lo + 1, column: offset - (starts[lo] ?? 0) + 1 };
+	};
 }
 
 /**

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,11 +1,16 @@
 import { access, readFile, writeFile } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
-import { extractFromFile, type ThirdPartyEntry } from "./analyse";
+import { extractFromFile, type ScannerDiagnostic, type ThirdPartyEntry } from "./analyse";
 import { KNOWN_COOKIE_PACKAGES, KNOWN_PACKAGES } from "./known-packages";
 import { walkSources } from "./scan";
 import { type CookieMap, renderGenModule, type Scanned } from "./scanned";
-import { formatIssue, loadAndValidateConfig, type ValidatedConfig } from "./validate";
+import {
+	formatIssue,
+	formatScannerDiagnostic,
+	loadAndValidateConfig,
+	type ValidatedConfig,
+} from "./validate";
 
 export type OpenPolicyOptions = {
 	/**
@@ -117,6 +122,7 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 		dataCollected: {},
 		thirdParties: [],
 		cookies: { essential: true },
+		diagnostics: [],
 	};
 
 	async function readPackageJsonDeps(root: string): Promise<Record<string, string>> {
@@ -169,6 +175,7 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 		const mergedParties: ThirdPartyEntry[] = [];
 		const seenParties = new Set<string>();
 		const cookieSet = new Set<string>();
+		const diagnostics: ScannerDiagnostic[] = [];
 		const genFile = resolvedConfigDir ? resolve(resolvedConfigDir, GEN_FILENAME) : null;
 		for (const file of files) {
 			if (file === genFile) continue;
@@ -179,6 +186,7 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 				continue;
 			}
 			const extracted = extractFromFile(file, code);
+			for (const d of extracted.diagnostics) diagnostics.push(d);
 			for (const [category, labels] of Object.entries(extracted.dataCollected)) {
 				const existing = mergedData[category] ?? [];
 				const seen = new Set(existing);
@@ -220,6 +228,7 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			dataCollected: mergedData,
 			thirdParties: mergedParties,
 			cookies,
+			diagnostics,
 		};
 	}
 
@@ -250,6 +259,10 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			scanned = next;
 			await writeGenModule(resolvedConfigDir, scanned);
 		}
+		// Re-emit scanner diagnostics every rescan (like validation below) so
+		// a skipped recognized call stays visible after each edit. Not gated
+		// by `validateOpt` — silent data loss is independent of config checks.
+		for (const d of next.diagnostics) server.config.logger.warn(formatScannerDiagnostic(d));
 		await runValidationDev(server);
 	}
 
@@ -294,6 +307,11 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			resolvedConfigFile = found.file;
 			scanned = await scanAndMerge();
 			await writeGenModule(resolvedConfigDir, scanned);
+			// Always surface scanner diagnostics — a recognized call that
+			// couldn't be read statically is silent data loss regardless of
+			// the `validate` option. `this.warn` routes to the Rollup build
+			// log on `vite build` and to Vite's logger on `vite dev` startup.
+			for (const d of scanned.diagnostics) this.warn(formatScannerDiagnostic(d));
 			// Only validate via Rollup's PluginContext in `vite build` —
 			// `this.error` aborts the build, which is the desired CI signal.
 			// In `vite dev` we let `configureServer` handle validation

--- a/packages/vite/src/scanned.ts
+++ b/packages/vite/src/scanned.ts
@@ -1,4 +1,4 @@
-import type { ThirdPartyEntry } from "./analyse";
+import type { ScannerDiagnostic, ThirdPartyEntry } from "./analyse";
 
 export type CookieMap = { essential: boolean; [key: string]: boolean };
 
@@ -6,6 +6,11 @@ export type Scanned = {
 	dataCollected: Record<string, string[]>;
 	thirdParties: ThirdPartyEntry[];
 	cookies: CookieMap;
+	/**
+	 * Located warnings for recognized calls that couldn't be read statically.
+	 * Carried through the scan but never rendered into the generated module.
+	 */
+	diagnostics: ScannerDiagnostic[];
 };
 
 /**

--- a/packages/vite/src/validate.test.ts
+++ b/packages/vite/src/validate.test.ts
@@ -128,6 +128,7 @@ export default defineConfig({
 		dataCollected: { "Browser Telemetry": ["User-Agent"] },
 		thirdParties: [],
 		cookies: { essential: true },
+		diagnostics: [],
 	});
 	const result = await loadAndValidateConfig({ configFile: file });
 	expect(result.loadError).toBeNull();

--- a/packages/vite/src/validate.ts
+++ b/packages/vite/src/validate.ts
@@ -7,6 +7,7 @@ import {
 	type ValidationIssue,
 } from "@openpolicy/core";
 import { bundleRequire } from "bundle-require";
+import type { ScannerDiagnostic } from "./analyse";
 
 export type ValidatedConfig = {
 	config: OpenPolicyConfig | null;
@@ -100,4 +101,13 @@ export async function loadAndValidateConfig(args: {
  */
 export function formatIssue(issue: ValidationIssue): string {
 	return `[openpolicy] ${issue.code}: ${issue.message}`;
+}
+
+/**
+ * Formats a located scanner diagnostic for terminal output as
+ * `[openpolicy] file:line:col code: message` — same greppable prefix as
+ * {@link formatIssue}, with a clickable `file:line:col` location.
+ */
+export function formatScannerDiagnostic(d: ScannerDiagnostic): string {
+	return `[openpolicy] ${d.file}:${d.line}:${d.column} ${d.code}: ${d.message}`;
 }


### PR DESCRIPTION
…all (PS-7)

The scanner silently dropped recognized collecting()/thirdParty()/ defineCookie() calls it couldn't read statically (dynamic category, non-literal arg, non-object/spread/non-literal label), losing privacy data with zero output. It now records a structured located diagnostic (file:line:col + reason) for each, carried through scanAndMerge and surfaced unconditionally via this.warn on build and the dev logger on each rescan — warnings only, never failing the build. Benign within-file dedups stay silent by design.

Acceptance: no recognized call is ever dropped silently; each emits a located diagnostic. Verified end-to-end on the tanstack example (client, SSR, nitro) and by 95 passing unit tests covering every skip reason, location accuracy, and the dedup/non-recognized exclusions.

## Summary

What does this PR do and why?

## Changes

-
