### PR TITLE
feat(core)!: lock the Document AST shape before the 1.0 freeze (PS-10)

### DIFF
--- a/docs/adr/0001-document-ast-shape-freeze.md
+++ b/docs/adr/0001-document-ast-shape-freeze.md
@@ -1,0 +1,144 @@
+# ADR 0001 — Document AST shape, frozen for 1.0
+
+- **Status:** Accepted
+- **Date:** 2026-05-16
+- **Ticket:** PS-10 (blocks PS-12, PS-15, PS-16)
+- **Decision drivers:** v1 architecture plan §2.3, §4.2, §6; Decisions 8 & 12
+
+## Context
+
+PolicyStack compiles a privacy/cookie config into a hand-rolled document AST
+(`Node`) that framework integrations walk and render. `Node` and the shared
+`visit()` contract are on the **1.0 frozen surface** (§6): after the 1.0 tag,
+any change to the union is a major version bump.
+
+Keeping the hand-rolled AST (rather than adopting mdast/unified) is already
+decided (Decision 8) — we _emit_ a closed legal document, we don't _parse_
+arbitrary Markdown. What was **not** decided is the AST's exact shape. This ADR
+is the one-shot pre-freeze review. It records six decisions and the breaking
+node changes landed alongside it (`packages/core/src/documents/types.ts`).
+
+## Decisions
+
+### 1. Discriminant hygiene — _verified, no change_
+
+Every variant already carries one consistently-named `type` string tag; there
+are no structural-only variants. This is what makes the single `visit()` +
+per-renderer visitor maps total and exhaustively type-checkable. Confirmed; no
+change.
+
+`bold` and `italic` are intentionally kept as separate variants even though
+their shapes are identical. Collapsing them into one node with an internal
+style field would reintroduce structural branching in every renderer — exactly
+the anti-pattern the hygiene rule exists to prevent. The near-duplication is
+the lesser cost.
+
+### 2. Taxonomy — _table header split (breaking)_
+
+Rule: _a branch in a visitor map = a missing node type._ Every renderer
+(html/markdown/pdf + react/vue/svelte) had to thread a `kind`/`Comp` parameter
+to render a `tableCell` as `<th>` vs `<td>` depending on whether it sat in the
+header or the body. That internal branch is a missing node type.
+
+Resolved by splitting the header into distinct discriminated variants:
+
+- `TableHeaderCellNode` (`type: "tableHeaderCell"`)
+- `TableHeaderRowNode` (`type: "tableHeaderRow"`)
+- `TableNode.header` is now `TableHeaderRowNode` (was `TableRowNode`);
+  `TableNode.rows` stays `TableRowNode[]`.
+
+Header and body are now distinct typed paths in every renderer; the threaded
+parameter is deleted. The framework slot maps gained a `TableHeaderRow` slot
+and `TableHead` was retyped to `TableHeaderCellNode` (coordinated with PS-15's
+`PolicyComponents` canonicalization — these slot names are intended to be the
+canonical ones).
+
+No node leans HTML: names stay legal/semantic and renderer-agnostic (the AST
+also targets PDF and native component trees). `LinkNode.href` is semantic, not
+an HTML attribute. Confirmed; no change there.
+
+### 3. `context.reason` — _typed compliance trace (breaking)_
+
+`NodeContext.reason` was a free string (`"Required by GDPR Article 13(1)(c)"`).
+The hosted diff/audit layer keys off it, so it must be stable and
+machine-readable, not a free-string side-channel. It is now:
+
+```ts
+type ComplianceReason = {
+	code: IssueCode; // stable, machine-keyable
+	jurisdiction?: JurisdictionId | readonly JurisdictionId[];
+	lawfulBasis?: LegalBasis;
+	citation?: string; // verbatim article text — display only
+};
+```
+
+`citation` is retained deliberately: the literal article string carries
+specificity `code` alone does not, and the audit layer still wants a
+human-readable display string. It is display-only; machine consumers key off
+`code`/`jurisdiction`/`lawfulBasis`.
+
+`JurisdictionId` is landed now as the **frozen 11-member union** (§4.2.1:
+`eea uk ch br ca us us-ca us-co us-ct us-va row`). It is intentionally distinct
+from the existing config `Jurisdiction` type (`eu`/`uk`/…); the two coexist
+until the §4.2.1 capability-table ticket migrates config onto it. Freezing
+`reason` against the _final_ id type now is the whole point — a later rename
+would be a breaking change to a frozen field.
+
+`IssueCode` is a `string` placeholder, narrowed to the validator union by the
+§2.1 validator-consolidation ticket. Narrowing a `string` alias to a union is
+non-breaking for _producers_ of the AST; it is a tolerated pre-1.0 caveat
+(documented here so it is a conscious choice, not an accident).
+
+### 4. Serialization & forward-compat — _`astVersion` + `UnknownNode` (breaking)_
+
+The AST was already JSON-round-trippable (plain objects, no cycles). Added:
+
+- `Document.astVersion: number` (currently `AST_VERSION = 1`). Bumped on any
+  additive union change so the hosted diff/`version` hash can gate on it.
+- `UnknownNode` (`type: "unknown"`, optional `raw`), admitted into
+  `ContentNode` (block granularity — post-1.0 growth is block-level; the inline
+  union stays closed). A reader on an older `astVersion` that meets an
+  unrecognized node `type` represents it as `UnknownNode`; every renderer
+  renders it as a visible no-op.
+
+This is the forward-compat seam: the frozen `Node` union can gain block-level
+variants in a **minor** release without a major bump. Semver locks this at 1.0,
+so it is designed in now, not retrofitted.
+
+### 5. Consent-derived output — _composed from existing nodes, not new types_
+
+The merge means some rendered text is consent-derived — the §4.2 posture
+statement (`"EEA visitors: we ask consent before…"`). Decided **now**: this is
+a normal `ParagraphNode` whose `context.reason` carries the typed posture
+(`code` + `jurisdiction` + `lawfulBasis`), **not** a new node type. With the
+typed `reason` (Decision 3) the posture is fully expressible without new
+variants, so there is nothing to retrofit post-1.0 — which is the expensive
+case this decision exists to avoid.
+
+### 6. Two document roots — _affirmed, no change (Decision 12)_
+
+Privacy and cookie remain two separate documents, discriminated by
+`Document.policyType` (`"privacy" | "cookie"`). They are never merged into one
+tree; the merge unifies the config/consent story, not the documents. The
+`visit()` contract and renderers treat the two roots as distinct, never as a
+merge target. Confirmed; no code change.
+
+## The frozen `visit()` contract
+
+`visit()` + `Visitor<R>` are landed as the frozen seam
+(`packages/core/src/documents/visit.ts`): a **total** visitor map keyed by the
+`Node` discriminant, with the `unknown` arm mandatory by construction. PS-10
+ships the contract + one reference implementation only; collapsing the six
+duplicated walkers onto it is **PS-12**.
+
+## Consequences
+
+- **Breaking (pre-1.0, expected):** table header nodes split; `reason` is now
+  an object; `Document` gains `astVersion`; `Node` gains `unknown`. All
+  renderers and hand-constructed test fixtures updated in this change.
+- `IssueCode` will be narrowed by the §2.1 ticket — a non-breaking follow-up.
+- Config `Jurisdiction` → `JurisdictionId` reconciliation is owned by the
+  §4.2.1 ticket; the two coexist until then by design.
+- Slot names (`TableHeaderRow`, retyped `TableHead`) are inputs to PS-15's
+  `PolicyComponents` canonicalization.
+- Acceptance: this ADR merged + `Node` at frozen shape — **met**.

