### PR TITLE
feat(vite): graceful gen-file write failure + freeze merge order (PS-9)

### DIFF
--- a/1.md
+++ b/1.md
@@ -661,6 +661,12 @@ Semver protects this after 1.0; everything else is internal/refactorable.
   (§4.2.1; `aliases` explicitly **excluded** — migration-only, removed
   pre-freeze), `gateScript`.
 - `@policystack/vite` plugin options (merged).
+- **Scanner determinism:** the multi-file merge order is the lexicographic
+  sort of absolute source paths (`walkSources`, §7.6). It fixes the array
+  order of `dataCollected` labels and `thirdParties` in the generated
+  `openpolicy.gen.ts`, and therefore `compilePolicy()`'s `version` hash — so
+  it is part of the frozen surface; changing the collation or dropping the
+  sort is a breaking change.
 - `compilePolicy()` return shape.
 - i18n: the closed built-in `Locale` union + the exhaustive `Dictionary`
   contract + the optional custom-`Dictionary` parameter (§2.6).
@@ -690,8 +696,13 @@ the surface documented as unstable until the tag so refactor freedom is kept.
    OpenPolicy's `known-packages.ts` into one canonical vendor registry feeding
    the single oxc walk; keep `usePackageJson` (opt-in) as a detector against
    it; add the declared-vs-used cross-check.
-5. Graceful gen-file write failure (warn + retain last good).
-6. Keep the documented alphabetical merge order; add it to frozen behavior.
+5. Graceful gen-file write failure (warn + retain last good) — **done
+   (PS-9):** atomic temp-write + `rename` so a partial/blocked write never
+   truncates the committed file; callers warn-and-continue (build) /
+   skip-and-retry (dev).
+6. The documented lexicographic merge order is **frozen behaviour (PS-9):**
+   stated in §6 ("Scanner determinism"), pinned by the `walkSources` contract
+   comment + a `scan.test.ts` regression test.
 
 ---
 

--- a/packages/vite/src/index.test.ts
+++ b/packages/vite/src/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, test } from "vite-plus/test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ThirdPartyEntry } from "./analyse";
@@ -14,6 +14,9 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+	// A test may have made tmp read-only to force a gen-file write failure;
+	// restore write perms so the recursive cleanup can remove its contents.
+	await chmod(tmp, 0o755).catch(() => {});
 	await rm(tmp, { recursive: true, force: true });
 });
 
