### PR TITLE
feat(vite): resolve the SDK specifier via the resolver, not string ma…

### DIFF
--- a/packages/vite/src/analyse.test.ts
+++ b/packages/vite/src/analyse.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vite-plus/test";
-import { extractFromFile } from "./analyse";
+import { extractFromFile, extractFromParsed, parseModule } from "./analyse";
+import { isCanonicalSdkSpecifier, type SdkSpecifierMatcher } from "./sdk-specifier";
 
 // ---------------------------------------------------------------------------
 // collecting() tests
@@ -617,4 +618,68 @@ test("multiple skipped calls each produce their own located diagnostic", () => {
 			column: 3,
 		},
 	]);
+});
+
+// ---------------------------------------------------------------------------
+// SDK specifier predicate (PS-8)
+// ---------------------------------------------------------------------------
+
+test("default predicate recognises the @policystack/sdk scope (rename window)", () => {
+	const code = `
+		import { collecting } from "@policystack/sdk";
+		collecting("Account Information", v, { email: "Email address" });
+	`;
+	expect(extractFromFile("a.ts", code).dataCollected).toEqual({
+		"Account Information": ["Email address"],
+	});
+});
+
+test("default predicate recognises a renamed import from @policystack/sdk", () => {
+	const code = `
+		import { collecting as col } from "@policystack/sdk";
+		col("Contact", v, { phone: "Phone number" });
+	`;
+	expect(extractFromFile("a.ts", code).dataCollected).toEqual({
+		Contact: ["Phone number"],
+	});
+});
+
+test("an injected predicate makes an aliased specifier collectable", () => {
+	const code = `
+		import { collecting } from "#sdk";
+		collecting("Account Information", v, { email: "Email address" });
+	`;
+	const aliasMatcher: SdkSpecifierMatcher = (s) => s === "#sdk";
+	expect(extractFromFile("a.ts", code, aliasMatcher).dataCollected).toEqual({
+		"Account Information": ["Email address"],
+	});
+	// The default (canonical) predicate must NOT match the alias.
+	expect(extractFromFile("a.ts", code).dataCollected).toEqual({});
+});
+
+test("parseModule + extractFromParsed equals extractFromFile (single-parse seam)", () => {
+	const code = `
+		import { collecting, thirdParty } from "@openpolicy/sdk";
+		collecting("Account Information", v, { email: "Email" });
+		thirdParty("Stripe", "Payments", "https://stripe.com/privacy");
+	`;
+	const parsed = parseModule("a.ts", code);
+	expect(parsed).not.toBeNull();
+	if (!parsed) return;
+	expect(parsed.importSources).toEqual(["@openpolicy/sdk"]);
+	expect(extractFromParsed(parsed, isCanonicalSdkSpecifier)).toEqual(extractFromFile("a.ts", code));
+});
+
+test("parseModule skips type-only import sources", () => {
+	const code = `
+		import type { PolicyConfig } from "@openpolicy/core";
+		import { collecting } from "@openpolicy/sdk";
+		collecting("C", v, { a: "A" });
+	`;
+	const parsed = parseModule("a.ts", code);
+	expect(parsed?.importSources).toEqual(["@openpolicy/sdk"]);
+});
+
+test("parseModule returns null on a hard parse failure", () => {
+	expect(parseModule("a.ts", "import { from 'broken")).toBeNull();
 });

--- a/packages/vite/src/analyse.ts
+++ b/packages/vite/src/analyse.ts
@@ -1,6 +1,6 @@
 import { parseSync } from "oxc-parser";
+import { isCanonicalSdkSpecifier, type SdkSpecifierMatcher } from "./sdk-specifier";
 
-const SDK_SPECIFIER = "@openpolicy/sdk";
 const COLLECTING_NAME = "collecting";
 const THIRD_PARTY_NAME = "thirdParty";
 const IGNORE_NAME = "Ignore";
@@ -48,6 +48,71 @@ type ExtractResult = {
 	diagnostics: ScannerDiagnostic[];
 };
 