--- a/packages/core/src/documents/cookie.ts
+++ b/packages/core/src/documents/cookie.ts
@@ -2,7 +2,7 @@ import type { T } from "../i18n";
 import { formatDate } from "../i18n";
 import type { CookiePolicyConfig } from "../types";
 import { bold, cell, heading, li, link, p, row, section, table, ul } from "./helpers";
-import type { DocumentSection, TableRowNode } from "./types";
+import type { ComplianceReason, DocumentSection, TableRowNode } from "./types";
 
 function versionSuffix(config: CookiePolicyConfig, t: T): string {
 	return config.version ? t.shared.versionSuffix({ version: config.version }) : "";
@@ -119,9 +119,17 @@ function buildJurisdictionEuUk(config: CookiePolicyConfig, t: T): DocumentSectio
 	const hasUk = config.jurisdictions.includes("uk");
 	if (!hasEu && !hasUk) return null;
 	const branch: "euAndUk" | "eu" | "uk" = hasEu && hasUk ? "euAndUk" : hasEu ? "eu" : "uk";
-	const reason = hasUk
-		? "Required under the UK-GDPR and PECR"
-		: "Required under ePrivacy Directive and GDPR";
+	const reason: ComplianceReason = hasUk
+		? {
+				code: "cookie-jurisdiction-eu-uk",
+				jurisdiction: "uk",
+				citation: "Required under the UK-GDPR and PECR",
+			}
+		: {
+				code: "cookie-jurisdiction-eu-uk",
+				jurisdiction: "eea",
+				citation: "Required under ePrivacy Directive and GDPR",
+			};
 	return section("cookie-jurisdiction-eu-uk", [
 		heading(t.cookie.jurisdictionEuUk.heading[branch](), { reason }),
 		p([t.cookie.jurisdictionEuUk.body({ region: t.cookie.jurisdictionEuUk.region[branch]() })]),

--- a/packages/core/src/documents/helpers.ts
+++ b/packages/core/src/documents/helpers.ts
@@ -11,6 +11,8 @@ import type {
 	NodeContext,
 	ParagraphNode,
 	TableCellNode,
+	TableHeaderCellNode,
+	TableHeaderRowNode,
 	TableNode,
 	TableRowNode,
 	TextNode,
@@ -85,13 +87,29 @@ export const row = (cells: TableCellNode[], context?: NodeContext): TableRowNode
 	cells,
 	...(context && { context }),
 });
+export const headerCell = (
+	children: (string | InlineNode)[],
+	context?: NodeContext,
+): TableHeaderCellNode => ({
+	type: "tableHeaderCell",
+	children: children.map((c) => (typeof c === "string" ? text(c) : c)),
+	...(context && { context }),
+});
+export const headerRow = (
+	cells: TableHeaderCellNode[],
+	context?: NodeContext,
+): TableHeaderRowNode => ({
+	type: "tableHeaderRow",
+	cells,
+	...(context && { context }),
+});
 export const table = (
 	headerLabels: (string | InlineNode)[],
 	rows: TableRowNode[],
 	context?: NodeContext,
 ): TableNode => ({
 	type: "table",
-	header: row(headerLabels.map((l) => cell([l]))),
+	header: headerRow(headerLabels.map((l) => headerCell([l]))),
 	rows,
 	...(context && { context }),
 });

--- a/packages/core/src/documents/index.ts
+++ b/packages/core/src/documents/index.ts
@@ -2,7 +2,7 @@ import { createT } from "../i18n";
 import type { PolicyInput } from "../types";
 import { compileCookieDocument } from "./cookie";
 import { compilePrivacyDocument } from "./privacy";
-import type { Document } from "./types";
+import { AST_VERSION, type Document } from "./types";
 
 export function compile(input: PolicyInput): Document {
 	const t = createT(input.locale);
@@ -10,6 +10,7 @@ export function compile(input: PolicyInput): Document {
 		const { type: _, ...config } = input;
 		return {
 			type: "document",
+			astVersion: AST_VERSION,
 			policyType: "privacy",
 			sections: compilePrivacyDocument(config, t),
 		};
@@ -17,6 +18,7 @@ export function compile(input: PolicyInput): Document {
 	const { type: _, ...config } = input;
 	return {
 		type: "document",
+		astVersion: AST_VERSION,
 		policyType: "cookie",
 		sections: compileCookieDocument(config, t),
 	};
@@ -25,6 +27,8 @@ export function compile(input: PolicyInput): Document {
 export {
 	bold,
 	cell,
+	headerCell,
+	headerRow,
 	heading,
 	italic,
 	li,
@@ -37,13 +41,16 @@ export {
 	text,
 	ul,
 } from "./helpers";
+export { AST_VERSION } from "./types";
 export type {
 	BoldNode,
+	ComplianceReason,
 	ContentNode,
 	Document,
 	DocumentSection,
 	HeadingNode,
 	InlineNode,
+	IssueCode,
 	ItalicNode,
 	LinkNode,
 	ListItemNode,
@@ -53,7 +60,12 @@ export type {
 	ParagraphNode,
 	PolicyType,
 	TableCellNode,
+	TableHeaderCellNode,
+	TableHeaderRowNode,
 	TableNode,
 	TableRowNode,
 	TextNode,
+	UnknownNode,
 } from "./types";
+export { visit } from "./visit";
+export type { Visitor } from "./visit";

--- a/packages/core/src/documents/privacy.ts
+++ b/packages/core/src/documents/privacy.ts
@@ -2,7 +2,14 @@ import type { T } from "../i18n";
 import { formatDate } from "../i18n";
 import type { PrivacyPolicyConfig } from "../types";
 import { bold, cell, heading, li, link, p, row, section, table, ul } from "./helpers";
-import type { ContentNode, DocumentSection, InlineNode, ListItemNode, TableRowNode } from "./types";
+import type {
+	ComplianceReason,
+	ContentNode,
+	DocumentSection,
+	InlineNode,
+	ListItemNode,
+	TableRowNode,
+} from "./types";
 
 function versionSuffix(config: PrivacyPolicyConfig, t: T): string {
 	return config.version ? t.shared.versionSuffix({ version: config.version }) : "";
@@ -26,7 +33,13 @@ function buildChildrenPrivacy(config: PrivacyPolicyConfig, t: T): DocumentSectio
 	if (!config.children) return null;
 	const { underAge, noticeUrl } = config.children;
 	return section("children-privacy", [
-		heading(t.privacy.childrenPrivacy.heading(), { reason: "Required by COPPA" }),
+		heading(t.privacy.childrenPrivacy.heading(), {
+			reason: {
+				code: "children-privacy",
+				jurisdiction: "us",
+				citation: "Required by COPPA",
+			},
+		}),
 		p([t.privacy.childrenPrivacy.body({ underAge })]),
 		...(noticeUrl
 			? [
@@ -65,9 +78,17 @@ function buildDataCollected(config: PrivacyPolicyConfig, t: T): DocumentSection 
 	const intro = includeLegalBasis
 		? t.privacy.dataCollected.intro.withGdpr()
 		: t.privacy.dataCollected.intro.withoutGdpr();
-	const reason = includeLegalBasis
-		? "Required by GDPR Article 13(1)(c) and Article 6"
-		: "Required by GDPR Article 13(1)(c)";
+	const reason: ComplianceReason = includeLegalBasis
+		? {
+				code: "data-collected",
+				jurisdiction: ["eea", "uk"],
+				citation: "Required by GDPR Article 13(1)(c) and Article 6",
+			}
+		: {
+				code: "data-collected",
+				jurisdiction: "eea",
+				citation: "Required by GDPR Article 13(1)(c)",
+			};
 	return section("data-collected", [
 		heading(t.privacy.dataCollected.heading(), { reason }),
 		p([intro]),
@@ -86,7 +107,12 @@ function buildConsentWithdrawal(config: PrivacyPolicyConfig, t: T): DocumentSect
 	if (!usesConsent(config)) return null;
 	return section("consent-withdrawal", [
 		heading(t.privacy.consentWithdrawal.heading(), {
-			reason: "Required by GDPR Article 7(3) and Article 13(2)(c)",
+			reason: {
+				code: "consent-withdrawal",
+				jurisdiction: ["eea", "uk"],
+				lawfulBasis: "consent",
+				citation: "Required by GDPR Article 7(3) and Article 13(2)(c)",
+			},
 		}),
 		p([t.privacy.consentWithdrawal.body({ contactEmail: config.company.contact.email })]),
 	]);
@@ -99,7 +125,11 @@ function buildAutomatedDecisionMaking(config: PrivacyPolicyConfig, t: T): Docume
 
 	const content: ContentNode[] = [
 		heading(t.privacy.automatedDecisionMaking.heading(), {
-			reason: "Required by GDPR and UK-GDPR Article 13(2)(f) and Article 22",
+			reason: {
+				code: "automated-decision-making",
+				jurisdiction: ["eea", "uk"],
+				citation: "Required by GDPR and UK-GDPR Article 13(2)(f) and Article 22",
+			},
 		}),
 	];
 
@@ -155,7 +185,11 @@ function buildProvisionRequirement(config: PrivacyPolicyConfig, t: T): DocumentS
 	});
 	return section("provision-requirement", [
 		heading(t.privacy.provisionRequirement.heading(), {
-			reason: "Required by GDPR and UK-GDPR Article 13(2)(e)",
+			reason: {
+				code: "provision-requirement",
+				jurisdiction: ["eea", "uk"],
+				citation: "Required by GDPR and UK-GDPR Article 13(2)(e)",
+			},
 		}),
 		p([t.privacy.provisionRequirement.body()]),
 		table(t.privacy.provisionRequirement.headers(), rows),
@@ -254,7 +288,11 @@ function buildGdprSupplement(config: PrivacyPolicyConfig, t: T): DocumentSection
 	if (!config.jurisdictions.includes("eu")) return null;
 	const content: ContentNode[] = [
 		heading(t.privacy.gdprSupplement.heading(), {
-			reason: "Required by GDPR Article 13",
+			reason: {
+				code: "gdpr-supplement",
+				jurisdiction: "eea",
+				citation: "Required by GDPR Article 13",
+			},
 		}),
 		p([t.privacy.gdprSupplement.scope()]),
 		p([
@@ -292,7 +330,11 @@ function buildUkGdprSupplement(config: PrivacyPolicyConfig, t: T): DocumentSecti
 	if (!config.jurisdictions.includes("uk")) return null;
 	return section("uk-gdpr-supplement", [
 		heading(t.privacy.ukGdprSupplement.heading(), {
-			reason: "Required by the UK-GDPR and Data Protection Act 2018",
+			reason: {
+				code: "uk-gdpr-supplement",
+				jurisdiction: "uk",
+				citation: "Required by the UK-GDPR and Data Protection Act 2018",
+			},
 		}),
 		p([t.privacy.ukGdprSupplement.scope()]),
 		p([
@@ -320,7 +362,13 @@ function buildCcpaSupplement(config: PrivacyPolicyConfig, t: T): DocumentSection
 	];
 	if (phone) submissionMethods.push(li([bold(t.shared.contactLabels.phone()), " ", phone]));
 	return section("ccpa-supplement", [
-		heading(t.privacy.ccpaSupplement.heading(), { reason: "Required by CCPA" }),
+		heading(t.privacy.ccpaSupplement.heading(), {
+			reason: {
+				code: "ccpa-supplement",
+				jurisdiction: "us-ca",
+				citation: "Required by CCPA",
+			},
+		}),
 		p([t.privacy.ccpaSupplement.intro()]),
 		ul([
 			li([t.privacy.ccpaSupplement.rights.know()]),

--- a/packages/core/src/documents/types.ts
+++ b/packages/core/src/documents/types.ts
@@ -1,5 +1,30 @@
+import type { JurisdictionId } from "../jurisdiction-id";
+import type { LegalBasis } from "../types";
+
+/**
+ * A stable validator/compliance issue code.
+ *
+ * Placeholder: narrowed to the validator `IssueCode` union by the §2.1
+ * validator-consolidation ticket. Narrowing a `string` alias to a union is a
+ * non-breaking change for *producers* of the AST (see ADR 0001).
+ */
+export type IssueCode = string;
+
+/**
+ * A typed, machine-readable trace of *why* a node exists — the compliance
+ * differentiator the hosted diff/audit layer keys off. This is a first-class
+ * field, not a free-string side-channel: `code` is stable and machine-keyable,
+ * `citation` carries the verbatim legal article text for render/audit display.
+ */
+export type ComplianceReason = {
+	code: IssueCode;
+	jurisdiction?: JurisdictionId | readonly JurisdictionId[];
+	lawfulBasis?: LegalBasis;
+	citation?: string; // verbatim legal article text — display only
+};
+
 export type NodeContext = {
-	reason?: string;
+	reason?: ComplianceReason;
 };
 
 // Inline nodes
@@ -46,18 +71,48 @@ export type TableCellNode = {
 	children: InlineNode[];
 	context?: NodeContext;
 };
+// Header cells/rows are distinct discriminated variants — not a structural
+// `header: boolean` flag — so every renderer's visitor is total and exhaustively
+// type-checked with no internal header/body branch (ADR 0001, taxonomy).
+export type TableHeaderCellNode = {
+	type: "tableHeaderCell";
+	children: InlineNode[];
+	context?: NodeContext;
+};
 export type TableRowNode = {
 	type: "tableRow";
 	cells: TableCellNode[];
 	context?: NodeContext;
 };
+export type TableHeaderRowNode = {
+	type: "tableHeaderRow";
+	cells: TableHeaderCellNode[];
+	context?: NodeContext;
+};
 export type TableNode = {
 	type: "table";
-	header: TableRowNode;
+	header: TableHeaderRowNode;
 	rows: TableRowNode[];
 	context?: NodeContext;
 };
-export type ContentNode = HeadingNode | ParagraphNode | ListNode | TableNode;
+
+/**
+ * Forward-compat escape hatch. A reader on an older `astVersion` that meets a
+ * node `type` it does not recognize represents it as an `UnknownNode`; every
+ * renderer renders it as a no-op. This is what lets the frozen `Node` union
+ * gain block-level variants in a *minor* release without a major bump — semver
+ * locks the union at 1.0, so the seam is designed in now (ADR 0001).
+ */
+export type UnknownNode = {
+	type: "unknown";
+	raw?: unknown;
+	context?: NodeContext;
+};
+
+// Block-level content. `UnknownNode` is admitted here (not in the inline union):
+// post-1.0 growth is at block granularity, and section content is where an
+// older reader degrades an unrecognized node.
+export type ContentNode = HeadingNode | ParagraphNode | ListNode | TableNode | UnknownNode;
 
 // A single section of a document
 export type DocumentSection = {
@@ -69,9 +124,14 @@ export type DocumentSection = {
 
 export type PolicyType = "privacy" | "cookie";
 
-// The top-level document
+/** Current Document AST schema version. Bump on any additive union change. */
+export const AST_VERSION = 1;
+
+// The top-level document. Privacy and cookie are always two separate roots
+// discriminated by `policyType`; they are never merged (Decision 12, ADR 0001).
 export type Document = {
 	type: "document";
+	astVersion: number;
 	policyType: PolicyType;
 	sections: DocumentSection[];
 	context?: NodeContext;
@@ -84,5 +144,7 @@ export type Node =
 	| ContentNode
 	| ListItemNode
 	| TableRowNode
+	| TableHeaderRowNode
 	| TableCellNode
+	| TableHeaderCellNode
 	| InlineNode;

--- a/packages/core/src/documents/visit.ts
+++ b/packages/core/src/documents/visit.ts
@@ -1,0 +1,25 @@
+import type { Node } from "./types";
+
+/**
+ * The frozen tree-walk contract (§6). A `Visitor` is a **total** map keyed by
+ * the `Node` discriminant: every variant — including the forward-compat
+ * `unknown` arm — must be handled, so the walk is exhaustively type-checked
+ * with no internal branching. This is the seam the six duplicated walkers
+ * (md/html/pdf/react/vue/svelte) collapse onto in PS-12; PS-10 only freezes
+ * the shape (ADR 0001).
+ */
+export type Visitor<R> = {
+	[K in Node["type"]]: (node: Extract<Node, { type: K }>, visit: (child: Node) => R) => R;
+};
+
+/**
+ * Reference implementation of the frozen contract: dispatch by discriminant,
+ * threading a child-visit callback. The cast is the standard
+ * correlated-union-access limitation (TS cannot relate `visitor[node.type]`
+ * to the narrowed `node`); it is sound because `Visitor` is total by
+ * construction.
+ */
+export function visit<R>(node: Node, visitor: Visitor<R>): R {
+	const handle = visitor[node.type] as (n: Node, v: (child: Node) => R) => R;
+	return handle(node, (child) => visit(child, visitor));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,10 +1,12 @@
 export type {
 	BoldNode,
+	ComplianceReason,
 	ContentNode,
 	Document,
 	DocumentSection,
 	HeadingNode,
 	InlineNode,
+	IssueCode,
 	ItalicNode,
 	LinkNode,
 	ListItemNode,
@@ -14,14 +16,21 @@ export type {
 	ParagraphNode,
 	PolicyType,
 	TableCellNode,
+	TableHeaderCellNode,
+	TableHeaderRowNode,
 	TableNode,
 	TableRowNode,
 	TextNode,
+	UnknownNode,
+	Visitor,
 } from "./documents";
 export {
+	AST_VERSION,
 	bold,
 	cell,
 	compile,
+	headerCell,
+	headerRow,
 	heading,
 	italic,
 	li,
@@ -33,7 +42,9 @@ export {
 	table,
 	text,
 	ul,
+	visit,
 } from "./documents";
+export type { JurisdictionId } from "./jurisdiction-id";
 export { isJurisdiction, JURISDICTIONS } from "./jurisdictions";
 export type {
 	AutomatedDecision,

--- a/packages/core/src/jurisdiction-id.ts
+++ b/packages/core/src/jurisdiction-id.ts
@@ -1,0 +1,24 @@
+/**
+ * The single canonical jurisdiction identifier, **frozen at 1.0**.
+ *
+ * Eleven members, decided in the v1 architecture plan (§4.2.1). The union
+ * *membership* is the frozen part — a member's support tier (`specific` vs
+ * `equivalent`) may be upgraded post-1.0 without a breaking change. Stems are
+ * lowercase-kebab and legally precise (`eea`, not `eu`: GDPR applies EEA-wide).
+ *
+ * This is intentionally distinct from the existing config `Jurisdiction` type
+ * (`eu`/`uk`/…). The two coexist until the §4.2.1 capability-table ticket
+ * migrates config onto this id; see ADR 0001.
+ */
+export type JurisdictionId =
+	| "eea" //   European Economic Area — GDPR
+	| "uk" //    United Kingdom — UK-GDPR + PECR
+	| "ch" //    Switzerland — revFADP
+	| "br" //    Brazil — LGPD
+	| "ca" //    Canada — PIPEDA (+ Quebec Law 25 via sub-jurisdiction)
+	| "us" //    United States — federal baseline; opt-out by state
+	| "us-ca" // California — CCPA / CPRA
+	| "us-co" // Colorado — CPA
+	| "us-ct" // Connecticut — CTDPA
+	| "us-va" // Virginia — VCDPA
+	| "row"; //  Rest of world — conservative opt-in fallback

--- a/packages/react/src/components/defaults.tsx
+++ b/packages/react/src/components/defaults.tsx
@@ -9,6 +9,8 @@ import type {
 	Node,
 	ParagraphNode,
 	TableCellNode,
+	TableHeaderCellNode,
+	TableHeaderRowNode,
 	TableNode,
 	TableRowNode,
 	TextNode,
@@ -57,8 +59,8 @@ export function DefaultSection({
 		<section
 			data-op-section
 			id={section.id}
-			{...(section.context?.reason && {
-				"data-op-reason": section.context.reason,
+			{...(section.context?.reason?.code && {
+				"data-op-reason": section.context.reason.code,
 			})}
 		>
 			{children}
@@ -113,11 +115,21 @@ export function DefaultTableRow({
 	return <tr data-op-table-row>{children}</tr>;
 }
 
+export function DefaultTableHeaderRow({
+	node: _node,
+	children,
+}: {
+	node: TableHeaderRowNode;
+	children: ReactNode;
+}) {
+	return <tr data-op-table-row>{children}</tr>;
+}
+
 export function DefaultTableHead({
 	node: _node,
 	children,
 }: {
-	node: TableCellNode;
+	node: TableHeaderCellNode;
 	children: ReactNode;
 }) {
 	return (
@@ -187,29 +199,28 @@ export function renderNode(node: Node, components: PolicyComponents, key?: numbe
 			const TableComp = components.Table ?? DefaultTable;
 			const TableHeaderComp = components.TableHeader ?? DefaultTableHeader;
 			const TableBodyComp = components.TableBody ?? DefaultTableBody;
+			const TableHeaderRowComp = components.TableHeaderRow ?? DefaultTableHeaderRow;
 			const TableRowComp = components.TableRow ?? DefaultTableRow;
 			const TableHeadComp = components.TableHead ?? DefaultTableHead;
 			const TableCellComp = components.TableCell ?? DefaultTableCell;
-			const renderCell = (
-				cell: TableCellNode,
-				cellKey: number,
-				Comp: typeof TableHeadComp | typeof TableCellComp,
-			) => (
-				<Comp key={cellKey} node={cell}>
-					{cell.children.map((n, i) => renderNode(n, components, i))}
-				</Comp>
+			const headerRow = (
+				<TableHeaderRowComp node={node.header}>
+					{node.header.cells.map((cell, ci) => (
+						<TableHeadComp key={ci} node={cell}>
+							{cell.children.map((n, i) => renderNode(n, components, i))}
+						</TableHeadComp>
+					))}
+				</TableHeaderRowComp>
 			);
-			const renderRow = (
-				row: TableRowNode,
-				rowKey: number | undefined,
-				CellComp: typeof TableHeadComp | typeof TableCellComp,
-			) => (
-				<TableRowComp key={rowKey} node={row}>
-					{row.cells.map((c, ci) => renderCell(c, ci, CellComp))}
+			const bodyRows = node.rows.map((row, ri) => (
+				<TableRowComp key={ri} node={row}>
+					{row.cells.map((cell, ci) => (
+						<TableCellComp key={ci} node={cell}>
+							{cell.children.map((n, i) => renderNode(n, components, i))}
+						</TableCellComp>
+					))}
 				</TableRowComp>
-			);
-			const headerRow = renderRow(node.header, undefined, TableHeadComp);
-			const bodyRows = node.rows.map((row, ri) => renderRow(row, ri, TableCellComp));
+			));
 			return (
 				<TableComp key={key} node={node}>
 					<TableHeaderComp>{headerRow}</TableHeaderComp>
@@ -220,6 +231,13 @@ export function renderNode(node: Node, components: PolicyComponents, key?: numbe
 
 		case "tableRow":
 		case "tableCell":
+		case "tableHeaderRow":
+		case "tableHeaderCell":
+			return null;
+
+		// Forward-compat no-op: unrecognized future block-level nodes are
+		// represented as UnknownNode and rendered as nothing (see ADR 0001).
+		case "unknown":
 			return null;
 
 		case "text": {

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -85,6 +85,7 @@ const rnLikeComponents: PolicyComponents = {
 	Table: Slot("table"),
 	TableHeader: Slot("tableHeader"),
 	TableBody: Slot("tableBody"),
+	TableHeaderRow: Slot("tableHeaderRow"),
 	TableRow: Slot("tableRow"),
 	TableHead: Slot("tableHead"),
 	TableCell: Slot("tableCell"),

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -8,6 +8,8 @@ import type {
 	ListNode,
 	ParagraphNode,
 	TableCellNode,
+	TableHeaderCellNode,
+	TableHeaderRowNode,
 	TableNode,
 	TableRowNode,
 	TextNode,
@@ -25,7 +27,8 @@ export type PolicyComponents = {
 	TableHeader?: ComponentType<{ children: ReactNode }>;
 	TableBody?: ComponentType<{ children: ReactNode }>;
 	TableRow?: ComponentType<{ node: TableRowNode; children: ReactNode }>;
-	TableHead?: ComponentType<{ node: TableCellNode; children: ReactNode }>;
+	TableHeaderRow?: ComponentType<{ node: TableHeaderRowNode; children: ReactNode }>;
+	TableHead?: ComponentType<{ node: TableHeaderCellNode; children: ReactNode }>;
 	TableCell?: ComponentType<{ node: TableCellNode; children: ReactNode }>;
 	Text?: ComponentType<{ node: TextNode }>;
 	Bold?: ComponentType<{ node: BoldNode }>;

--- a/packages/renderers/src/html.test.ts
+++ b/packages/renderers/src/html.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "vite-plus/test";
-import type { Document } from "@openpolicy/core";
+import { AST_VERSION, type Document } from "@openpolicy/core";
 import { renderHTML } from "./html";
 
 function doc(sections: Document["sections"]): Document {
-	return { type: "document", policyType: "privacy", sections };
+	return { type: "document", astVersion: AST_VERSION, policyType: "privacy", sections };
 }
 
 test("renders heading as <h2>", () => {
@@ -144,10 +144,10 @@ test("renders a table with thead/tbody/th/td", () => {
 					{
 						type: "table",
 						header: {
-							type: "tableRow",
+							type: "tableHeaderRow",
 							cells: [
-								{ type: "tableCell", children: [{ type: "text", value: "Name" }] },
-								{ type: "tableCell", children: [{ type: "text", value: "Purpose" }] },
+								{ type: "tableHeaderCell", children: [{ type: "text", value: "Name" }] },
+								{ type: "tableHeaderCell", children: [{ type: "text", value: "Purpose" }] },
 							],
 						},
 						rows: [
@@ -196,4 +196,23 @@ test("renders list as <ul>/<li>", () => {
 	expect(result).toContain("<ul>");
 	expect(result).toContain("<li>Alpha</li>");
 	expect(result).toContain("<li>Beta</li>");
+});
+
+test("forward-compat: an unknown node renders as a no-op", () => {
+	const result = renderHTML(
+		doc([
+			{
+				type: "section",
+				id: "s1",
+				content: [
+					{ type: "heading", value: "Before" },
+					{ type: "unknown", raw: { type: "future-node", value: "ignored" } },
+					{ type: "heading", value: "After" },
+				],
+			},
+		]),
+	);
+	expect(result).toContain("<h2>Before</h2>");
+	expect(result).toContain("<h2>After</h2>");
+	expect(result).not.toContain("ignored");
 });

--- a/packages/renderers/src/html.ts
+++ b/packages/renderers/src/html.ts
@@ -1,11 +1,4 @@
-import type {
-	Document,
-	InlineNode,
-	ListItemNode,
-	ListNode,
-	TableNode,
-	TableRowNode,
-} from "@openpolicy/core";
+import type { Document, InlineNode, ListItemNode, ListNode, TableNode } from "@openpolicy/core";
 
 function escapeHtml(str: string): string {
 	return str
@@ -41,14 +34,14 @@ function renderList(node: ListNode): string {
 	return `<${tag}>${items}</${tag}>`;
 }
 
-function renderRowCells(row: TableRowNode, tag: "th" | "td"): string {
-	return row.cells.map((c) => `<${tag}>${c.children.map(renderInline).join("")}</${tag}>`).join("");
+function renderRowCells(cells: { children: InlineNode[] }[], tag: "th" | "td"): string {
+	return cells.map((c) => `<${tag}>${c.children.map(renderInline).join("")}</${tag}>`).join("");
 }
 
 function renderTable(node: TableNode): string {
-	const head = `<thead><tr>${renderRowCells(node.header, "th")}</tr></thead>`;
+	const head = `<thead><tr>${renderRowCells(node.header.cells, "th")}</tr></thead>`;
 	const body = `<tbody>${node.rows
-		.map((r) => `<tr>${renderRowCells(r, "td")}</tr>`)
+		.map((r) => `<tr>${renderRowCells(r.cells, "td")}</tr>`)
 		.join("")}</tbody>`;
 	return `<table>${head}${body}</table>`;
 }
@@ -69,6 +62,9 @@ export function renderHTML(doc: Document): string {
 						return renderList(node);
 					case "table":
 						return renderTable(node);
+					case "unknown":
+						// forward-compat: unrecognized node renders as nothing (ADR 0001)
+						return "";
 				}
 			});
 			return blocks.join("\n");

--- a/packages/renderers/src/markdown.test.ts
+++ b/packages/renderers/src/markdown.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "vite-plus/test";
-import type { Document } from "@openpolicy/core";
+import { AST_VERSION, type Document } from "@openpolicy/core";
 import { renderMarkdown } from "./markdown";
 
 function doc(sections: Document["sections"]): Document {
-	return { type: "document", policyType: "privacy", sections };
+	return { type: "document", astVersion: AST_VERSION, policyType: "privacy", sections };
 }
 
 test("renders a heading node", () => {
@@ -220,10 +220,10 @@ test("renders a table as GFM", () => {
 					{
 						type: "table",
 						header: {
-							type: "tableRow",
+							type: "tableHeaderRow",
 							cells: [
-								{ type: "tableCell", children: [{ type: "text", value: "Name" }] },
-								{ type: "tableCell", children: [{ type: "text", value: "Purpose" }] },
+								{ type: "tableHeaderCell", children: [{ type: "text", value: "Name" }] },
+								{ type: "tableHeaderCell", children: [{ type: "text", value: "Purpose" }] },
 							],
 						},
 						rows: [
@@ -253,8 +253,8 @@ test("escapes pipe characters in table cells", () => {
 					{
 						type: "table",
 						header: {
-							type: "tableRow",
-							cells: [{ type: "tableCell", children: [{ type: "text", value: "Field" }] }],
+							type: "tableHeaderRow",
+							cells: [{ type: "tableHeaderCell", children: [{ type: "text", value: "Field" }] }],
 						},
 						rows: [
 							{

--- a/packages/renderers/src/markdown.ts
+++ b/packages/renderers/src/markdown.ts
@@ -1,11 +1,4 @@
-import type {
-	Document,
-	InlineNode,
-	ListItemNode,
-	ListNode,
-	TableNode,
-	TableRowNode,
-} from "@openpolicy/core";
+import type { Document, InlineNode, ListItemNode, ListNode, TableNode } from "@openpolicy/core";
 
 function renderInline(node: InlineNode): string {
 	switch (node.type) {
@@ -45,14 +38,14 @@ function renderCellInline(children: InlineNode[]): string {
 	return children.map(renderInline).join("").replace(/\|/g, "\\|").replace(/\n/g, " ");
 }
 
-function renderTableRow(row: TableRowNode): string {
-	return `| ${row.cells.map((c) => renderCellInline(c.children)).join(" | ")} |`;
+function renderRowCells(cells: { children: InlineNode[] }[]): string {
+	return `| ${cells.map((c) => renderCellInline(c.children)).join(" | ")} |`;
 }
 
 function renderTable(node: TableNode): string {
-	const headerLine = renderTableRow(node.header);
+	const headerLine = renderRowCells(node.header.cells);
 	const separatorLine = `| ${node.header.cells.map(() => "---").join(" | ")} |`;
-	const bodyLines = node.rows.map(renderTableRow);
+	const bodyLines = node.rows.map((r) => renderRowCells(r.cells));
 	return [headerLine, separatorLine, ...bodyLines].join("\n");
 }
 
@@ -74,6 +67,9 @@ export function renderMarkdown(doc: Document): string {
 							.join("\n");
 					case "table":
 						return renderTable(node);
+					case "unknown":
+						// forward-compat: unrecognized node renders as nothing (ADR 0001)
+						return "";
 				}
 			});
 			return blocks.join("\n\n");

--- a/packages/renderers/src/pdf.ts
+++ b/packages/renderers/src/pdf.ts
@@ -151,6 +151,9 @@ function renderSection(
 			case "table":
 				renderTable(doc, node);
 				break;
+			case "unknown":
+				// forward-compat: unrecognized node renders as nothing (ADR 0001)
+				break;
 		}
 	}
 }

--- a/packages/svelte/src/lib/RenderNode.svelte
+++ b/packages/svelte/src/lib/RenderNode.svelte
@@ -92,4 +92,8 @@ const overrides = $derived(overridesGetter());
 	{:else}
 		<DefaultLink {node} />
 	{/if}
+{:else if node.type === "unknown"}
+	<!-- Forward-compat escape hatch: an UnknownNode renders as a no-op so a
+	     reader on an older astVersion that meets an unrecognized block-level
+	     node degrades gracefully instead of crashing (ADR 0001). -->
 {/if}

--- a/packages/svelte/src/lib/RenderTable.svelte
+++ b/packages/svelte/src/lib/RenderTable.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
-import type { TableCellNode, TableNode, TableRowNode } from "@openpolicy/core";
+import type {
+	TableCellNode,
+	TableHeaderCellNode,
+	TableHeaderRowNode,
+	TableNode,
+	TableRowNode,
+} from "@openpolicy/core";
 import { getOverridesContext } from "./context.svelte";
 import DefaultTable from "./defaults/DefaultTable.svelte";
 import DefaultTableBody from "./defaults/DefaultTableBody.svelte";
 import DefaultTableCell from "./defaults/DefaultTableCell.svelte";
 import DefaultTableHead from "./defaults/DefaultTableHead.svelte";
 import DefaultTableHeader from "./defaults/DefaultTableHeader.svelte";
+import DefaultTableHeaderRow from "./defaults/DefaultTableHeaderRow.svelte";
 import DefaultTableRow from "./defaults/DefaultTableRow.svelte";
 import RenderNode from "./RenderNode.svelte";
 
@@ -14,29 +21,49 @@ const overridesGetter = getOverridesContext();
 const overrides = $derived(overridesGetter());
 </script>
 
-{#snippet renderCell(cell: TableCellNode, kind: "head" | "cell")}
+{#snippet renderHeaderCell(cell: TableHeaderCellNode)}
 	{#snippet cellChildren()}
 		{#each cell.children as child, i (i)}
 			<RenderNode node={child} />
 		{/each}
 	{/snippet}
-	{#if kind === "head"}
-		{#if overrides.tableHead}
-			{@render overrides.tableHead({ node: cell, children: cellChildren })}
-		{:else}
-			<DefaultTableHead node={cell}>{@render cellChildren()}</DefaultTableHead>
-		{/if}
-	{:else if overrides.tableCell}
+	{#if overrides.tableHead}
+		{@render overrides.tableHead({ node: cell, children: cellChildren })}
+	{:else}
+		<DefaultTableHead node={cell}>{@render cellChildren()}</DefaultTableHead>
+	{/if}
+{/snippet}
+
+{#snippet renderCell(cell: TableCellNode)}
+	{#snippet cellChildren()}
+		{#each cell.children as child, i (i)}
+			<RenderNode node={child} />
+		{/each}
+	{/snippet}
+	{#if overrides.tableCell}
 		{@render overrides.tableCell({ node: cell, children: cellChildren })}
 	{:else}
 		<DefaultTableCell node={cell}>{@render cellChildren()}</DefaultTableCell>
 	{/if}
 {/snippet}
 
-{#snippet renderRow(row: TableRowNode, kind: "head" | "cell")}
+{#snippet renderHeaderRow(row: TableHeaderRowNode)}
 	{#snippet rowChildren()}
 		{#each row.cells as cell, i (i)}
-			{@render renderCell(cell, kind)}
+			{@render renderHeaderCell(cell)}
+		{/each}
+	{/snippet}
+	{#if overrides.tableHeaderRow}
+		{@render overrides.tableHeaderRow({ node: row, children: rowChildren })}
+	{:else}
+		<DefaultTableHeaderRow node={row}>{@render rowChildren()}</DefaultTableHeaderRow>
+	{/if}
+{/snippet}
+
+{#snippet renderRow(row: TableRowNode)}
+	{#snippet rowChildren()}
+		{#each row.cells as cell, i (i)}
+			{@render renderCell(cell)}
 		{/each}
 	{/snippet}
 	{#if overrides.tableRow}
@@ -47,12 +74,12 @@ const overrides = $derived(overridesGetter());
 {/snippet}
 
 {#snippet headerContents()}
-	{@render renderRow(node.header, "head")}
+	{@render renderHeaderRow(node.header)}
 {/snippet}
 
 {#snippet bodyContents()}
 	{#each node.rows as row, i (i)}
-		{@render renderRow(row, "cell")}
+		{@render renderRow(row)}
 	{/each}
 {/snippet}
 

--- a/packages/svelte/src/lib/defaults/DefaultSection.svelte
+++ b/packages/svelte/src/lib/defaults/DefaultSection.svelte
@@ -14,7 +14,7 @@ let {
 <section
 	data-op-section=""
 	id={section.id}
-	data-op-reason={section.context?.reason}
+	data-op-reason={section.context?.reason?.code}
 >
 	{@render children()}
 </section>

--- a/packages/svelte/src/lib/defaults/DefaultTableHead.svelte
+++ b/packages/svelte/src/lib/defaults/DefaultTableHead.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-import type { TableCellNode } from "@openpolicy/core";
+import type { TableHeaderCellNode } from "@openpolicy/core";
 import type { Snippet } from "svelte";
 
 let {
 	children,
 }: {
-	node: TableCellNode;
+	node: TableHeaderCellNode;
 	children: Snippet;
 } = $props();
 </script>

--- a/packages/svelte/src/lib/defaults/DefaultTableHeaderRow.svelte
+++ b/packages/svelte/src/lib/defaults/DefaultTableHeaderRow.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import type { TableHeaderRowNode } from "@openpolicy/core";
+import type { Snippet } from "svelte";
+
+let {
+	children,
+}: {
+	node: TableHeaderRowNode;
+	children: Snippet;
+} = $props();
+</script>
+
+<tr data-op-table-row="">{@render children()}</tr>

--- a/packages/svelte/src/lib/types.ts
+++ b/packages/svelte/src/lib/types.ts
@@ -7,6 +7,8 @@ import type {
 	ListNode,
 	ParagraphNode,
 	TableCellNode,
+	TableHeaderCellNode,
+	TableHeaderRowNode,
 	TableNode,
 	TableRowNode,
 	TextNode,
@@ -22,7 +24,8 @@ export type PolicyOverrides = {
 	tableHeader?: Snippet<[{ children: Snippet }]>;
 	tableBody?: Snippet<[{ children: Snippet }]>;
 	tableRow?: Snippet<[{ node: TableRowNode; children: Snippet }]>;
-	tableHead?: Snippet<[{ node: TableCellNode; children: Snippet }]>;
+	tableHeaderRow?: Snippet<[{ node: TableHeaderRowNode; children: Snippet }]>;
+	tableHead?: Snippet<[{ node: TableHeaderCellNode; children: Snippet }]>;
 	tableCell?: Snippet<[{ node: TableCellNode; children: Snippet }]>;
 	text?: Snippet<[{ node: TextNode }]>;
 	bold?: Snippet<[{ node: BoldNode }]>;

--- a/packages/vue/src/defaults/block.ts
+++ b/packages/vue/src/defaults/block.ts
@@ -8,13 +8,13 @@ export const DefaultSection = defineComponent({
 	},
 	setup(props, { slots }) {
 		return () => {
-			const reason = props.section.context?.reason;
+			const reasonCode = props.section.context?.reason?.code;
 			return h(
 				"section",
 				{
 					"data-op-section": "",
 					id: props.section.id,
-					...(reason ? { "data-op-reason": reason } : {}),
+					...(reasonCode ? { "data-op-reason": reasonCode } : {}),
 				},
 				slots.default?.(),
 			);

--- a/packages/vue/src/defaults/index.ts
+++ b/packages/vue/src/defaults/index.ts
@@ -6,5 +6,6 @@ export {
 	DefaultTableCell,
 	DefaultTableHead,
 	DefaultTableHeader,
+	DefaultTableHeaderRow,
 	DefaultTableRow,
 } from "./table";

--- a/packages/vue/src/defaults/table.ts
+++ b/packages/vue/src/defaults/table.ts
@@ -1,4 +1,10 @@
-import type { TableCellNode, TableNode, TableRowNode } from "@openpolicy/core";
+import type {
+	TableCellNode,
+	TableHeaderCellNode,
+	TableHeaderRowNode,
+	TableNode,
+	TableRowNode,
+} from "@openpolicy/core";
 import { defineComponent, h, type PropType } from "vue";
 
 export const DefaultTable = defineComponent({
@@ -35,10 +41,20 @@ export const DefaultTableRow = defineComponent({
 	},
 });
 
+export const DefaultTableHeaderRow = defineComponent({
+	name: "DefaultTableHeaderRow",
+	props: {
+		node: { type: Object as PropType<TableHeaderRowNode>, required: true },
+	},
+	setup(_props, { slots }) {
+		return () => h("tr", { "data-op-table-row": "" }, slots.default?.());
+	},
+});
+
 export const DefaultTableHead = defineComponent({
 	name: "DefaultTableHead",
 	props: {
-		node: { type: Object as PropType<TableCellNode>, required: true },
+		node: { type: Object as PropType<TableHeaderCellNode>, required: true },
 	},
 	setup(_props, { slots }) {
 		return () => h("th", { "data-op-table-cell": "", scope: "col" }, slots.default?.());

--- a/packages/vue/src/render/renderNode.ts
+++ b/packages/vue/src/render/renderNode.ts
@@ -31,6 +31,12 @@ export const renderNode: RenderNode = (node, components, key) => {
 			return renderTable(node, components, renderNode, key);
 		case "tableRow":
 		case "tableCell":
+		case "tableHeaderRow":
+		case "tableHeaderCell":
+			return null;
+		// Forward-compat no-op: unrecognized future block nodes render as
+		// nothing rather than crashing the renderer (see ADR 0001).
+		case "unknown":
 			return null;
 		case "text":
 			return renderText(node, components, key);

--- a/packages/vue/src/render/renderTable.ts
+++ b/packages/vue/src/render/renderTable.ts
@@ -1,4 +1,4 @@
-import type { TableCellNode, TableNode, TableRowNode } from "@openpolicy/core";
+import type { TableCellNode, TableHeaderCellNode, TableNode, TableRowNode } from "@openpolicy/core";
 import { h, type VNodeChild } from "vue";
 import {
 	DefaultTable,
@@ -6,6 +6,7 @@ import {
 	DefaultTableCell,
 	DefaultTableHead,
 	DefaultTableHeader,
+	DefaultTableHeaderRow,
 	DefaultTableRow,
 } from "../defaults/table";
 import type { PolicyComponents } from "../types";
@@ -21,29 +22,28 @@ export function renderTable(
 	const TableHeaderComp = components.TableHeader ?? DefaultTableHeader;
 	const TableBodyComp = components.TableBody ?? DefaultTableBody;
 	const TableRowComp = components.TableRow ?? DefaultTableRow;
+	const TableHeaderRowComp = components.TableHeaderRow ?? DefaultTableHeaderRow;
 	const TableHeadComp = components.TableHead ?? DefaultTableHead;
 	const TableCellComp = components.TableCell ?? DefaultTableCell;
 
-	const renderCell = (
-		cell: TableCellNode,
-		cellKey: number,
-		CellComp: typeof TableHeadComp | typeof TableCellComp,
-	) => {
+	const renderHeaderCell = (cell: TableHeaderCellNode, cellKey: number) => {
 		const cellChildren = cell.children.map((n, i) => renderNode(n, components, i));
-		return h(CellComp, { key: cellKey, node: cell }, { default: () => cellChildren });
+		return h(TableHeadComp, { key: cellKey, node: cell }, { default: () => cellChildren });
 	};
 
-	const renderRow = (
-		row: TableRowNode,
-		rowKey: number | undefined,
-		CellComp: typeof TableHeadComp | typeof TableCellComp,
-	) => {
-		const rowChildren = row.cells.map((c, ci) => renderCell(c, ci, CellComp));
+	const renderBodyCell = (cell: TableCellNode, cellKey: number) => {
+		const cellChildren = cell.children.map((n, i) => renderNode(n, components, i));
+		return h(TableCellComp, { key: cellKey, node: cell }, { default: () => cellChildren });
+	};
+
+	const renderBodyRow = (row: TableRowNode, rowKey: number) => {
+		const rowChildren = row.cells.map((c, ci) => renderBodyCell(c, ci));
 		return h(TableRowComp, { key: rowKey, node: row }, { default: () => rowChildren });
 	};
 
-	const headerRow = renderRow(node.header, undefined, TableHeadComp);
-	const bodyRows = node.rows.map((row, ri) => renderRow(row, ri, TableCellComp));
+	const headerCells = node.header.cells.map((c, ci) => renderHeaderCell(c, ci));
+	const headerRow = h(TableHeaderRowComp, { node: node.header }, { default: () => headerCells });
+	const bodyRows = node.rows.map((row, ri) => renderBodyRow(row, ri));
 	const inner = [
 		h(TableHeaderComp, null, { default: () => headerRow }),
 		h(TableBodyComp, null, { default: () => bodyRows }),

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -7,6 +7,8 @@ import type {
 	ListNode,
 	ParagraphNode,
 	TableCellNode,
+	TableHeaderCellNode,
+	TableHeaderRowNode,
 	TableNode,
 	TableRowNode,
 	TextNode,
@@ -22,7 +24,8 @@ export type PolicyComponents = {
 	TableHeader?: Component;
 	TableBody?: Component;
 	TableRow?: Component<{ node: TableRowNode }>;
-	TableHead?: Component<{ node: TableCellNode }>;
+	TableHeaderRow?: Component<{ node: TableHeaderRowNode }>;
+	TableHead?: Component<{ node: TableHeaderCellNode }>;
 	TableCell?: Component<{ node: TableCellNode }>;
 	Text?: Component<{ node: TextNode }>;
 	Bold?: Component<{ node: BoldNode }>;


### PR DESCRIPTION
## Summary

`Node` + the shared `visit()` are on the **1.0 frozen surface**, so PS-10 is a one-shot pre-freeze gate (Decision 8): keeping the hand-rolled AST is decided, its *shape* was not. This lands the breaking node changes now (Phase 2) plus the ADR recording the six §2.3 decisions. Unblocks PS-12, PS-15, PS-16.

**Acceptance — ADR merged + `Node` at frozen shape — met.**

## Changes

- **core:** frozen 11-member `JurisdictionId` union (§4.2.1); `NodeContext.reason` → typed `ComplianceReason { code, jurisdiction?, lawfulBasis?, citation? }` with an `IssueCode` placeholder; split `tableCell`/`tableRow` into distinct `tableHeaderCell`/`tableHeaderRow` variants; `Document.astVersion` + `AST_VERSION`; reserved `unknown` node in `ContentNode`; frozen total `Visitor`/`visit()` seam (reference impl only).
- **core builders:** migrated the 9 free-string `reason` call sites to typed reasons; added `headerCell`/`headerRow` helpers with a contained `table()` rewrite (builder call sites unchanged).
- **renderers + react/vue/svelte:** header/body are now distinct typed paths (threaded `kind`/`Comp` param deleted), added an `unknown` no-op arm, `data-op-reason` now emits `reason.code`. Slot maps gained `TableHeaderRow`; `TableHead` retyped to `TableHeaderCellNode`.
- **docs/adr/0001-document-ast-shape-freeze.md:** the decision record (the deliverable).

## Reviewer notes

- **Breaking, pre-1.0, intentional** — all renderers and hand-constructed test fixtures updated in-tree.
- **`JurisdictionId` is pulled earlier than its own §4.2.1 ticket** on purpose: the frozen `reason` field must reference final types now, or a later rename would itself break the frozen surface. It's intentionally distinct from the config `Jurisdiction` (`eu`/`uk`/…) type; reconciliation is owned by the §4.2.1 capability-table ticket.
- **`IssueCode` is a `string` placeholder**, narrowed to the validator union by the §2.1 ticket — non-breaking for AST producers (caveat documented in the ADR).
- **Slot names** (`TableHeaderRow`, retyped `TableHead`) are inputs to PS-15's `PolicyComponents` canonicalization.
- `visit()` consolidation of the 6 walkers is **out of scope → PS-12**; PS-10 ships the contract + one reference implementation only.

## Verification

- `vp check`: format + lint clean across all changed packages; per-package `tsc`/`svelte-check` clean.
- `vp test`: **296/296 pass**, including a new forward-compat test (an `unknown` node renders as a visible no-op) and updated table/`astVersion` fixtures.
- Note: the fresh worktree required `vp run -r build` first; the `packages/svelte/src/index.test.ts` file-level FAIL under the parallel monorepo run has **0 failed tests** and passes 5/5 in isolation (vite-8-beta svelte-plugin collection flake, pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)