@@ -205,6 +208,77 @@ test("buildStart writes scanned categories to the gen module", async () => {
 	expect((await readScanned(tmp)).dataCollected).toEqual({
 		"Account Information": ["Name", "Email address"],
 	});
+});
+
+test("buildStart degrades gracefully when the gen module can't be written", async () => {
+	await touch(
+		"src/lib/db.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("Account Information", v, { name: "Name" });
+		`,
+	);
+	// Seed a known-good gen module, then make its directory read-only so the
+	// atomic temp-write/rename fails. The build must not crash and the
+	// last-good file must survive untouched.
+	const lastGood = "// SEEDED LAST-GOOD — must survive a failed write\n";
+	await writeFile(join(tmp, "openpolicy.gen.ts"), lastGood, "utf8");
+	await chmod(tmp, 0o555);
+
+	const plugin = openPolicy();
+	let ctx: Awaited<ReturnType<typeof runPluginBuildStart>>;
+	try {
+		ctx = await runPluginBuildStart(plugin, tmp);
+	} finally {
+		await chmod(tmp, 0o755);
+	}
+
+	expect(ctx.errors).toEqual([]);
+	expect(ctx.warnings.some((w) => w.includes("could not write openpolicy.gen.ts"))).toBe(true);
+	expect(await readFile(join(tmp, "openpolicy.gen.ts"), "utf8")).toBe(lastGood);
+});
+
+test("dev rescan retries the write after a failure (in-memory state not advanced)", async () => {
+	await touch(
+		"src/a.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("A", v, { x: "X" });
+		`,
+	);
+
+	const plugin = openPolicy();
+	await runPluginBuildStart(plugin, tmp);
+	const before = await readFile(join(tmp, "openpolicy.gen.ts"), "utf8");
+
+	const stub = createStubServer();
+	await runConfigureServer(plugin, stub.server);
+
+	// Change the scan output, then block the write — the gen file stays at
+	// last-good and a warning is logged through the dev-server logger.
+	await touch(
+		"src/a.ts",
+		`
+		import { collecting } from "@openpolicy/sdk";
+		collecting("B", v, { y: "Y" });
+		`,
+	);
+	await chmod(tmp, 0o555);
+	try {
+		await stub.runHandler("change", join(tmp, "src/a.ts"));
+	} finally {
+		await chmod(tmp, 0o755);
+	}
+	expect(stub.loggedWarnings.some((w) => w.includes("could not write openpolicy.gen.ts"))).toBe(
+		true,
+	);
+	expect(await readFile(join(tmp, "openpolicy.gen.ts"), "utf8")).toBe(before);
+
+	// Because the failed write did NOT advance the in-memory `scanned`, the
+	// next event still sees a change and retries — the write now lands.
+	await stub.runHandler("change", join(tmp, "src/a.ts"));
+	const after = await readScanned(tmp);
+	expect(after.dataCollected).toEqual({ B: ["Y"] });
 });
 
 test("merges calls across multiple files", async () => {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,4 +1,4 @@
-import { access, readFile, writeFile } from "node:fs/promises";
+import { access, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
 import {
@@ -96,9 +96,29 @@ async function findConfig(root: string): Promise<{ dir: string; file: string | n
  * and `provision`) and `cookies.context` entries. Commit the file — that
  * keeps both the values and the type-level constraints live in CI without
  * needing to run the Vite plugin first.
+ *
+ * The write is atomic: content goes to a unique temp sibling and is then
+ * `rename`d over the target. A crashed or partial write (ENOSPC, an EACCES
+ * mid-write, …) leaves the previously committed `openpolicy.gen.ts` intact —
+ * the last-good output is retained rather than truncated. Throws on failure;
+ * callers decide whether to warn-and-continue (build) or skip-and-retry (dev).
  */
 async function writeGenModule(targetDir: string, scanned: Scanned): Promise<void> {
-	await writeFile(resolve(targetDir, GEN_FILENAME), renderGenModule(scanned), "utf8");
+	const target = resolve(targetDir, GEN_FILENAME);
+	// Same-directory temp so `rename` stays on one filesystem (atomic on
+	// POSIX, replace-on-Windows). The `.tmp` extension keeps it out of
+	// `walkSources` / `isTrackedSource`, which both gate on `.ts`/`.tsx`.
+	const tmp = resolve(
+		targetDir,
+		`${GEN_FILENAME}.${process.pid}-${Math.random().toString(36).slice(2)}.tmp`,
+	);
+	try {
+		await writeFile(tmp, renderGenModule(scanned), "utf8");
+		await rename(tmp, target);
+	} catch (err) {
+		await rm(tmp, { force: true });
+		throw err;
+	}
 }
 
 /**
@@ -287,8 +307,18 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 		const next = await scanAndMerge();
 		const changed = JSON.stringify(next) !== JSON.stringify(scanned);
 		if (changed) {
-			scanned = next;
-			await writeGenModule(resolvedConfigDir, scanned);
+			// Commit the new in-memory state only once the write succeeds. On
+			// failure `scanned` stays put so the `changed` check re-fires on
+			// the next file event and retries — no permanent disk/memory drift,
+			// and the prior `openpolicy.gen.ts` remains as last-good.
+			try {
+				await writeGenModule(resolvedConfigDir, next);
+				scanned = next;
+			} catch (err) {
+				server.config.logger.warn(
+					`[openpolicy] could not write ${GEN_FILENAME}: ${err}; keeping the previously generated module`,
+				);
+			}
 		}
 		// Re-emit scanner diagnostics every rescan (like validation below) so
 		// a skipped recognized call stays visible after each edit. Not gated
@@ -358,7 +388,16 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			sdkMatcher = matcher.match;
 			prewarmSdk = matcher.prewarm;
 			scanned = await scanAndMerge();
-			await writeGenModule(resolvedConfigDir, scanned);
+			// A failed write must not abort the build. The in-memory `scanned`
+			// stays fresh, so the validation block below is unaffected — only
+			// the committed artifact is stale (last-good is retained on disk).
+			try {
+				await writeGenModule(resolvedConfigDir, scanned);
+			} catch (err) {
+				this.warn(
+					`[openpolicy] could not write ${GEN_FILENAME}: ${err}; keeping the previously generated module`,
+				);
+			}
 			// Always surface scanner diagnostics — a recognized call that
 			// couldn't be read statically is silent data loss regardless of
 			// the `validate` option. `this.warn` routes to the Rollup build

--- a/packages/vite/src/scan.test.ts
+++ b/packages/vite/src/scan.test.ts
@@ -76,3 +76,27 @@ test("returns absolute paths", async () => {
 	expect(files).toHaveLength(1);
 	expect(files[0]?.startsWith("/")).toBe(true);
 });
+
+// FROZEN 1.0 CONTRACT (1.md §6 / §7.6). The multi-file merge order is the
+// lexicographic sort of absolute source paths; it determines `dataCollected`
+// / `thirdParties` array order in `openpolicy.gen.ts` and therefore the
+// policy `version` hash. This test pins that order so a future refactor that
+// reorders the walk fails loudly. Do not relax it without a deliberate
+// breaking-change decision.
+test("merge order is the frozen lexicographic sort regardless of creation order", async () => {
+	// Created in deliberately scrambled order.
+	await touch("m/charlie.ts", "");
+	await touch("a/zulu.ts", "");
+	await touch("a/alpha.ts", "");
+	await touch("z/bravo.ts", "");
+	await touch("m/alpha.ts", "");
+
+	const files = await walkSources(tmp, [".ts"]);
+	expect(files.map((f) => relative(tmp, f))).toEqual([
+		"a/alpha.ts",
+		"a/zulu.ts",
+		"m/alpha.ts",
+		"m/charlie.ts",
+		"z/bravo.ts",
+	]);
+});

--- a/packages/vite/src/scan.ts
+++ b/packages/vite/src/scan.ts
@@ -51,6 +51,14 @@ export async function walkSources(
 	}
 
 	await walk(root);
+	// FROZEN 1.0 CONTRACT (1.md §6 / §7.6): the multi-file merge order is the
+	// default lexicographic sort of absolute source paths. `scanAndMerge`
+	// folds per-file results in this order, so it fixes the array order of
+	// `dataCollected` labels and `thirdParties` in `openpolicy.gen.ts`, which
+	// in turn feeds `compilePolicy()`'s deterministic `version` hash
+	// (`@openpolicy/core` policy-version.ts sorts object keys but preserves
+	// array order). Removing this sort or changing the collation is a
+	// breaking change — keep it.
 	results.sort();
 	return results;
 }


### PR DESCRIPTION
## Summary

Implements [PS-9](https://linear.app/open-policy/issue/PS-9) — robustness + a frozen-behaviour commitment from the `1.md` spec (§7.5 / §7.6). A gen-file write failure now degrades gracefully instead of crashing the build, and the alphabetical multi-file merge order is documented as frozen 1.0 behaviour because it feeds the deterministic policy `version` hash.

Targets `v1` (the PS-* scanner-hardening work lives there; this also edits the `1.md` frozen-contract spec).

## Changes

- **§7.5 — graceful gen-file write failure:**
  - `writeGenModule()` now writes atomically: render → unique `.tmp` sibling → `rename()` over the target. A blocked/partial write (EACCES, ENOSPC) leaves the previously committed `openpolicy.gen.ts` byte-intact — last-good is retained, not truncated. The `.tmp` extension keeps it out of `walkSources`/`isTrackedSource`.
  - `buildStart` wraps the write in try/catch and `this.warn`s instead of aborting the build. In-memory `scanned` stays fresh, so the validation block is unaffected.
  - `rescanAndRefresh` commits new in-memory state only *after* a successful write; on failure it warns via the dev logger and leaves `scanned` unchanged so the next file event retries (no permanent disk/memory drift).
  - Two new tests in `index.test.ts`: build degrades gracefully with last-good retained; dev rescan retries after a blocked write.
- **§7.6 — freeze alphabetical merge order:**
  - Frozen-contract comment at the `walkSources` sort explaining it fixes `dataCollected`/`thirdParties` array order and therefore `compilePolicy()`'s `version` hash.
  - Explicit `scan.test.ts` regression test pinning the exact lexicographic order against scrambled creation order.
  - `1.md` §6 gains a "Scanner determinism" frozen-surface bullet; §7.5/§7.6 marked done.

## Reviewer notes

- Verified: `vp test` (vite) **111 passing** incl. all 3 new tests; `vp check` + `tsc --noEmit` clean.
- The 5 failing tests in `validate.test.ts` are **pre-existing and unrelated** (effective-date issue dedup in core) — reproduced on the clean baseline with these changes stashed; consistent with the v1 policy that failing tests are acceptable.
- No new dependencies; reuses Node `fs/promises` and existing loggers/test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)