### PR TITLE
feat(vite): strict mode + per-code issue suppression (PS-13)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -216,8 +216,10 @@ export function isOpenPolicyConfig(value: unknown): value is OpenPolicyConfig {
 }
 
 // Stable public diagnostic codes emitted by validate(). Frozen at 1.0 (§6);
-// each is one-per-condition. Severity in the trailing comment is the default
-// (PS-13 may later allow promotion/suppression).
+// each is one-per-condition. The trailing severity is exactly what validate()
+// emits — it stays pure and frozen. Promotion (warnings→errors) and per-code
+// suppression are applied downstream by the @openpolicy/vite plugin's
+// `strict` / `suppress` options (PS-13), not here.
 export type IssueCode =
 	| "effective-date-required" //          error   — effectiveDate missing
 	| "company-name-required" //            error   — company.name missing

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -34,6 +34,39 @@ Astro users: add it the same way under `vite.plugins` in `astro.config.mjs`.
 | `extensions`                  | `string[]` | `[".ts", ".tsx"]` | File extensions to scan.                                                                                                                        |
 | `ignore`                      | `string[]` | `[]`              | Extra directory basenames to skip (appended to the built-in list: `node_modules`, `dist`, `.git`, `.next`, `.output`, `.svelte-kit`, `.cache`). |
 | `thirdParties.usePackageJson` | `boolean`  | `false`           | Auto-detect third-party services from `package.json` dependencies against the built-in registry (Stripe, Sentry, PostHog, etc.).                |