+function emptyResult(): ExtractResult {
+	return { dataCollected: {}, thirdParties: [], cookies: [], diagnostics: [] };
+}
+
+/**
+ * A successfully parsed module plus the metadata the scan pipeline needs
+ * before deciding SDK-ness. `importSources` is the de-duplicated set of
+ * non-type `import … from "<source>"` specifier strings — the Vite plugin
+ * resolves these through the Vite resolver to learn which (possibly aliased)
+ * specifiers point at the SDK before extraction runs.
+ */
+export type ParsedModule = {
+	program: AnyNode;
+	code: string;
+	filename: string;
+	importSources: string[];
+};
+
+/**
+ * Parse a single source file with oxc. Returns `null` on a hard parse
+ * failure (oxc still produces a usable AST for recoverable errors, so those
+ * are kept). Also collects the distinct non-type import source specifiers so
+ * the caller can resolve them once, in batch, before extraction.
+ */
+export function parseModule(filename: string, code: string): ParsedModule | null {
+	let result: ReturnType<typeof parseSync>;
+	try {
+		result = parseSync(filename, code);
+	} catch {
+		console.warn(`[openpolicy] parse error in ${filename}`);
+		return null;
+	}
+
+	if (result.errors.length > 0) {
+		// Hard parse failures only — oxc reports recoverable errors but still
+		// produces a usable AST, so we keep going and let the walker decide.
+		const fatal = result.errors.some((e) => e.severity === ("Error" as never));
+		if (fatal) {
+			console.warn(`[openpolicy] parse error in ${filename}`);
+			return null;
+		}
+	}
+
+	const program = result.program as unknown as AnyNode;
+	return { program, code, filename, importSources: collectImportSources(program) };
+}
+
+/**
+ * Distinct, non-type `import … from "<source>"` specifier strings in program
+ * order. Type-only declarations are skipped — they can't carry runtime SDK
+ * calls, so there's no point resolving them.
+ */
+function collectImportSources(program: AnyNode): string[] {
+	const seen = new Set<string>();
+	const body = program.body as AnyNode[] | undefined;
+	if (!body) return [];
+	for (const node of body) {
+		if (node.type !== "ImportDeclaration") continue;
+		if ((node.importKind as string | undefined) === "type") continue;
+		const source = node.source as AnyNode | undefined;
+		if (source && typeof source.value === "string") seen.add(source.value);
+	}
+	return [...seen];
+}
+
 /**
  * Extract `collecting()`, `thirdParty()`, and `defineCookie()` call metadata
  * from a single source file.
@@ -59,45 +124,46 @@ type ExtractResult = {
  * ever dropped silently). Files with no matching calls — or that fail to
  * parse — return empty defaults.
  *
- * The analyser runs in two phases:
+ * `isSdkSpecifier` decides whether an import source is the SDK. It defaults
+ * to {@link isCanonicalSdkSpecifier} (exact dual-scope match) so direct
+ * `@openpolicy/sdk` / `@policystack/sdk` imports work with no resolver; the
+ * Vite plugin swaps in a resolver-backed predicate so import aliases also
+ * resolve.
+ */
+export function extractFromFile(
+	filename: string,
+	code: string,
+	isSdkSpecifier: SdkSpecifierMatcher = isCanonicalSdkSpecifier,
+): ExtractResult {
+	const parsed = parseModule(filename, code);
+	if (!parsed) return emptyResult();
+	return extractFromParsed(parsed, isSdkSpecifier);
+}
+
+/**
+ * Extract call metadata from an already-parsed module. The scan pipeline
+ * parses every file once ({@link parseModule}), resolves the union of
+ * `importSources`, then calls this with a resolver-backed predicate — so
+ * parsing happens exactly once per file.
+ *
+ * Runs in two phases:
  * 1. Collect local names bound to `collecting` / `thirdParty` / `defineCookie`
- *    imported from `@openpolicy/sdk` (handles renamed imports, skips
- *    type-only imports, ignores look-alikes from other modules).
+ *    imported from an SDK specifier (handles renamed imports, skips type-only
+ *    imports, ignores look-alikes from other modules).
  * 2. Walk the program body and inspect `CallExpression` nodes whose target
  *    is one of those tracked local names.
  */