+| `validate`                    | `boolean`  | `true`            | Validate the resolved `openpolicy.ts` after each scan (see [Validation](#validation)).                                                          |
+| `strict`                      | `boolean`  | `false`           | Promote remaining warnings to errors, so they fail `vite build` like real errors.                                                              |
+| `suppress`                    | `IssueCode[]` | `[]`           | Issue codes to drop entirely, at any level (errors included). Applied before `strict`.                                                          |
+
+## Validation
+
+When `validate` is `true`, the plugin runs the single `validate()` from
+`@openpolicy/core` against your resolved config after every scan and reports
+each [`IssueCode`](https://docs.openpolicy.sh) once:
+
+- In **`vite build`**, errors abort the build (`PluginContext.error`); warnings
+  are reported (`PluginContext.warn`) but never block.
+- In **`vite dev`**, both are logged through the dev-server logger and never
+  crash HMR.
+
+`strict` and `suppress` shape the issue list **before** that error/warn split,
+in this order:
+
+1. **`suppress`** drops every issue whose `code` is listed, at **any** level —
+   errors included. Use it to accept a known disclosure gap; because the list
+   lives in `vite.config.ts`, the decision is committed and shows up in review.
+   It does **not** silence config load/parse failures.
+2. **`strict`** then promotes every remaining warning to an error. A suppressed
+   code is gone before this step, so it is never promoted. In `vite build` the
+   promoted issues now abort the build; in `vite dev` they log at error level
+   but still never crash HMR.
+
+```ts
+openPolicy({
+	strict: true, // warnings now fail `vite build`
+	suppress: ["company-dpo-undeclared"], // …except this one, which we accept
+});
+```
 
 ## Documentation
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,5 +1,6 @@
 import { access, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
+import type { IssueCode } from "@openpolicy/core";
 import type { Plugin, ViteDevServer } from "vite";
 import {
 	extractFromParsed,
@@ -51,8 +52,28 @@ export type OpenPolicyOptions = {
 	 * (`PluginContext.error`); warnings are reported (`PluginContext.warn`)
 	 * but never block. In dev, both error and warning issues are logged
 	 * through the dev-server logger and never crash HMR. Defaults to `true`.
+	 *
+	 * `strict` / `suppress` (below) shape the issue list before this
+	 * error/warn split is applied.
 	 */
 	validate?: boolean;
+
+	/**
+	 * Promote every remaining warning to an error, so they fail `vite build`
+	 * the same way real errors do. Applied *after* `suppress` — a suppressed
+	 * code is never promoted. In dev, promoted issues log at error level but
+	 * still never crash HMR. Defaults to `false`.
+	 */
+	strict?: boolean;
+
+	/**
+	 * Issue codes to drop from the result entirely, at any level (errors
+	 * included). Applied *before* `strict`. Use this to accept a known
+	 * disclosure gap — the list lives in `vite.config.ts`, so the decision is
+	 * committed and shows up in review. Does not silence config load/parse
+	 * failures. Defaults to `[]`.
+	 */
+	suppress?: IssueCode[];
 };
 
 /**
@@ -141,6 +162,8 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 	const usePackageJsonOpt = options.thirdParties?.usePackageJson ?? false;
 	const useCookiesPackageJsonOpt = options.cookies?.usePackageJson ?? false;
 	const validateOpt = options.validate ?? true;
+	const strictOpt = options.strict ?? false;
+	const suppressOpt = options.suppress ?? [];
 	let resolvedRoot: string;
 	let resolvedSrcDir: string;
 	let resolvedConfigDir: string;
@@ -333,6 +356,8 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 		try {
 			result = await loadAndValidateConfig({
 				configFile: resolvedConfigFile,
+				strict: strictOpt,
+				suppress: suppressOpt,
 			});
 		} catch (err) {
 			server.config.logger.error(`[openpolicy] validation crashed: ${err}`);
@@ -410,6 +435,8 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			if (validateOpt && resolvedConfigFile && resolvedCommand === "build") {
 				const result = await loadAndValidateConfig({
 					configFile: resolvedConfigFile,
+					strict: strictOpt,
+					suppress: suppressOpt,
 				});
 				if (result.loadError) {
 					this.warn(

--- a/packages/vite/src/validate.test.ts
+++ b/packages/vite/src/validate.test.ts
@@ -1,9 +1,10 @@
+import type { Issue, IssueCode } from "@openpolicy/core";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, expect, test } from "vite-plus/test";
 import { renderGenModule, type Scanned } from "./scanned";
-import { loadAndValidateConfig } from "./validate";
+import { applyIssuePolicy, loadAndValidateConfig } from "./validate";
 
 /**
  * Tmp dirs sit inside this package's own directory so that `bundle-require`'s
@@ -158,4 +159,81 @@ test("captures missing default export as a load error", async () => {
 	const result = await loadAndValidateConfig({ configFile: file });
 	expect(result.loadError).toBeInstanceOf(Error);
 	expect(result.loadError?.message).toContain("no default export");
+});
+
+// --- applyIssuePolicy (PS-13: strict + per-code suppression) ---
+
+const warn = (code: IssueCode): Issue => ({ code, level: "warning", message: `${code} msg` });
+const err = (code: IssueCode): Issue => ({ code, level: "error", message: `${code} msg` });
+
+test("applyIssuePolicy: no options is the identity transform", () => {
+	const issues = [err("effective-date-required"), warn("automated-decision-making")];
+	expect(applyIssuePolicy(issues, {})).toEqual(issues);
+});
+
+test("applyIssuePolicy: suppress drops a warning code", () => {
+	const issues = [warn("automated-decision-making"), warn("company-dpo-undeclared")];
+	const out = applyIssuePolicy(issues, { suppress: ["automated-decision-making"] });
+	expect(out).toEqual([warn("company-dpo-undeclared")]);
+});
+
+test("applyIssuePolicy: suppress drops an error code too (any level)", () => {
+	const issues = [err("effective-date-required"), warn("automated-decision-making")];
+	const out = applyIssuePolicy(issues, { suppress: ["effective-date-required"] });
+	expect(out).toEqual([warn("automated-decision-making")]);
+});
+
+test("applyIssuePolicy: strict promotes every warning to an error, codes/messages preserved", () => {
+	const issues = [err("effective-date-required"), warn("automated-decision-making")];
+	const out = applyIssuePolicy(issues, { strict: true });
+	expect(out).toEqual([
+		{ code: "effective-date-required", level: "error", message: "effective-date-required msg" },
+		{ code: "automated-decision-making", level: "error", message: "automated-decision-making msg" },
+	]);
+});
+
+test("applyIssuePolicy: suppress runs before strict — a suppressed code is never promoted", () => {
+	const issues = [warn("automated-decision-making"), warn("company-dpo-undeclared")];
+	const out = applyIssuePolicy(issues, {
+		strict: true,
+		suppress: ["automated-decision-making"],
+	});
+	expect(out).toEqual([
+		{ code: "company-dpo-undeclared", level: "error", message: "company-dpo-undeclared msg" },
+	]);
+});
+
+test("loadAndValidateConfig: strict flips the us-ca phone warning to an error", async () => {
+	const file = await writeConfig(
+		VALID_CONFIG.replace('jurisdictions: ["eu"],', 'jurisdictions: ["us-ca"],'),
+	);
+	const result = await loadAndValidateConfig({ configFile: file, strict: true });
+	expect(result.loadError).toBeNull();
+	const hit = result.issues.find((i) => i.code === "company-contact-phone-recommended");
+	expect(hit).toBeDefined();
+	expect(hit?.level).toBe("error");
+	expect(result.issues.some((i) => i.level === "warning")).toBe(false);
+});
+
+test("loadAndValidateConfig: suppress removes a code entirely", async () => {
+	const file = await writeConfig(
+		VALID_CONFIG.replace('jurisdictions: ["eu"],', 'jurisdictions: ["us-ca"],'),
+	);
+	const result = await loadAndValidateConfig({
+		configFile: file,
+		suppress: ["company-contact-phone-recommended"],
+	});
+	expect(result.loadError).toBeNull();
+	expect(result.issues.some((i) => i.code === "company-contact-phone-recommended")).toBe(false);
+});
+
+test("loadAndValidateConfig: suppress does not silence config load failures", async () => {
+	const file = await writeConfig("export default this is not valid typescript;");
+	const result = await loadAndValidateConfig({
+		configFile: file,
+		suppress: ["effective-date-required"],
+		strict: true,
+	});
+	expect(result.loadError).toBeInstanceOf(Error);
+	expect(result.issues).toEqual([]);
 });

--- a/packages/vite/src/validate.ts
+++ b/packages/vite/src/validate.ts
@@ -1,4 +1,4 @@
-import { type Issue, type OpenPolicyConfig, validate } from "@openpolicy/core";
+import { type Issue, type IssueCode, type OpenPolicyConfig, validate } from "@openpolicy/core";
 import { bundleRequire } from "bundle-require";
 import type { ScannerDiagnostic } from "./analyse";
 
@@ -9,6 +9,29 @@ export type ValidatedConfig = {
 };
 
 /**
+ * The Vite plugin's `strict` / `suppress` issue policy (PS-13). `validate()`
+ * itself stays pure and frozen; promotion/suppression is applied here, in the
+ * one OSS consumer of `validate()`.
+ */
+export type IssuePolicy = {
+	strict?: boolean;
+	suppress?: readonly IssueCode[];
+};
+
+/**
+ * Applies the {@link IssuePolicy} to a raw `validate()` result. Order matters:
+ * `suppress` drops every issue whose `code` matches FIRST (any level), then
+ * `strict` promotes the remaining warnings to errors — so a suppressed code is
+ * never promoted. Pure; an absent/empty policy is the identity transform.
+ */
+export function applyIssuePolicy(issues: Issue[], policy: IssuePolicy): Issue[] {
+	const suppressed = new Set<IssueCode>(policy.suppress ?? []);
+	const kept = suppressed.size > 0 ? issues.filter((i) => !suppressed.has(i.code)) : issues;
+	if (!policy.strict) return kept;
+	return kept.map((i) => (i.level === "warning" ? { ...i, level: "error" } : i));
+}
+
+/**
  * Loads the user's `openpolicy.ts` via bundle-require, then runs the single
  * `validate()` exported from `@openpolicy/core` against the resolved config.
  * The config imports its scanned values from the on-disk `./openpolicy.gen`
@@ -16,15 +39,20 @@ export type ValidatedConfig = {
  * interception shim is needed. The caller must have written `openpolicy.gen.ts`
  * (via `writeGenModule`) before calling this. `validate()` operates on the
  * flat config and emits each code at most once, so no dedupe pass is needed.
+ * The raw result is then run through {@link applyIssuePolicy} with the caller's
+ * `strict` / `suppress` options. `loadError` is independent of the policy —
+ * suppression never silences a config load/parse failure.
  *
  * Bundle-require errors (TS syntax errors, missing imports, runtime throws in
  * the user's config module) are surfaced as `loadError` rather than thrown so
  * the caller can decide whether to forward — TS errors should already be
  * caught by the user's type-check pipeline; we don't want to double-report.
  */
-export async function loadAndValidateConfig(args: {
-	configFile: string;
-}): Promise<ValidatedConfig> {
+export async function loadAndValidateConfig(
+	args: {
+		configFile: string;
+	} & IssuePolicy,
+): Promise<ValidatedConfig> {
 	let mod: { default?: OpenPolicyConfig };
 	try {
 		const result = await bundleRequire({
@@ -66,7 +94,10 @@ export async function loadAndValidateConfig(args: {
 
 	return {
 		config,
-		issues: validate(config),
+		issues: applyIssuePolicy(validate(config), {
+			strict: args.strict,
+			suppress: args.suppress,
+		}),
 		loadError: null,
 	};
 }


### PR DESCRIPTION
## Summary

Implements [PS-13](https://linear.app/open-policy/issue/PS-13): adds `strict` mode and per-`IssueCode` suppression to the `openPolicy()` Vite plugin, building on PS-11's single frozen `validate(config): Issue[]`.

- **`strict`** — promotes every remaining warning to an error, so warnings fail `vite build` like real errors.
- **`suppress`** — drops issues by `IssueCode` at **any** level (errors included).

**Design decision:** the config lives on the Vite plugin's `OpenPolicyOptions`, not on `OpenPolicyConfig`. The Vite plugin is the only OSS consumer of `validate()` (the CLI `validate` command was removed; the framework packages never call it; PolicyCloud §9 is out-of-repo), so config-carried options would be inert for non-Vite users. It is still committed, since it lives in `vite.config.ts`.

The strict/suppress transform is a pure, exported, unit-tested `applyIssuePolicy()` applied inside `loadAndValidateConfig()` — the single chokepoint both the build (`buildStart`) and dev (`runValidationDev`) paths already call. PS-11's frozen `validate(config): Issue[]` signature is untouched and no new `@openpolicy/core` export is added. The existing build/dev error-warn branching is unchanged: strict-promoted warnings arrive as `level: "error"` and abort the build automatically; suppressed codes simply vanish.

**Semantics:** `suppress` runs first (any level), then `strict` promotes the remainder — so a suppressed code is never promoted. `loadError` is independent; suppression never silences a config load/parse failure.

## Changes

- `packages/vite/src/validate.ts` — pure exported `applyIssuePolicy()` + `IssuePolicy` type; `loadAndValidateConfig` threads `strict`/`suppress`.
- `packages/vite/src/index.ts` — `strict?: boolean` / `suppress?: IssueCode[]` on `OpenPolicyOptions` (JSDoc'd), passed through both the build and dev validation paths.
- `packages/vite/README.md` — Options-table rows + a "Validation" section documenting the build/dev error-warn interaction and the suppress→strict ordering.
- `packages/core/src/types.ts` — corrected the now-stale "PS-13 may later…" comment (comment-only; `validate()` stays pure/frozen).
- `packages/vite/src/validate.test.ts` — 5 unit tests for `applyIssuePolicy` ordering + 3 integration tests through `loadAndValidateConfig`.

## Reviewer notes

- Branch is rebased onto `v1` (`d59d6a1`, PS-15 #117). An earlier "duplicate `IssueCode`" type error was a stale-base artifact from PS-11 and is already fixed on `v1` — not part of this PR.
- No `index.test.ts` build-mode test: its OS-temp dir can't resolve `@openpolicy/sdk`, so build tests there can only use stub `{}` configs (all-errors, where `strict` is a no-op). Promotion is proven in `validate.test.ts`, which uses package-relative temp dirs.
- Verification: `packages/core` & `packages/vite` `tsc --noEmit` clean; `vp test` (vite) 124/124 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)