-export function extractFromFile(filename: string, code: string): ExtractResult {
-	const empty: ExtractResult = {
-		dataCollected: {},
-		thirdParties: [],
-		cookies: [],
-		diagnostics: [],
-	};
-	let result: ReturnType<typeof parseSync>;
-	try {
-		result = parseSync(filename, code);
-	} catch {
-		console.warn(`[openpolicy] parse error in ${filename}`);
-		return empty;
-	}
-
-	if (result.errors.length > 0) {
-		// Hard parse failures only — oxc reports recoverable errors but still
-		// produces a usable AST, so we keep going and let the walker decide.
-		const fatal = result.errors.some((e) => e.severity === ("Error" as never));
-		if (fatal) {
-			console.warn(`[openpolicy] parse error in ${filename}`);
-			return empty;
-		}
-	}
-
-	const program = result.program as unknown as AnyNode;
-	const collectingNames = collectBindings(program, SDK_SPECIFIER, COLLECTING_NAME);
-	const thirdPartyNames = collectBindings(program, SDK_SPECIFIER, THIRD_PARTY_NAME);
-	const ignoreNames = collectBindings(program, SDK_SPECIFIER, IGNORE_NAME);
-	const defineCookieNames = collectBindings(program, SDK_SPECIFIER, DEFINE_COOKIE_NAME);
+export function extractFromParsed(
+	parsed: ParsedModule,
+	isSdkSpecifier: SdkSpecifierMatcher,
+): ExtractResult {
+	const { program, code, filename } = parsed;
+	const collectingNames = collectBindings(program, isSdkSpecifier, COLLECTING_NAME);
+	const thirdPartyNames = collectBindings(program, isSdkSpecifier, THIRD_PARTY_NAME);
+	const ignoreNames = collectBindings(program, isSdkSpecifier, IGNORE_NAME);
+	const defineCookieNames = collectBindings(program, isSdkSpecifier, DEFINE_COOKIE_NAME);
 	if (collectingNames.size === 0 && thirdPartyNames.size === 0 && defineCookieNames.size === 0)
-		return empty;
+		return emptyResult();
 
 	const dataCollected: Record<string, string[]> = {};
 	const thirdParties: ThirdPartyEntry[] = [];
@@ -205,10 +271,15 @@ export function extractFromFile(filename: string, code: string): ExtractResult {
 
 /**
  * Walk `ImportDeclaration` nodes and return the local names bound to the given
- * `exportName` imported from `moduleName`. Skips type-only imports and
- * specifiers whose imported name doesn't match.
+ * `exportName` imported from a module `isSdkSpecifier` accepts. Skips type-only
+ * imports (so type-only imports are never resolved or matched) and specifiers
+ * whose imported name doesn't match.
  */
-function collectBindings(program: AnyNode, moduleName: string, exportName: string): Set<string> {
+function collectBindings(
+	program: AnyNode,
+	isSdkSpecifier: SdkSpecifierMatcher,
+	exportName: string,
+): Set<string> {
 	const names = new Set<string>();
 	const body = program.body as AnyNode[] | undefined;
 	if (!body) return names;
@@ -216,7 +287,7 @@ function collectBindings(program: AnyNode, moduleName: string, exportName: strin
 		if (node.type !== "ImportDeclaration") continue;
 		if ((node.importKind as string | undefined) === "type") continue;
 		const source = node.source as AnyNode | undefined;
-		if (!source || source.value !== moduleName) continue;
+		if (!source || typeof source.value !== "string" || !isSdkSpecifier(source.value)) continue;
 		const specifiers = node.specifiers as AnyNode[] | undefined;
 		if (!specifiers) continue;
 		for (const spec of specifiers) {

--- a/packages/vite/src/index.test.ts
+++ b/packages/vite/src/index.test.ts
@@ -33,9 +33,21 @@ type PluginContextStub = {
 	warnings: string[];
 	error(msg: string): never;
 	warn(msg: string): void;
+	resolve?: (
+		source: string,
+		importer?: string,
+		options?: { skipSelf?: boolean },
+	) => Promise<{ id: string } | null>;
 };
 
-function createPluginContext(): PluginContextStub {
+/**
+ * `resolveMap` maps an import specifier to the id Rollup's resolver would
+ * return. When provided, a fake `this.resolve` is installed so the
+ * resolver-backed SDK matcher can be exercised; omit it (the default) and the
+ * plugin falls back to pure dual-scope matching — the path every pre-existing
+ * test relies on.
+ */
+function createPluginContext(resolveMap?: Record<string, string>): PluginContextStub {
 	const ctx: PluginContextStub = {
 		errors: [],
 		warnings: [],
@@ -47,6 +59,12 @@ function createPluginContext(): PluginContextStub {
 			ctx.warnings.push(msg);
 		},
 	};
+	if (resolveMap) {
+		ctx.resolve = async (source) => {
+			const id = resolveMap[source];
+			return id ? { id } : null;
+		};
+	}
 	return ctx;
 }
 
@@ -871,5 +889,100 @@ test("validate:false still writes the gen module so scanned data still flows thr
 	await runPluginBuildStart(plugin, tmp);
 	expect((await readScanned(tmp)).dataCollected).toEqual({
 		"Account Information": ["Name"],
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Resolver-backed SDK matching (PS-8)
+// ---------------------------------------------------------------------------
+
+test("recognises an aliased SDK import end-to-end via the Vite resolver", async () => {
+	await touch(
+		"src/lib/db.ts",
+		`
+		import { collecting } from "@/sdk";
+		collecting("Account Information", v, { email: "Email address" });
+		`,
+	);
+
+	const plugin = openPolicy();
+	const sdkId = join(tmp, "node_modules/@openpolicy/sdk/dist/index.js");
+	const ctx = createPluginContext({ "@openpolicy/sdk": sdkId, "@/sdk": sdkId });
+	await runPluginBuildStart(plugin, tmp, { ctx });
+
+	expect((await readScanned(tmp)).dataCollected).toEqual({
+		"Account Information": ["Email address"],
+	});
+});
+
+test("an alias resolving elsewhere is NOT treated as the SDK", async () => {
+	await touch(
+		"src/lib/db.ts",
+		`
+		import { collecting } from "@openpolicy/sdk-fake";
+		collecting("Should Not Appear", v, { x: "X" });
+		`,
+	);
+
+	const plugin = openPolicy();
+	const ctx = createPluginContext({
+		"@openpolicy/sdk": join(tmp, "node_modules/@openpolicy/sdk/dist/index.js"),
+		"@openpolicy/sdk-fake": join(tmp, "node_modules/@openpolicy/sdk-fake/index.js"),
+	});
+	await runPluginBuildStart(plugin, tmp, { ctx });
+
+	expect((await readScanned(tmp)).dataCollected).toEqual({});
+});
+
+test("recognises @policystack/sdk with no resolver (rename window, fallback path)", async () => {
+	await touch(
+		"src/lib/db.ts",
+		`
+		import { collecting } from "@policystack/sdk";
+		collecting("Account Information", v, { email: "Email address" });
+		`,
+	);
+
+	const plugin = openPolicy();
+	await runPluginBuildStart(plugin, tmp); // default ctx → no this.resolve
+
+	expect((await readScanned(tmp)).dataCollected).toEqual({
+		"Account Information": ["Email address"],
+	});
+});
+
+test("dev rescan reuses the resolver matcher captured at buildStart", async () => {
+	await touch(
+		"src/lib/db.ts",
+		`
+		import { collecting } from "@/sdk";
+		collecting("Initial", v, { x: "X" });
+		`,
+	);
+
+	const plugin = openPolicy();
+	const sdkId = join(tmp, "node_modules/@openpolicy/sdk/dist/index.js");
+	const ctx = createPluginContext({ "@openpolicy/sdk": sdkId, "@/sdk": sdkId });
+	await runPluginBuildStart(plugin, tmp, { ctx });
+	expect((await readScanned(tmp)).dataCollected).toEqual({ Initial: ["X"] });
+
+	const stub = createStubServer();
+	await runConfigureServer(plugin, stub.server);
+
+	// configureServer has no PluginContext, so the alias is only still
+	// recognised if the buildStart-captured matcher is reused.
+	await touch(
+		"src/lib/db.ts",
+		`
+		import { collecting } from "@/sdk";
+		collecting("Initial", v, { x: "X" });
+		collecting("Added", v, { y: "Y" });
+		`,
+	);
+	await stub.runHandler("change", join(tmp, "src/lib/db.ts"));
+
+	expect((await readScanned(tmp)).dataCollected).toEqual({
+		Initial: ["X"],
+		Added: ["Y"],
 	});
 });

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,10 +1,18 @@
 import { access, readFile, writeFile } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
-import { extractFromFile, type ScannerDiagnostic, type ThirdPartyEntry } from "./analyse";
+import {
+	extractFromParsed,
+	parseModule,
+	type ParsedModule,
+	type ScannerDiagnostic,
+	type ThirdPartyEntry,
+} from "./analyse";
 import { KNOWN_COOKIE_PACKAGES, KNOWN_PACKAGES } from "./known-packages";
 import { walkSources } from "./scan";
 import { type CookieMap, renderGenModule, type Scanned } from "./scanned";
+import { createSdkMatcher, type ResolveId } from "./sdk-resolver";
+import { isCanonicalSdkSpecifier, type SdkSpecifierMatcher } from "./sdk-specifier";
 import {
 	formatIssue,
 	formatScannerDiagnostic,
@@ -118,6 +126,15 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 	let resolvedConfigDir: string;
 	let resolvedConfigFile: string | null = null;
 	let resolvedCommand: "build" | "serve" = "build";
+	// Resolver-backed SDK matcher, built from `this.resolve` in `buildStart`.
+	// Defaults are the pure dual-scope predicate so an out-of-order or
+	// resolver-less call (test stubs, a dev rescan that somehow beats
+	// `buildStart`) still recognises direct `@openpolicy/sdk` /
+	// `@policystack/sdk` imports. Vite runs `buildStart` before the
+	// `configureServer` watcher fires, so dev rescans reuse the captured
+	// resolver matcher — no `PluginContext` is needed in `configureServer`.
+	let sdkMatcher: SdkSpecifierMatcher = isCanonicalSdkSpecifier;
+	let prewarmSdk: (specifiers: Iterable<string>) => Promise<void> = async () => {};
 	let scanned: Scanned = {
 		dataCollected: {},
 		thirdParties: [],
@@ -177,6 +194,11 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 		const cookieSet = new Set<string>();
 		const diagnostics: ScannerDiagnostic[] = [];
 		const genFile = resolvedConfigDir ? resolve(resolvedConfigDir, GEN_FILENAME) : null;
+		// Phase 1: parse every file once and collect the union of import
+		// specifiers, so the resolver runs once per distinct specifier (in
+		// batch) — not once per import per file.
+		const parsedModules: ParsedModule[] = [];
+		const allImportSources = new Set<string>();
 		for (const file of files) {
 			if (file === genFile) continue;
 			let code: string;
@@ -185,7 +207,16 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			} catch {
 				continue;
 			}
-			const extracted = extractFromFile(file, code);
+			const parsed = parseModule(file, code);
+			if (!parsed) continue;
+			parsedModules.push(parsed);
+			for (const s of parsed.importSources) allImportSources.add(s);
+		}
+		// Phase 2: resolve specifiers, then extract from the already-parsed
+		// modules with the resolver-backed predicate (extraction stays sync).
+		await prewarmSdk(allImportSources);
+		for (const parsed of parsedModules) {
+			const extracted = extractFromParsed(parsed, sdkMatcher);
 			for (const d of extracted.diagnostics) diagnostics.push(d);
 			for (const [category, labels] of Object.entries(extracted.dataCollected)) {
 				const existing = mergedData[category] ?? [];
@@ -305,6 +336,27 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			const found = await findConfig(resolvedRoot);
 			resolvedConfigDir = found.dir;
 			resolvedConfigFile = found.file;
+			// Adapt Rollup's `this.resolve` to the matcher's `ResolveId`. The
+			// test stub omits `resolve`, so guard at runtime — a missing
+			// resolver falls back to pure dual-scope matching.
+			const resolveId: ResolveId | null =
+				typeof this.resolve === "function"
+					? async (source, importer) => {
+							const r = await this.resolve(source, importer, {});
+							return r ? { id: r.id } : null;
+						}
+					: null;
+			// Resolve the canonical specifier from inside the user's project
+			// (the config if found, else its package.json) so pnpm's strict
+			// layout picks the same SDK copy the user's source files see.
+			const sdkImporter = resolvedConfigFile ?? resolve(resolvedRoot, "package.json");
+			const matcher = await createSdkMatcher({
+				resolve: resolveId,
+				importer: sdkImporter,
+				warn: (msg) => this.warn(msg),
+			});
+			sdkMatcher = matcher.match;
+			prewarmSdk = matcher.prewarm;
 			scanned = await scanAndMerge();
 			await writeGenModule(resolvedConfigDir, scanned);
 			// Always surface scanner diagnostics — a recognized call that

--- a/packages/vite/src/sdk-resolver.test.ts
+++ b/packages/vite/src/sdk-resolver.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "vite-plus/test";
+import { createSdkMatcher, type ResolveId } from "./sdk-resolver";
+
+const SDK_ID = "/proj/node_modules/@openpolicy/sdk/dist/index.js";
+
+/** Fake `this.resolve`: a specifier → resolved-id map; missing → null. */
+function fakeResolve(map: Record<string, string>): {
+	resolve: ResolveId;
+	calls: Array<{ source: string; importer: string }>;
+} {
+	const calls: Array<{ source: string; importer: string }> = [];
+	const resolve: ResolveId = async (source, importer) => {
+		calls.push({ source, importer });
+		const id = map[source];
+		return id ? { id } : null;
+	};
+	return { resolve, calls };
+}
+
+test("alias resolving to the SDK root id is matched; subpath/non-SDK are not", async () => {
+	const { resolve } = fakeResolve({
+		"@openpolicy/sdk": SDK_ID,
+		"@policystack/sdk": SDK_ID,
+		"@/sdk": SDK_ID,
+		"@openpolicy/sdk/foo": "/proj/node_modules/@openpolicy/sdk/dist/foo.js",
+		"@other": "/proj/node_modules/other/index.js",
+	});
+	const m = await createSdkMatcher({ resolve, importer: "/proj/openpolicy.ts", warn: () => {} });
+
+	// Canonical specifiers match without any prewarm.
+	expect(m.match("@openpolicy/sdk")).toBe(true);
+	expect(m.match("@policystack/sdk")).toBe(true);
+	// Alias only matches once resolution has been pre-warmed.
+	expect(m.match("@/sdk")).toBe(false);
+	await m.prewarm(["@/sdk", "@openpolicy/sdk/foo", "@other", "unknown-pkg"]);
+	expect(m.match("@/sdk")).toBe(true);
+	expect(m.match("@openpolicy/sdk/foo")).toBe(false); // subpath → different id
+	expect(m.match("@other")).toBe(false);
+	expect(m.match("unknown-pkg")).toBe(false); // unresolvable
+});
+
+test("canonical specifier is resolved from the given importer", async () => {
+	const { resolve, calls } = fakeResolve({ "@openpolicy/sdk": SDK_ID });
+	await createSdkMatcher({ resolve, importer: "/proj/openpolicy.ts", warn: () => {} });
+	expect(calls).toContainEqual({ source: "@openpolicy/sdk", importer: "/proj/openpolicy.ts" });
+});
+
+test("query/fragment suffixes and backslashes are normalised before comparison", async () => {
+	const { resolve } = fakeResolve({
+		"@openpolicy/sdk": SDK_ID,
+		"@dev/sdk": `${SDK_ID}?v=abc123`,
+		"@win/sdk": "\\proj\\node_modules\\@openpolicy\\sdk\\dist\\index.js#frag",
+	});
+	const m = await createSdkMatcher({
+		// Canonical id arrives with backslashes too, to prove both sides normalise.
+		resolve: async (source, importer) => {
+			const r = await resolve(source, importer);
+			return r;
+		},
+		importer: "/proj/openpolicy.ts",
+		warn: () => {},
+	});
+	await m.prewarm(["@dev/sdk", "@win/sdk"]);
+	expect(m.match("@dev/sdk")).toBe(true);
+});
+
+test("no resolver → pure dual-scope fallback, warns once", async () => {
+	const warnings: string[] = [];
+	const m = await createSdkMatcher({
+		resolve: null,
+		importer: "/proj/openpolicy.ts",
+		warn: (msg) => warnings.push(msg),
+	});
+	// `resolve: null` is the test-stub path — silent fallback, no warning.
+	expect(warnings).toHaveLength(0);
+	expect(m.match("@openpolicy/sdk")).toBe(true);
+	expect(m.match("@policystack/sdk")).toBe(true);
+	expect(m.match("@/sdk")).toBe(false);
+	await m.prewarm(["@/sdk"]); // no-op fallback
+	expect(m.match("@/sdk")).toBe(false);
+});
+
+test("canonical specifier unresolvable → fallback with a one-time warning", async () => {
+	const warnings: string[] = [];
+	const { resolve } = fakeResolve({ "@other": "/proj/node_modules/other/index.js" });
+	const m = await createSdkMatcher({
+		resolve,
+		importer: "/proj/openpolicy.ts",
+		warn: (msg) => warnings.push(msg),
+	});
+	expect(warnings).toHaveLength(1);
+	expect(warnings[0]).toContain("falling back to literal specifier matching");
+	expect(m.match("@openpolicy/sdk")).toBe(true); // still recognises canonical
+});
+
+test("prewarm resolves each distinct specifier exactly once across calls", async () => {
+	const { resolve, calls } = fakeResolve({ "@openpolicy/sdk": SDK_ID, "@/sdk": SDK_ID });
+	const m = await createSdkMatcher({ resolve, importer: "/proj/openpolicy.ts", warn: () => {} });
+	const before = calls.length;
+	await m.prewarm(["@/sdk", "@/sdk"]);
+	await m.prewarm(["@/sdk"]); // already memoised — no extra resolve
+	expect(calls.length - before).toBe(1);
+	expect(m.match("@/sdk")).toBe(true);
+});

--- a/packages/vite/src/sdk-resolver.ts
+++ b/packages/vite/src/sdk-resolver.ts
@@ -1,0 +1,118 @@
+import {
+	CANONICAL_SDK_SPECIFIERS,
+	isCanonicalSdkSpecifier,
+	type SdkSpecifierMatcher,
+} from "./sdk-specifier";
+
+/**
+ * Minimal slice of Vite/Rollup's `PluginContext.resolve`. The plugin adapts
+ * `this.resolve(source, importer, {})` to this shape; `null` means the
+ * specifier didn't resolve (alias typo, SDK not installed, etc.).
+ */
+export type ResolveId = (source: string, importer: string) => Promise<{ id: string } | null>;
+
+/**
+ * A resolver-backed SDK matcher plus its batch pre-warm step. The plugin
+ * calls {@link SdkMatcher.prewarm} once per scan with the union of every
+ * file's import specifiers, then consults the synchronous {@link
+ * SdkMatcher.match} during extraction (extraction stays sync; resolution,
+ * which is async, has already happened).
+ */
+export type SdkMatcher = {
+	match: SdkSpecifierMatcher;
+	prewarm(specifiers: Iterable<string>): Promise<void>;
+};
+
+/**
+ * Strip a Vite/Rollup resolved id down to a stable comparison key: drop the
+ * `?v=`/`?t=`/`?import` query and `#fragment` suffixes dev adds, and
+ * normalise Windows separators. Both the canonical SDK id and every
+ * candidate id pass through this before comparison.
+ */
+function normaliseId(id: string): string {
+	const noQuery = id.split("?", 1)[0] ?? id;
+	const noHash = noQuery.split("#", 1)[0] ?? noQuery;
+	return noHash.replace(/\\/g, "/");
+}
+
+/**
+ * Build the SDK matcher used by the Vite plugin.
+ *
+ * Resolves the canonical specifiers once (via the user's project, see
+ * `importer`) to learn the SDK's resolved *root* module id. A candidate
+ * specifier is the SDK iff it's a canonical specifier (so the
+ * `@openpolicy/` → `@policystack/` rename and the no-resolver path keep
+ * working) **or** it resolves to exactly that root id (so aliases resolve;
+ * subpaths like `@openpolicy/sdk/foo` resolve to a *different* id and are
+ * correctly rejected — the tracked exports are root-only).
+ *
+ * Falls back to the pure dual-scope predicate when there's no resolver or the
+ * canonical specifier itself can't be resolved (SDK not installed). The
+ * fallback is strictly more conservative than literal matching; because
+ * silently dropping privacy data is never acceptable, `warn` is called once
+ * so an aliased-but-undetectable SDK setup is visible in the build/dev log.
+ */
+export async function createSdkMatcher(args: {
+	resolve: ResolveId | null;
+	importer: string;
+	warn: (msg: string) => void;
+}): Promise<SdkMatcher> {
+	const { resolve, importer, warn } = args;
+
+	const fallback: SdkMatcher = {
+		match: isCanonicalSdkSpecifier,
+		prewarm: async () => {},
+	};
+
+	if (!resolve) return fallback;
+
+	const sdkRootIds = new Set<string>();
+	for (const spec of CANONICAL_SDK_SPECIFIERS) {
+		try {
+			const resolved = await resolve(spec, importer);
+			if (resolved) sdkRootIds.add(normaliseId(resolved.id));
+		} catch {
+			// Treat a throwing resolver like an unresolvable specifier.
+		}
+	}
+
+	if (sdkRootIds.size === 0) {
+		warn(
+			"[openpolicy] could not resolve the SDK via the Vite resolver; " +
+				"falling back to literal specifier matching — aliased SDK imports " +
+				"will not be detected.",
+		);
+		return fallback;
+	}
+
+	// specifier → is-SDK. Persists for the plugin instance, so dev rescans
+	// never re-resolve an already-seen specifier.
+	const memo = new Map<string, boolean>();
+
+	const match: SdkSpecifierMatcher = (specifier) =>
+		isCanonicalSdkSpecifier(specifier) || memo.get(specifier) === true;
+
+	const prewarm = async (specifiers: Iterable<string>): Promise<void> => {
+		const pending: string[] = [];
+		for (const specifier of specifiers) {
+			if (isCanonicalSdkSpecifier(specifier)) continue;
+			if (memo.has(specifier)) continue;
+			memo.set(specifier, false); // claim it so the batch resolves each once
+			pending.push(specifier);
+		}
+		await Promise.all(
+			pending.map(async (specifier) => {
+				try {
+					const resolved = await resolve(specifier, importer);
+					if (resolved && sdkRootIds.has(normaliseId(resolved.id))) {
+						memo.set(specifier, true);
+					}
+				} catch {
+					// Leave the claimed `false` — an unresolvable specifier is not the SDK.
+				}
+			}),
+		);
+	};
+
+	return { match, prewarm };
+}

--- a/packages/vite/src/sdk-specifier.test.ts
+++ b/packages/vite/src/sdk-specifier.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vite-plus/test";
+import { CANONICAL_SDK_SPECIFIERS, isCanonicalSdkSpecifier } from "./sdk-specifier";
+
+test("both canonical scopes are recognised", () => {
+	expect(isCanonicalSdkSpecifier("@openpolicy/sdk")).toBe(true);
+	// PS-34: the rename window needs no scanner change — @policystack/sdk is
+	// already canonical.
+	expect(isCanonicalSdkSpecifier("@policystack/sdk")).toBe(true);
+	expect(CANONICAL_SDK_SPECIFIERS).toEqual(["@openpolicy/sdk", "@policystack/sdk"]);
+});
+
+test("look-alikes and subpaths are rejected", () => {
+	for (const s of [
+		"@openpolicy/sdk-x",
+		"@openpolicy/sdkk",
+		"@openpolicy/sdk/foo",
+		"@policystack/sdk/opencookies",
+		"openpolicy-sdk",
+		"@openpolicy/core",
+		"./sdk",
+		"",
+	]) {
+		expect(isCanonicalSdkSpecifier(s)).toBe(false);
+	}
+});

--- a/packages/vite/src/sdk-specifier.ts
+++ b/packages/vite/src/sdk-specifier.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical, dual-scope root specifiers for the OpenPolicy SDK.
+ *
+ * Recognising *both* scopes is what lets the `@openpolicy/` → `@policystack/`
+ * rename (Phase 6 / PS-34) happen with **no scanner change at rename time** —
+ * source files importing either scope keep being scanned. This array is the
+ * only place PS-34 ever touches, and only to *drop* the old scope once the
+ * rename window closes; the scanner code below never changes.
+ */
+export const CANONICAL_SDK_SPECIFIERS = ["@openpolicy/sdk", "@policystack/sdk"] as const;
+
+/**
+ * Decides whether an import source string is the OpenPolicy SDK. The Vite
+ * plugin swaps in a resolver-backed implementation so import aliases resolve;
+ * the default ({@link isCanonicalSdkSpecifier}) is used everywhere a Vite
+ * resolver isn't available (unit tests, SDK not installed) and as the
+ * always-true base case inside the resolver-backed matcher.
+ */
+export type SdkSpecifierMatcher = (specifier: string) => boolean;
+
+/**
+ * Exact match against either canonical scope's *root* specifier. Subpaths
+ * (`@openpolicy/sdk/foo`) and look-alikes (`@openpolicy/sdk-x`,
+ * `@openpolicy/sdkk`) are intentionally rejected: the tracked exports
+ * (`collecting` / `thirdParty` / `Ignore` / `defineCookie`) are package-root
+ * exports only, so only the bare scope specifier can carry them.
+ */
+export function isCanonicalSdkSpecifier(specifier: string): boolean {
+	return (CANONICAL_SDK_SPECIFIERS as readonly string[]).includes(specifier);
+}


### PR DESCRIPTION
…tch (PS-8)

Recognise the SDK import through the Vite resolver plus a dual-scope canonical fallback instead of an exact `@openpolicy/sdk` string match. Import aliases now resolve, and the `@openpolicy`->`@policystack` scope rename (PS-34) needs no scanner change at rename time.

- sdk-specifier.ts: CANONICAL_SDK_SPECIFIERS (both scopes) + predicate; the single place the scanner encodes scopes.
- sdk-resolver.ts: createSdkMatcher resolves canonical specifiers once from inside the user's project, batch-prewarms a memo, matches an alias iff it resolves to the SDK root id; falls back to pure dual-scope match with a one-time warn when unresolvable.
- analyse.ts: collectBindings takes an SdkSpecifierMatcher; split into parseModule + extractFromParsed (single parse per file). extractFromFile keeps its 2-arg shape (default canonical predicate).
- index.ts: buildStart captures this.resolve; dev rescan reuses it.

Out of scope (left for PS-34): gen-module declare-module augmentation and validate.ts notExternal still hardcode `@openpolicy/`.

## Summary

What does this PR do and why?

## Changes

-
