### PR TITLE
feat(vite): fold OpenCookies scanner into one plugin (PS-19)

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -34,7 +34,8 @@
 	"dependencies": {
 		"@openpolicy/core": "workspace:*",
 		"bundle-require": "^5.1.0",
-		"oxc-parser": "^0.124.0"
+		"oxc-parser": "^0.124.0",
+		"tinyglobby": "^0.2.0"
 	},
 	"devDependencies": {
 		"@openpolicy/sdk": "workspace:*",

--- a/packages/vite/src/consent/__fixtures__/projects/gated-vs-ungated/expected.json
+++ b/packages/vite/src/consent/__fixtures__/projects/gated-vs-ungated/expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": { "count": 0, "kinds": [] },
+  "vendors": { "count": 2, "vendors": ["google-analytics", "google-analytics"] },
+  "ungated": { "exact": 1, "files": ["Ungated.tsx"] }
+}

--- a/packages/vite/src/consent/__fixtures__/projects/gated-vs-ungated/src/Gated.tsx
+++ b/packages/vite/src/consent/__fixtures__/projects/gated-vs-ungated/src/Gated.tsx
@@ -1,0 +1,10 @@
+export function Gated() {
+  return (
+    <ConsentGate purpose="analytics">
+      {(() => {
+        gtag("event", "page_view");
+        return null;
+      })()}
+    </ConsentGate>
+  );
+}

--- a/packages/vite/src/consent/__fixtures__/projects/gated-vs-ungated/src/Ungated.tsx
+++ b/packages/vite/src/consent/__fixtures__/projects/gated-vs-ungated/src/Ungated.tsx
@@ -1,0 +1,4 @@
+export function Ungated() {
+  gtag("event", "page_view");
+  return null;
+}

--- a/packages/vite/src/consent/__fixtures__/projects/nextjs-app/expected.json
+++ b/packages/vite/src/consent/__fixtures__/projects/nextjs-app/expected.json
@@ -1,0 +1,13 @@
+{
+  "cookies": {
+    "count": 3,
+    "kinds": ["next-headers", "next-headers", "react-cookie"]
+  },
+  "vendors": {
+    "count": 1,
+    "vendors": ["google-analytics"]
+  },
+  "ungated": {
+    "min": 1
+  }
+}

--- a/packages/vite/src/consent/__fixtures__/projects/nextjs-app/src/app/auth.ts
+++ b/packages/vite/src/consent/__fixtures__/projects/nextjs-app/src/app/auth.ts
@@ -1,0 +1,10 @@
+import { cookies } from "next/headers";
+
+export async function setSession(token: string) {
+  const c = await cookies();
+  c.set("session", token, { httpOnly: true });
+}
+
+export async function setRefresh(token: string) {
+  (await cookies()).set({ name: "refresh", value: token });
+}

--- a/packages/vite/src/consent/__fixtures__/projects/nextjs-app/src/app/layout.tsx
+++ b/packages/vite/src/consent/__fixtures__/projects/nextjs-app/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import Script from "next/script";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <head>
+        <Script id="ga" src="https://www.googletagmanager.com/gtag/js?id=G-XYZ" />
+      </head>
+      <body>
+        <ConsentGate purpose="analytics">
+          <GtagInit />
+        </ConsentGate>
+        {children}
+      </body>
+    </html>
+  );
+}
+
+function GtagInit() {
+  gtag("config", "G-XYZ");
+  return null;
+}

--- a/packages/vite/src/consent/__fixtures__/projects/nextjs-app/src/components/banner.tsx
+++ b/packages/vite/src/consent/__fixtures__/projects/nextjs-app/src/components/banner.tsx
@@ -1,0 +1,9 @@
+import { useCookies } from "react-cookie";
+
+export function Banner() {
+  const [, setCookie] = useCookies(["accepted"]);
+  function acceptAll() {
+    setCookie("accepted", "1", { path: "/" });
+  }
+  return <button onClick={acceptAll}>Accept</button>;
+}

--- a/packages/vite/src/consent/__fixtures__/projects/remix-app/app/analytics.ts
+++ b/packages/vite/src/consent/__fixtures__/projects/remix-app/app/analytics.ts
@@ -1,0 +1,3 @@
+import { AnalyticsBrowser } from "@segment/analytics-next";
+
+export const analytics = AnalyticsBrowser.load({ writeKey: "abc" });

--- a/packages/vite/src/consent/__fixtures__/projects/remix-app/app/loader.ts
+++ b/packages/vite/src/consent/__fixtures__/projects/remix-app/app/loader.ts
@@ -1,0 +1,13 @@
+export async function loader() {
+  return new Response("ok", {
+    headers: {
+      "Set-Cookie": "session=abc; HttpOnly",
+    },
+  });
+}
+
+export async function altLoader() {
+  const headers = new Headers();
+  headers.append("Set-Cookie", "tracking=1");
+  return new Response("ok", { headers });
+}

--- a/packages/vite/src/consent/__fixtures__/projects/remix-app/expected.json
+++ b/packages/vite/src/consent/__fixtures__/projects/remix-app/expected.json
@@ -1,0 +1,13 @@
+{
+  "cookies": {
+    "count": 2,
+    "kinds": ["set-cookie-header", "set-cookie-header"]
+  },
+  "vendors": {
+    "count": 1,
+    "vendors": ["segment"]
+  },
+  "ungated": {
+    "min": 2
+  }
+}

--- a/packages/vite/src/consent/__fixtures__/projects/svelte-app/expected.json
+++ b/packages/vite/src/consent/__fixtures__/projects/svelte-app/expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": { "count": 0, "kinds": [] },
+  "vendors": { "minCount": 1, "vendors": ["sentry"] },
+  "ungated": { "min": 1 }
+}

--- a/packages/vite/src/consent/__fixtures__/projects/svelte-app/src/App.svelte
+++ b/packages/vite/src/consent/__fixtures__/projects/svelte-app/src/App.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import * as Sentry from "@sentry/browser";
+
+  Sentry.init({ dsn: "https://example.ingest.sentry.io/1" });
+</script>
+
+<main>
+  <h1>App</h1>
+</main>

--- a/packages/vite/src/consent/__fixtures__/projects/vue-app/expected.json
+++ b/packages/vite/src/consent/__fixtures__/projects/vue-app/expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": { "count": 0, "kinds": [] },
+  "vendors": { "minCount": 1, "vendors": ["posthog"] },
+  "ungated": { "min": 1 }
+}

--- a/packages/vite/src/consent/__fixtures__/projects/vue-app/src/App.vue
+++ b/packages/vite/src/consent/__fixtures__/projects/vue-app/src/App.vue
@@ -1,0 +1,13 @@
+<template>
+  <button @click="track">Track</button>
+</template>
+
+<script setup lang="ts">
+import posthog from "posthog-js";
+
+posthog.init("phc_xxx", { api_host: "https://app.posthog.com" });
+
+function track() {
+  posthog.capture("button_click");
+}
+</script>

--- a/packages/vite/src/consent/__fixtures__/real-world/NOTICE.md
+++ b/packages/vite/src/consent/__fixtures__/real-world/NOTICE.md
@@ -1,0 +1,14 @@
+# Real-world fixture snippets
+
+These files are **hand-authored fixtures** that model patterns observed in
+public open-source projects (Cal.com, Documenso). They are not direct copies
+of code from those projects.
+
+The intent is to prove the scanner correctly identifies cookie writes and
+vendor scripts in idiomatic production code shapes, while keeping the test
+corpus small, deterministic, and free of any third-party licensing
+considerations.
+
+For full-app coverage against the upstream projects themselves, see the
+tarball-driven test suite under `tests/real-world/` (gated on
+`OPENCOOKIES_REAL_WORLD=1`).

--- a/packages/vite/src/consent/__fixtures__/real-world/calcom/Button.tsx
+++ b/packages/vite/src/consent/__fixtures__/real-world/calcom/Button.tsx
@@ -1,0 +1,10 @@
+// Pure UI component — must produce zero hits.
+import type { ButtonHTMLAttributes } from "react";
+
+export function Button({ children, ...rest }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button className="btn" {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/packages/vite/src/consent/__fixtures__/real-world/calcom/auth-cookie.ts
+++ b/packages/vite/src/consent/__fixtures__/real-world/calcom/auth-cookie.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { setCookie } from "cookies-next";
+
+export function setSessionCookie(req: NextApiRequest, res: NextApiResponse, token: string) {
+  setCookie("session", token, {
+    req,
+    res,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 7,
+    path: "/",
+  });
+}

--- a/packages/vite/src/consent/__fixtures__/real-world/calcom/middleware.ts
+++ b/packages/vite/src/consent/__fixtures__/real-world/calcom/middleware.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+  res.cookies.set("locale", req.headers.get("accept-language")?.split(",")[0] ?? "en");
+  return res;
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};

--- a/packages/vite/src/consent/__fixtures__/real-world/calcom/posthog-provider.tsx
+++ b/packages/vite/src/consent/__fixtures__/real-world/calcom/posthog-provider.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import posthog from "posthog-js";
+import { PostHogProvider as Provider } from "posthog-js/react";
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY ?? "", {
+      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+      person_profiles: "identified_only",
+      capture_pageview: false,
+    });
+  }, []);
+
+  return <Provider client={posthog}>{children}</Provider>;
+}

--- a/packages/vite/src/consent/__fixtures__/real-world/calcom/sentry-init.ts
+++ b/packages/vite/src/consent/__fixtures__/real-world/calcom/sentry-init.ts
@@ -1,0 +1,9 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: 0.1,
+  replaysSessionSampleRate: 0,
+  replaysOnErrorSampleRate: 0.1,
+  integrations: [Sentry.replayIntegration()],
+});

--- a/packages/vite/src/consent/__fixtures__/real-world/calcom/utils.ts
+++ b/packages/vite/src/consent/__fixtures__/real-world/calcom/utils.ts
@@ -1,0 +1,16 @@
+// Pure utilities — must produce zero hits.
+export function classNames(...names: (string | false | null | undefined)[]): string {
+  return names.filter(Boolean).join(" ");
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function debounce<T extends (...args: unknown[]) => unknown>(fn: T, ms: number): T {
+  let h: ReturnType<typeof setTimeout> | undefined;
+  return ((...args: unknown[]) => {
+    if (h) clearTimeout(h);
+    h = setTimeout(() => fn(...args), ms);
+  }) as T;
+}

--- a/packages/vite/src/consent/__fixtures__/real-world/documenso/Card.tsx
+++ b/packages/vite/src/consent/__fixtures__/real-world/documenso/Card.tsx
@@ -1,0 +1,10 @@
+// Pure UI primitive — must produce zero hits.
+import type { HTMLAttributes } from "react";
+
+export function Card({ children, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className="card rounded-lg border p-4" {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/packages/vite/src/consent/__fixtures__/real-world/documenso/cookies.ts
+++ b/packages/vite/src/consent/__fixtures__/real-world/documenso/cookies.ts
@@ -1,0 +1,17 @@
+import { cookies } from "next/headers";
+
+const COOKIE_NAME = "documenso.locale";
+
+export async function setLocaleCookie(locale: string) {
+  const store = await cookies();
+  store.set(COOKIE_NAME, locale, {
+    path: "/",
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+  });
+}
+
+export async function getLocaleCookie(): Promise<string | undefined> {
+  const store = await cookies();
+  return store.get(COOKIE_NAME)?.value;
+}

--- a/packages/vite/src/consent/__fixtures__/real-world/documenso/posthog.ts
+++ b/packages/vite/src/consent/__fixtures__/real-world/documenso/posthog.ts
@@ -1,0 +1,15 @@
+import { PostHog } from "posthog-node";
+
+let client: PostHog | null = null;
+
+export function getPostHog(): PostHog | null {
+  if (typeof window !== "undefined") return null;
+  if (client) return client;
+  if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return null;
+  client = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    flushAt: 1,
+    flushInterval: 0,
+  });
+  return client;
+}

--- a/packages/vite/src/consent/__fixtures__/real-world/documenso/route-handler.ts
+++ b/packages/vite/src/consent/__fixtures__/real-world/documenso/route-handler.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const body = JSON.stringify({ ok: true });
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Set-Cookie": "documenso.token=abc; Path=/; HttpOnly; Secure",
+    },
+  });
+}

--- a/packages/vite/src/consent/__fixtures__/real-world/documenso/server-utils.ts
+++ b/packages/vite/src/consent/__fixtures__/real-world/documenso/server-utils.ts
@@ -1,0 +1,17 @@
+// Server utilities — must produce zero hits.
+import { createHash } from "node:crypto";
+
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function compareSignatures(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+export const SIGNING_ALG = "sha256" as const;

--- a/packages/vite/src/consent/__fixtures__/rules/cookies-next/basic.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/cookies-next/basic.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "cookies-next", "line": 3, "name": "session" }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/cookies-next/basic.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/cookies-next/basic.ts
@@ -1,0 +1,3 @@
+import { setCookie } from "cookies-next";
+
+setCookie("session", "abc", { maxAge: 3600 });

--- a/packages/vite/src/consent/__fixtures__/rules/cookies-next/negative-local-fn.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/cookies-next/negative-local-fn.expected.json
@@ -1,0 +1,1 @@
+{ "cookies": [], "vendors": [], "ungated": [] }

--- a/packages/vite/src/consent/__fixtures__/rules/cookies-next/negative-local-fn.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/cookies-next/negative-local-fn.ts
@@ -1,0 +1,2 @@
+function setCookie(_name: string, _value: string): void {}
+setCookie("foo", "bar");

--- a/packages/vite/src/consent/__fixtures__/rules/cookies-next/nookies.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/cookies-next/nookies.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "cookies-next", "line": 3, "name": "tok" }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/cookies-next/nookies.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/cookies-next/nookies.ts
@@ -1,0 +1,3 @@
+import { setCookie } from "nookies";
+
+setCookie(null, "tok", "v", { path: "/" });

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/basic.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/basic.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "document.cookie", "line": 1, "column": 0, "name": "session" }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/basic.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/basic.ts
@@ -1,0 +1,1 @@
+document.cookie = "session=abc123";

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/in-function.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/in-function.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "document.cookie", "line": 2, "column": 2 }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/in-function.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/in-function.ts
@@ -1,0 +1,3 @@
+export function setSession(token: string): void {
+  document.cookie = `session=${token}`;
+}

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/negative-other-object.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/negative-other-object.expected.json
@@ -1,0 +1,1 @@
+{ "cookies": [], "vendors": [], "ungated": [] }

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/negative-other-object.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/negative-other-object.ts
@@ -1,0 +1,3 @@
+type Doc = { cookie: string };
+const doc: Doc = { cookie: "" };
+doc.cookie = "not-a-real-cookie";

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/negative-string-literal.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/negative-string-literal.expected.json
@@ -1,0 +1,1 @@
+{ "cookies": [], "vendors": [], "ungated": [] }

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/negative-string-literal.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/negative-string-literal.ts
@@ -1,0 +1,2 @@
+const example = "document.cookie = 'foo'";
+console.log(example);

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/template-literal.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/template-literal.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "document.cookie", "line": 2, "column": 0 }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/document-cookie/template-literal.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/document-cookie/template-literal.ts
@@ -1,0 +1,2 @@
+const value = "x";
+document.cookie = `consent=${value}; path=/`;

--- a/packages/vite/src/consent/__fixtures__/rules/js-cookie/basic.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/js-cookie/basic.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "js-cookie", "line": 3, "name": "session" }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/js-cookie/basic.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/js-cookie/basic.ts
@@ -1,0 +1,4 @@
+import Cookies from "js-cookie";
+
+Cookies.set("session", "abc");
+Cookies.remove("session");

--- a/packages/vite/src/consent/__fixtures__/rules/js-cookie/negative-different-package.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/js-cookie/negative-different-package.expected.json
@@ -1,0 +1,1 @@
+{ "cookies": [], "vendors": [], "ungated": [] }

--- a/packages/vite/src/consent/__fixtures__/rules/js-cookie/negative-different-package.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/js-cookie/negative-different-package.ts
@@ -1,0 +1,3 @@
+import Cookies from "some-other-cookies-lib";
+
+Cookies.set("ignored", "x");

--- a/packages/vite/src/consent/__fixtures__/rules/next-headers/basic.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/next-headers/basic.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "next-headers", "line": 5, "name": "session" }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/next-headers/basic.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/next-headers/basic.ts
@@ -1,0 +1,6 @@
+import { cookies } from "next/headers";
+
+export async function setSession(token: string): Promise<void> {
+  const c = await cookies();
+  c.set("session", token);
+}

--- a/packages/vite/src/consent/__fixtures__/rules/next-headers/negative-other-cookies.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/next-headers/negative-other-cookies.expected.json
@@ -1,0 +1,1 @@
+{ "cookies": [], "vendors": [], "ungated": [] }

--- a/packages/vite/src/consent/__fixtures__/rules/next-headers/negative-other-cookies.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/next-headers/negative-other-cookies.ts
@@ -1,0 +1,3 @@
+import { cookies } from "some-cookie-lib";
+
+cookies().set("ignored", "x");

--- a/packages/vite/src/consent/__fixtures__/rules/next-headers/object-form.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/next-headers/object-form.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "next-headers", "line": 4, "name": "tok" }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/next-headers/object-form.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/next-headers/object-form.ts
@@ -1,0 +1,5 @@
+import { cookies } from "next/headers";
+
+export function setIt() {
+  cookies().set({ name: "tok", value: "v", path: "/" });
+}

--- a/packages/vite/src/consent/__fixtures__/rules/react-cookie/basic.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/react-cookie/basic.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "react-cookie", "line": 6, "name": "consent" }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/react-cookie/basic.tsx
+++ b/packages/vite/src/consent/__fixtures__/rules/react-cookie/basic.tsx
@@ -1,0 +1,7 @@
+import { useCookies } from "react-cookie";
+
+export function Banner() {
+  const [cookies, setCookie] = useCookies(["consent"]);
+  void cookies;
+  return <button onClick={() => setCookie("consent", "yes", { path: "/" })}>OK</button>;
+}

--- a/packages/vite/src/consent/__fixtures__/rules/react-cookie/negative-no-import.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/react-cookie/negative-no-import.expected.json
@@ -1,0 +1,1 @@
+{ "cookies": [], "vendors": [], "ungated": [] }

--- a/packages/vite/src/consent/__fixtures__/rules/react-cookie/negative-no-import.tsx
+++ b/packages/vite/src/consent/__fixtures__/rules/react-cookie/negative-no-import.tsx
@@ -1,0 +1,6 @@
+function setCookie(_n: string, _v: string): void {}
+
+export function X() {
+  setCookie("x", "y");
+  return null;
+}

--- a/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/headers-set.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/headers-set.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "set-cookie-header", "line": 2 }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/headers-set.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/headers-set.ts
@@ -1,0 +1,3 @@
+export function withCookie(headers: Headers) {
+  headers.append("Set-Cookie", "id=42");
+}

--- a/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/negative-string-key.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/negative-string-key.expected.json
@@ -1,0 +1,1 @@
+{ "cookies": [], "vendors": [], "ungated": [] }

--- a/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/negative-string-key.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/negative-string-key.ts
@@ -1,0 +1,4 @@
+const docs = {
+  "Set-Cookie": "this is just an unrelated map of header names to descriptions",
+};
+console.log(docs);

--- a/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/response.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/response.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [{ "kind": "set-cookie-header", "line": 4 }],
+  "vendors": [],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/response.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/set-cookie-header/response.ts
@@ -1,0 +1,7 @@
+export function loader() {
+  return new Response("ok", {
+    headers: {
+      "Set-Cookie": "session=abc; Path=/",
+    },
+  });
+}

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/dynamic-import.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/dynamic-import.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [],
+  "vendors": [{ "vendor": "mixpanel", "category": "analytics", "via": "import", "line": 2 }],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/dynamic-import.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/dynamic-import.ts
@@ -1,0 +1,5 @@
+async function load() {
+  const mod = await import("mixpanel-browser");
+  mod.default.init("token");
+}
+void load();

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/gtag-global.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/gtag-global.expected.json
@@ -1,0 +1,7 @@
+{
+  "cookies": [],
+  "vendors": [
+    { "vendor": "google-analytics", "category": "analytics", "via": "global", "line": 4 }
+  ],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/gtag-global.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/gtag-global.ts
@@ -1,0 +1,4 @@
+// gtag is provided via the GA tag script
+// declared in __fixtures__/types.d.ts
+
+gtag("event", "page_view");

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/negative-shadowed.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/negative-shadowed.expected.json
@@ -1,0 +1,1 @@
+{ "cookies": [], "vendors": [], "ungated": [] }

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/negative-shadowed.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/negative-shadowed.ts
@@ -1,0 +1,7 @@
+function gtag(_event: string): void {
+  // local helper, not the GA global
+}
+gtag("ignored");
+
+const fbq = (..._args: unknown[]) => {};
+fbq("track", "PageView");

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/negative-string-similarity.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/negative-string-similarity.expected.json
@@ -1,0 +1,1 @@
+{ "cookies": [], "vendors": [], "ungated": [] }

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/negative-string-similarity.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/negative-string-similarity.ts
@@ -1,0 +1,3 @@
+const url = "https://googletagmanager.com/gtag/js";
+const note = "import posthog-js";
+console.log(url, note);

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/posthog-import.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/posthog-import.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [],
+  "vendors": [{ "vendor": "posthog", "category": "analytics", "via": "import", "line": 1 }],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/posthog-import.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/posthog-import.ts
@@ -1,0 +1,3 @@
+import posthog from "posthog-js";
+
+posthog.init("phc_123");

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/segment-subpath.expected.json
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/segment-subpath.expected.json
@@ -1,0 +1,5 @@
+{
+  "cookies": [],
+  "vendors": [{ "vendor": "segment", "category": "analytics", "via": "import", "line": 1 }],
+  "ungated": []
+}

--- a/packages/vite/src/consent/__fixtures__/rules/vendor-imports/segment-subpath.ts
+++ b/packages/vite/src/consent/__fixtures__/rules/vendor-imports/segment-subpath.ts
@@ -1,0 +1,4 @@
+import { AnalyticsBrowser } from "@segment/analytics-next";
+
+const a = AnalyticsBrowser.load({ writeKey: "x" });
+void a;

--- a/packages/vite/src/consent/__fixtures__/types.d.ts
+++ b/packages/vite/src/consent/__fixtures__/types.d.ts
@@ -1,0 +1,124 @@
+// Module + global declarations so the fixture corpus type-checks cleanly
+// without installing every analytics/cookie SDK.
+
+declare module "js-cookie" {
+  const Cookies: {
+    set(name: string, value: string, opts?: Record<string, unknown>): void;
+    get(name?: string): string | undefined;
+    remove(name: string, opts?: Record<string, unknown>): void;
+  };
+  export default Cookies;
+}
+
+declare module "cookies-next" {
+  export function setCookie(...args: unknown[]): void;
+  export function getCookie(...args: unknown[]): string | undefined;
+  export function deleteCookie(...args: unknown[]): void;
+}
+
+declare module "nookies" {
+  export function setCookie(...args: unknown[]): void;
+}
+
+declare module "react-cookie" {
+  export function useCookies(
+    deps?: string[],
+  ): [Record<string, string>, (name: string, value: string, opts?: unknown) => void];
+}
+
+declare module "next/headers" {
+  type CookieStore = {
+    get(name: string): { value: string } | undefined;
+    set(name: string, value: string, opts?: unknown): void;
+    set(opts: { name: string; value: string; path?: string }): void;
+  };
+  export function cookies(): Promise<CookieStore> & CookieStore;
+}
+
+declare module "next/server" {
+  export class NextResponse extends Response {
+    static next(): NextResponse;
+    cookies: { set(name: string, value: string, opts?: unknown): void };
+  }
+  export type NextRequest = Request & { headers: Headers };
+}
+
+declare module "next/script" {
+  const Script: (props: Record<string, unknown>) => unknown;
+  export default Script;
+}
+
+declare module "next" {
+  export type NextApiRequest = unknown;
+  export type NextApiResponse = unknown;
+}
+
+declare module "posthog-js" {
+  const posthog: {
+    init(key: string, opts?: Record<string, unknown>): void;
+    capture(event: string, props?: unknown): void;
+  };
+  export default posthog;
+}
+
+declare module "posthog-js/react" {
+  export const PostHogProvider: (props: Record<string, unknown>) => unknown;
+}
+
+declare module "posthog-node" {
+  export class PostHog {
+    constructor(key: string, opts?: Record<string, unknown>);
+  }
+}
+
+declare module "@segment/analytics-next" {
+  export const AnalyticsBrowser: { load(opts: { writeKey: string }): unknown };
+}
+
+declare module "@sentry/nextjs" {
+  export function init(opts: Record<string, unknown>): void;
+  export function replayIntegration(): unknown;
+}
+
+declare module "@sentry/browser" {
+  export function init(opts: Record<string, unknown>): void;
+}
+
+declare module "some-other-cookies-lib" {
+  const Cookies: { set(name: string, value: string): void };
+  export default Cookies;
+}
+
+declare module "some-cookie-lib" {
+  export function cookies(): { set(name: string, value: string): void };
+}
+
+declare module "mixpanel-browser" {
+  const m: { init(token: string): void };
+  export default m;
+}
+
+declare const gtag: (...args: unknown[]) => void;
+declare const fbq: (...args: unknown[]) => void;
+declare const posthog: {
+  init(key: string, opts?: Record<string, unknown>): void;
+  capture(event: string, props?: unknown): void;
+};
+declare const ConsentGate: (props: Record<string, unknown>) => unknown;
+
+declare module "react" {
+  export type ReactNode = unknown;
+  export type ButtonHTMLAttributes<T> = Record<string, unknown> & { children?: ReactNode };
+  export type HTMLAttributes<T> = Record<string, unknown> & { children?: ReactNode };
+  export function useEffect(fn: () => void, deps?: unknown[]): void;
+  export function useState<T>(initial: T): [T, (next: T) => void];
+}
+
+declare namespace React {
+  type ReactNode = unknown;
+}
+
+declare namespace JSX {
+  type Element = unknown;
+  type IntrinsicElements = Record<string, Record<string, unknown>>;
+}

--- a/packages/vite/src/consent/example-green.test.ts
+++ b/packages/vite/src/consent/example-green.test.ts
@@ -1,0 +1,25 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+import { scan } from "./scan";
+
+// Encodes PS-19's acceptance criterion as a regression test: the one canonical
+// scanner-wired example must stay "green" — i.e. the folded consent scanner
+// finds zero ungated cookie/vendor usage in it. src/consent → src → vite →
+// packages → repo root → examples/tanstack.
+const EXAMPLE = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"..",
+	"..",
+	"..",
+	"examples",
+	"tanstack",
+);
+
+describe("canonical example stays green", () => {
+	it("has zero ungated consent findings", async () => {
+		const result = await scan({ cwd: EXAMPLE });
+		expect(result.ungated).toEqual([]);
+	});
+});

--- a/packages/vite/src/consent/index.ts
+++ b/packages/vite/src/consent/index.ts
@@ -1,0 +1,37 @@
+import type { Rule } from "./types";
+
+export { scan, defaultRules, defaultVendors } from "./scan";
+export { parseFile } from "./parser";
+export { applySuppressions } from "./suppress";
+export { cookiesNextRule } from "./rules/cookies-next";
+export { documentCookieRule } from "./rules/document-cookie";
+export { jsCookieRule } from "./rules/js-cookie";
+export { nextHeadersRule } from "./rules/next-headers";
+export { reactCookieRule } from "./rules/react-cookie";
+export { setCookieHeaderRule } from "./rules/set-cookie-header";
+export { vendorImportsRule } from "./rules/vendor-imports";
+export { calleeMatches, getStringArg, isCallTo, walk } from "./visit";
+export type { WalkResult } from "./visit";
+export type {
+	AnyNode,
+	Cookie,
+	CookieKind,
+	Hit,
+	ImportInfo,
+	Lang,
+	ParsedComment,
+	ParsedFile,
+	Rule,
+	ScanOptions,
+	ScanResult,
+	Ungated,
+	VendorEntry,
+	VendorHit,
+	VendorRegistry,
+	VendorVia,
+	VisitContext,
+} from "./types";
+
+export function defineRule(rule: Rule): Rule {
+	return rule;
+}

--- a/packages/vite/src/consent/parser.test.ts
+++ b/packages/vite/src/consent/parser.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseFile, positionFor } from "./parser";
+import { extractScripts } from "./sfc";
+
+describe("parseFile", () => {
+	it("parses a TS file", () => {
+		const r = parseFile("a.ts", "const x: number = 1;\ndocument.cookie = 'a';");
+		expect(r).not.toBeNull();
+		expect(r?.lang).toBe("ts");
+		expect(r?.ast.type).toBe("Program");
+	});
+
+	it("parses TSX with JSX", () => {
+		const r = parseFile("a.tsx", "const C = () => <div>hi</div>;");
+		expect(r?.lang).toBe("tsx");
+	});
+
+	it("returns null for unsupported extensions", () => {
+		expect(parseFile("a.css", "body{}")).toBeNull();
+	});
+
+	it("captures comments with absolute line numbers", () => {
+		const src = "// hi\nconst x = 1;\n// opencookies-ignore-next-line\ndocument.cookie='a';";
+		const r = parseFile("a.ts", src);
+		expect(r?.comments.map((c) => c.line)).toEqual([1, 3]);
+	});
+
+	it("parses a Vue SFC <script> block", () => {
+		const src = `<template><div /></template>\n<script setup lang="ts">\ndocument.cookie = 'a';\n</script>`;
+		const r = parseFile("a.vue", src);
+		expect(r).not.toBeNull();
+		expect(r?.lineOffset).toBe(1);
+	});
+
+	it("parses a Svelte SFC <script> block", () => {
+		const src = `<script lang="ts">\nlet x = 1;\n</script>\n<div>{x}</div>`;
+		const r = parseFile("a.svelte", src);
+		expect(r).not.toBeNull();
+		expect(r?.lang).toBe("ts");
+	});
+});
+
+describe("extractScripts", () => {
+	it("extracts a single script block with line offset", () => {
+		const blocks = extractScripts(
+			"<template>\n  <div/>\n</template>\n<script>\nconsole.log(1);\n</script>",
+		);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0]?.startLine).toBe(3);
+		expect(blocks[0]?.source.trim()).toBe("console.log(1);");
+	});
+
+	it("respects lang attribute", () => {
+		const blocks = extractScripts(`<script lang="ts">const x: number = 1;</script>`);
+		expect(blocks[0]?.lang).toBe("ts");
+	});
+});
+
+describe("positionFor", () => {
+	it("returns 1-indexed line and 0-indexed column", () => {
+		expect(positionFor("ab\ncd", 0)).toEqual({ line: 1, column: 0 });
+		expect(positionFor("ab\ncd", 3)).toEqual({ line: 2, column: 0 });
+		expect(positionFor("ab\ncd", 4)).toEqual({ line: 2, column: 1 });
+	});
+});

--- a/packages/vite/src/consent/parser.ts
+++ b/packages/vite/src/consent/parser.ts
@@ -1,0 +1,161 @@
+import { parseSync } from "oxc-parser";
+import { extractScripts } from "./sfc";
+import type { AnyNode, ImportInfo, Lang, ParsedComment, ParsedFile } from "./types";
+
+const langByExt: Record<string, Lang> = {
+	js: "js",
+	mjs: "js",
+	cjs: "js",
+	jsx: "jsx",
+	ts: "ts",
+	mts: "ts",
+	cts: "ts",
+	tsx: "tsx",
+};
+
+export function langFor(file: string): Lang | null {
+	const ext = file.slice(file.lastIndexOf(".") + 1).toLowerCase();
+	if (ext === "vue" || ext === "svelte") return "ts";
+	return langByExt[ext] ?? null;
+}
+
+export function parseFile(file: string, source: string): ParsedFile | null {
+	const ext = file.slice(file.lastIndexOf(".") + 1).toLowerCase();
+	if (ext === "vue" || ext === "svelte") {
+		const blocks = extractScripts(source);
+		if (blocks.length === 0) return null;
+		const block = blocks[0]!;
+		const lang = block.lang ?? "ts";
+		return parsePlain(file, block.source, lang, block.startLine);
+	}
+	const lang = langFor(file);
+	if (!lang) return null;
+	return parsePlain(file, source, lang, 0);
+}
+
+function parsePlain(
+	file: string,
+	source: string,
+	lang: Lang,
+	lineOffset: number,
+): ParsedFile | null {
+	const result = parseSync(file, source, { lang });
+	const comments: ParsedComment[] = result.comments.map((c) => ({
+		type: c.type,
+		value: c.value,
+		line: lineFor(source, c.start) + lineOffset,
+	}));
+	const ast = result.program as unknown as AnyNode;
+	return {
+		file,
+		source,
+		lang,
+		ast,
+		comments,
+		lineOffset,
+		localBindings: collectTopLevelBindings(ast),
+		imports: collectImports(ast),
+	};
+}
+
+function collectImports(program: AnyNode): Map<string, ImportInfo> {
+	const out = new Map<string, ImportInfo>();
+	const body = program.body as AnyNode[] | undefined;
+	if (!body) return out;
+	for (const node of body) {
+		if (node.type !== "ImportDeclaration") continue;
+		const src = node.source as AnyNode | undefined;
+		if (src?.type !== "Literal" || typeof src.value !== "string") continue;
+		const source = src.value;
+		for (const spec of (node.specifiers as AnyNode[] | undefined) ?? []) {
+			const local = spec.local as AnyNode | undefined;
+			if (local?.type !== "Identifier") continue;
+			let imported = "default";
+			if (spec.type === "ImportSpecifier") {
+				const imp = spec.imported as AnyNode | undefined;
+				if (imp?.type === "Identifier") imported = imp.name as string;
+				else if (imp?.type === "Literal" && typeof imp.value === "string") imported = imp.value;
+			} else if (spec.type === "ImportNamespaceSpecifier") {
+				imported = "*";
+			}
+			out.set(local.name as string, { source, imported });
+		}
+	}
+	return out;
+}
+
+function collectTopLevelBindings(program: AnyNode): Set<string> {
+	const out = new Set<string>();
+	const body = program.body as AnyNode[] | undefined;
+	if (!body) return out;
+	for (const node of body) {
+		if (node.type === "ImportDeclaration") {
+			for (const spec of (node.specifiers as AnyNode[] | undefined) ?? []) {
+				const local = spec.local as AnyNode | undefined;
+				if (local?.type === "Identifier") out.add(local.name as string);
+			}
+		} else if (node.type === "VariableDeclaration") {
+			for (const decl of (node.declarations as AnyNode[] | undefined) ?? []) {
+				addPatternNames(decl.id as AnyNode | undefined, out);
+			}
+		} else if (node.type === "FunctionDeclaration" || node.type === "ClassDeclaration") {
+			const id = node.id as AnyNode | undefined;
+			if (id?.type === "Identifier") out.add(id.name as string);
+		} else if (node.type === "ExportNamedDeclaration") {
+			const decl = node.declaration as AnyNode | undefined;
+			if (decl) collectFromDecl(decl, out);
+		}
+	}
+	return out;
+}
+
+function collectFromDecl(decl: AnyNode, out: Set<string>): void {
+	if (decl.type === "VariableDeclaration") {
+		for (const d of (decl.declarations as AnyNode[] | undefined) ?? []) {
+			addPatternNames(d.id as AnyNode | undefined, out);
+		}
+	} else if (decl.type === "FunctionDeclaration" || decl.type === "ClassDeclaration") {
+		const id = decl.id as AnyNode | undefined;
+		if (id?.type === "Identifier") out.add(id.name as string);
+	}
+}
+
+function addPatternNames(node: AnyNode | undefined, out: Set<string>): void {
+	if (!node) return;
+	if (node.type === "Identifier") {
+		out.add(node.name as string);
+	} else if (node.type === "ObjectPattern") {
+		for (const p of (node.properties as AnyNode[] | undefined) ?? []) {
+			if (p.type === "Property") addPatternNames(p.value as AnyNode | undefined, out);
+			else if (p.type === "RestElement") addPatternNames(p.argument as AnyNode | undefined, out);
+		}
+	} else if (node.type === "ArrayPattern") {
+		for (const e of (node.elements as AnyNode[] | undefined) ?? []) {
+			if (e) addPatternNames(e, out);
+		}
+	} else if (node.type === "AssignmentPattern") {
+		addPatternNames(node.left as AnyNode | undefined, out);
+	} else if (node.type === "RestElement") {
+		addPatternNames(node.argument as AnyNode | undefined, out);
+	}
+}
+
+export function lineFor(source: string, offset: number): number {
+	let line = 1;
+	for (let i = 0; i < offset && i < source.length; i++) {
+		if (source.charCodeAt(i) === 10) line++;
+	}
+	return line;
+}
+
+export function positionFor(source: string, offset: number): { line: number; column: number } {
+	let line = 1;
+	let lastNl = -1;
+	for (let i = 0; i < offset && i < source.length; i++) {
+		if (source.charCodeAt(i) === 10) {
+			line++;
+			lastNl = i;
+		}
+	}
+	return { line, column: offset - lastNl - 1 };
+}

--- a/packages/vite/src/consent/plugin-fold.test.ts
+++ b/packages/vite/src/consent/plugin-fold.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { openPolicy } from "../index";
+
+// Proves PS-19's core invariant: ONE plugin object carries both rule sets.
+// The OpenCookies consent scan is folded into the same `openPolicy()` plugin
+// (no second exported plugin) and is opt-in via the `consent` option.
+
+type AnyFn = (...args: unknown[]) => unknown;
+
+type LoggerCapture = {
+	logger: { info: AnyFn; warn: AnyFn; error: AnyFn };
+	infos: string[];
+	warns: string[];
+	errors: string[];
+};
+
+function captureLogger(): LoggerCapture {
+	const infos: string[] = [];
+	const warns: string[] = [];
+	const errors: string[] = [];
+	return {
+		infos,
+		warns,
+		errors,
+		logger: {
+			info: (m: unknown) => infos.push(String(m)),
+			warn: (m: unknown) => warns.push(String(m)),
+			error: (m: unknown) => errors.push(String(m)),
+		},
+	};
+}
+
+// Minimal Rollup PluginContext stub. `error` throws (Rollup contract); the
+// consent path must never reach it — only `buildEnd` aborts.
+function pluginCtx(): { warn: AnyFn; error: AnyFn } {
+	return {
+		warn: () => {},
+		error: (m: unknown) => {
+			throw new Error(String(m));
+		},
+	};
+}
+
+async function driveBuild(
+	plugin: ReturnType<typeof openPolicy>,
+	root: string,
+	cap: LoggerCapture,
+): Promise<void> {
+	const configResolved = plugin.configResolved as AnyFn;
+	await configResolved({ root, command: "build", logger: cap.logger });
+	const buildStart = plugin.buildStart as AnyFn;
+	await buildStart.call(pluginCtx());
+}
+
+function callBuildEnd(plugin: ReturnType<typeof openPolicy>): void {
+	(plugin.buildEnd as AnyFn).call({});
+}
+
+let tmp: string;
+beforeEach(async () => {
+	tmp = await mkdtemp(join(tmpdir(), "openpolicy-consent-fold-"));
+});
+afterEach(async () => {
+	await rm(tmp, { recursive: true, force: true });
+});
+
+describe("PS-19 single-plugin fold", () => {
+	it("exposes one plugin with both rule sets' lifecycle hooks", () => {
+		const plugin = openPolicy({ consent: { mode: "warn" } });
+		expect(plugin.name).toBe("openpolicy");
+		expect(typeof plugin.buildStart).toBe("function");
+		expect(typeof plugin.configureServer).toBe("function");
+		// `buildEnd` is the consent build-fail seam added by PS-19.
+		expect(typeof plugin.buildEnd).toBe("function");
+	});
+
+	it("is fully inert when the `consent` option is omitted", async () => {
+		await writeFile(join(tmp, "track.ts"), "document.cookie = 'x=1';\n");
+		const plugin = openPolicy();
+		const cap = captureLogger();
+		await driveBuild(plugin, tmp, cap);
+		// No consent option → no consent scan, no findings logged, buildEnd
+		// never throws even though an ungated write exists.
+		expect(cap.errors).toEqual([]);
+		expect(() => callBuildEnd(plugin)).not.toThrow();
+	});
+
+	it("mode:'error' fails the build from buildEnd on an ungated write", async () => {
+		await writeFile(join(tmp, "track.ts"), "document.cookie = 'x=1';\n");
+		const plugin = openPolicy({ consent: { mode: "error" } });
+		const cap = captureLogger();
+		await driveBuild(plugin, tmp, cap);
+		expect(cap.errors.some((m) => m.includes("ungated"))).toBe(true);
+		expect(() => callBuildEnd(plugin)).toThrow(/ungated finding/);
+	});
+
+	it("mode:'warn' logs but never fails the build", async () => {
+		await writeFile(join(tmp, "track.ts"), "document.cookie = 'x=1';\n");
+		const plugin = openPolicy({ consent: { mode: "warn" } });
+		const cap = captureLogger();
+		await driveBuild(plugin, tmp, cap);
+		expect(cap.warns.some((m) => m.includes("ungated"))).toBe(true);
+		expect(() => callBuildEnd(plugin)).not.toThrow();
+	});
+});

--- a/packages/vite/src/consent/projects.test.ts
+++ b/packages/vite/src/consent/projects.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+import { scan } from "./scan";
+
+const PROJECTS_DIR = join(dirname(fileURLToPath(import.meta.url)), "__fixtures__", "projects");
+
+type Expectation = {
+	cookies: { count?: number; minCount?: number; kinds?: string[] };
+	vendors: { count?: number; minCount?: number; vendors?: string[] };
+	ungated: { min?: number; exact?: number; files?: string[] };
+};
+
+const projects = readdirSync(PROJECTS_DIR).filter((p) =>
+	statSync(join(PROJECTS_DIR, p)).isDirectory(),
+);
+
+describe("integrated projects", () => {
+	for (const name of projects) {
+		it(name, async () => {
+			const dir = join(PROJECTS_DIR, name);
+			const expected = JSON.parse(readFileSync(join(dir, "expected.json"), "utf8")) as Expectation;
+			const result = await scan({ cwd: dir });
+
+			if (typeof expected.cookies.count === "number") {
+				expect(result.cookies).toHaveLength(expected.cookies.count);
+			}
+			if (typeof expected.cookies.minCount === "number") {
+				expect(result.cookies.length).toBeGreaterThanOrEqual(expected.cookies.minCount);
+			}
+			if (expected.cookies.kinds) {
+				expect(result.cookies.map((c) => c.kind).sort()).toEqual(
+					expected.cookies.kinds.slice().sort(),
+				);
+			}
+
+			if (typeof expected.vendors.count === "number") {
+				expect(result.vendors).toHaveLength(expected.vendors.count);
+			}
+			if (typeof expected.vendors.minCount === "number") {
+				expect(result.vendors.length).toBeGreaterThanOrEqual(expected.vendors.minCount);
+			}
+			if (expected.vendors.vendors) {
+				for (const v of expected.vendors.vendors) {
+					expect(result.vendors.map((h) => h.vendor)).toContain(v);
+				}
+			}
+
+			if (typeof expected.ungated.min === "number") {
+				expect(result.ungated.length).toBeGreaterThanOrEqual(expected.ungated.min);
+			}
+			if (typeof expected.ungated.exact === "number") {
+				expect(result.ungated).toHaveLength(expected.ungated.exact);
+			}
+			if (expected.ungated.files) {
+				for (const f of expected.ungated.files) {
+					expect(result.ungated.some((u) => u.file.endsWith(f))).toBe(true);
+				}
+			}
+		});
+	}
+});

--- a/packages/vite/src/consent/real-world.test.ts
+++ b/packages/vite/src/consent/real-world.test.ts
@@ -1,0 +1,65 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+import { scan } from "./scan";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "__fixtures__", "real-world");
+
+const cleanFiles = [
+	"calcom/utils.ts",
+	"calcom/Button.tsx",
+	"documenso/server-utils.ts",
+	"documenso/Card.tsx",
+];
+
+type Expectation = {
+	file: string;
+	cookies?: string[];
+	vendors?: string[];
+};
+
+const expectations: Expectation[] = [
+	{ file: "calcom/posthog-provider.tsx", vendors: ["posthog"] },
+	{ file: "calcom/auth-cookie.ts", cookies: ["cookies-next"] },
+	{ file: "calcom/sentry-init.ts", vendors: ["sentry"] },
+	{ file: "calcom/middleware.ts", cookies: [] },
+	{ file: "documenso/posthog.ts", vendors: ["posthog"] },
+	{ file: "documenso/cookies.ts", cookies: ["next-headers"] },
+	{ file: "documenso/route-handler.ts", cookies: ["set-cookie-header"] },
+];
+
+describe("real-world snippets", () => {
+	it("produces zero hits on clean files", async () => {
+		const result = await scan({ cwd: ROOT });
+		for (const clean of cleanFiles) {
+			const fromFile = [
+				...result.cookies.filter((h) => h.file.endsWith(clean)),
+				...result.vendors.filter((h) => h.file.endsWith(clean)),
+			];
+			expect(fromFile, `expected zero hits in ${clean}`).toEqual([]);
+		}
+	});
+
+	it("detects every expected hit", async () => {
+		const result = await scan({ cwd: ROOT });
+		for (const exp of expectations) {
+			const hits = {
+				cookies: result.cookies.filter((h) => h.file.endsWith(exp.file)),
+				vendors: result.vendors.filter((h) => h.file.endsWith(exp.file)),
+			};
+			if (exp.cookies) {
+				expect(hits.cookies.map((h) => h.kind).sort(), `cookie kinds in ${exp.file}`).toEqual(
+					exp.cookies.slice().sort(),
+				);
+			}
+			if (exp.vendors) {
+				for (const v of exp.vendors) {
+					expect(
+						hits.vendors.map((h) => h.vendor),
+						`${v} hit in ${exp.file}`,
+					).toContain(v);
+				}
+			}
+		}
+	});
+});

--- a/packages/vite/src/consent/reporter.ts
+++ b/packages/vite/src/consent/reporter.ts
@@ -1,0 +1,113 @@
+import { relative } from "node:path";
+import type { Cookie, Hit, ScanResult, Ungated, VendorHit } from "./types";
+
+/**
+ * Build → fail (`buildEnd` throws); serve → warn; `off` → consent scan is
+ * skipped entirely. Omitting the `consent` option leaves the scan off.
+ */
+export type Mode = "warn" | "error" | "off";
+
+export type Logger = {
+	info: (msg: string) => void;
+	warn: (msg: string) => void;
+	error: (msg: string) => void;
+};
+
+const PREFIX = "[opencookies]";
+
+const FIX_HINTS: Record<string, string> = {
+	"vendor-imports":
+		'wrap call sites in <ConsentGate category="…"> or guard with store.has("category")',
+	"document-cookie": "set the cookie inside a setter that checks consent first",
+	"js-cookie": 'guard Cookies.set behind store.has("category")',
+	"cookies-next": 'guard setCookie/deleteCookie behind store.has("category")',
+	"react-cookie": "call setCookie inside a handler that checks consent first",
+	"next-headers":
+		"set cookies only on responses for routes that require consent (or behind a server-side gate)",
+	"set-cookie-header": "only attach Set-Cookie when the requesting category is granted",
+};
+
+export function formatHitLocation(hit: Hit, root: string): string {
+	const rel = toRel(hit.file, root);
+	return `${rel}:${hit.line}:${hit.column}`;
+}
+
+function toRel(file: string, root: string): string {
+	const r = relative(root, file);
+	return r === "" || r.startsWith("..") ? file : r;
+}
+
+function describeHit(hit: Hit): string {
+	if ("kind" in hit) {
+		const named = hit.name ? ` "${hit.name}"` : "";
+		return `cookie write${named} via ${hit.kind}`;
+	}
+	return `${hit.vendor} (${hit.category}) call via ${hit.via}`;
+}
+
+function ruleNameFor(hit: Hit): string {
+	if ("kind" in hit) return hit.kind;
+	return "vendor-imports";
+}
+
+export function formatUngated(u: Ungated, root: string): string {
+	const loc = formatHitLocation(u.hit, root);
+	const rule = ruleNameFor(u.hit);
+	const fix = FIX_HINTS[rule] ?? "wrap the call in a consent gate";
+	return [
+		`${PREFIX} ungated ${describeHit(u.hit)} at ${loc}`,
+		`  Rule: ${rule}`,
+		`  Fix: ${fix}`,
+		`  Suppress: // opencookies-ignore-next-line`,
+	].join("\n");
+}
+
+export function formatSummary(result: ScanResult): string {
+	const { cookies, vendors, ungated } = result;
+	return `${PREFIX} ${cookies.length} cookies, ${vendors.length} vendors, ${ungated.length} ungated`;
+}
+
+export function report(
+	result: ScanResult,
+	logger: Logger,
+	opts: { mode: Mode; root: string },
+): void {
+	if (opts.mode === "off") return;
+	const log = opts.mode === "error" ? logger.error : logger.warn;
+	for (const u of result.ungated) {
+		log(formatUngated(u, opts.root));
+	}
+	if (result.ungated.length > 0) log("");
+	logger.info(formatSummary(result));
+}
+
+export function reportFileDelta(
+	prevForFile: Ungated[],
+	nextForFile: Ungated[],
+	logger: Logger,
+	opts: { mode: Mode; root: string; file: string },
+): void {
+	if (opts.mode === "off") return;
+	const log = opts.mode === "error" ? logger.error : logger.warn;
+	const prevKeys = new Set(prevForFile.map(keyForUngated));
+	const nextKeys = new Set(nextForFile.map(keyForUngated));
+	const added = nextForFile.filter((u) => !prevKeys.has(keyForUngated(u)));
+	const removed = prevForFile.filter((u) => !nextKeys.has(keyForUngated(u)));
+	for (const u of added) log(formatUngated(u, opts.root));
+	if (removed.length > 0) {
+		const rel = toRel(opts.file, opts.root);
+		logger.info(`${PREFIX} ${removed.length} ungated finding(s) cleared in ${rel}`);
+	}
+}
+
+function keyForUngated(u: Ungated): string {
+	const h = u.hit;
+	const tag = "kind" in h ? h.kind : `${h.vendor}/${h.via}`;
+	return `${h.file}:${h.line}:${h.column}:${tag}`;
+}
+
+export function firstUngated(result: ScanResult): Ungated | undefined {
+	return result.ungated[0];
+}
+
+export type { Cookie, VendorHit };

--- a/packages/vite/src/consent/rules/cookies-next.ts
+++ b/packages/vite/src/consent/rules/cookies-next.ts
@@ -1,0 +1,36 @@
+import type { AnyNode, Rule } from "../types";
+
+const SETTERS = new Set(["setCookie", "destroyCookie"]);
+const SOURCES = new Set(["cookies-next", "nookies"]);
+
+export const cookiesNextRule: Rule = {
+	name: "cookies-next",
+	visit: (ctx) => {
+		if (ctx.node.type !== "CallExpression") return;
+		const callee = ctx.node.callee as AnyNode | undefined;
+		if (callee?.type !== "Identifier") return;
+		const name = callee.name as string;
+		if (!SETTERS.has(name)) return;
+		const info = ctx.imports.get(name);
+		if (!info || !SOURCES.has(info.source)) return;
+		if (name !== "setCookie") return;
+		const cookieName = readNameArg(ctx.node);
+		const pos = ctx.position(ctx.node.start);
+		ctx.report({
+			file: ctx.file,
+			line: pos.line,
+			column: pos.column,
+			kind: "cookies-next",
+			...(cookieName ? { name: cookieName } : {}),
+		});
+	},
+};
+
+function readNameArg(call: AnyNode): string | undefined {
+	const args = (call.arguments as AnyNode[] | undefined) ?? [];
+	for (let i = 0; i < Math.min(2, args.length); i++) {
+		const a = args[i]!;
+		if (a.type === "Literal" && typeof a.value === "string") return a.value;
+	}
+	return undefined;
+}

--- a/packages/vite/src/consent/rules/document-cookie.test.ts
+++ b/packages/vite/src/consent/rules/document-cookie.test.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { loadFixtures, partition, runRule } from "../test-helpers";
+import { documentCookieRule } from "./document-cookie";
+
+const FIXTURES = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"__fixtures__",
+	"rules",
+	"document-cookie",
+);
+
+describe("document-cookie rule", () => {
+	for (const fx of loadFixtures(FIXTURES)) {
+		it(fx.name, () => {
+			const hits = runRule(fx.file, fx.source, documentCookieRule);
+			const got = partition(hits);
+			const expected = fx.expected;
+			expect(got.cookies).toHaveLength(expected.cookies.length);
+			for (let i = 0; i < expected.cookies.length; i++) {
+				expect(got.cookies[i]).toMatchObject(expected.cookies[i]!);
+			}
+		});
+	}
+});

--- a/packages/vite/src/consent/rules/document-cookie.ts
+++ b/packages/vite/src/consent/rules/document-cookie.ts
@@ -1,0 +1,42 @@
+import type { AnyNode, Rule } from "../types";
+
+export const documentCookieRule: Rule = {
+	name: "document-cookie",
+	visit: (ctx) => {
+		if (ctx.node.type !== "AssignmentExpression") return;
+		const left = ctx.node.left as AnyNode | undefined;
+		if (!left) return;
+		if (left.type !== "StaticMemberExpression" && left.type !== "MemberExpression") return;
+		const obj = left.object as AnyNode | undefined;
+		const prop = left.property as AnyNode | undefined;
+		if (obj?.type !== "Identifier" || obj.name !== "document") return;
+		if (prop?.type !== "Identifier" || prop.name !== "cookie") return;
+		const right = ctx.node.right as AnyNode | undefined;
+		const name = extractCookieName(right);
+		const pos = ctx.position(ctx.node.start);
+		ctx.report({
+			file: ctx.file,
+			line: pos.line,
+			column: pos.column,
+			kind: "document.cookie",
+			...(name ? { name } : {}),
+		});
+	},
+};
+
+function extractCookieName(node: AnyNode | undefined): string | undefined {
+	if (!node) return undefined;
+	let raw: string | undefined;
+	if (node.type === "Literal" && typeof node.value === "string") raw = node.value;
+	else if (node.type === "TemplateLiteral") {
+		const quasis = node.quasis as AnyNode[] | undefined;
+		if (quasis?.[0]) {
+			const cooked = (quasis[0] as { value?: { cooked?: string } }).value?.cooked;
+			if (cooked) raw = cooked;
+		}
+	}
+	if (!raw) return undefined;
+	const eq = raw.indexOf("=");
+	if (eq <= 0) return undefined;
+	return raw.slice(0, eq).trim() || undefined;
+}

--- a/packages/vite/src/consent/rules/js-cookie.ts
+++ b/packages/vite/src/consent/rules/js-cookie.ts
@@ -1,0 +1,37 @@
+import type { AnyNode, Rule } from "../types";
+
+const SETTERS = new Set(["set", "remove", "withAttributes", "withConverter"]);
+const SOURCES = new Set(["js-cookie"]);
+
+export const jsCookieRule: Rule = {
+	name: "js-cookie",
+	visit: (ctx) => {
+		if (ctx.node.type !== "CallExpression") return;
+		const callee = ctx.node.callee as AnyNode | undefined;
+		if (!callee) return;
+		if (callee.type !== "StaticMemberExpression" && callee.type !== "MemberExpression") return;
+		const obj = callee.object as AnyNode | undefined;
+		const prop = callee.property as AnyNode | undefined;
+		if (obj?.type !== "Identifier" || prop?.type !== "Identifier") return;
+		if (!SETTERS.has(prop.name as string)) return;
+		const info = ctx.imports.get(obj.name as string);
+		if (!info || !SOURCES.has(info.source)) return;
+		if (prop.name !== "set") return;
+		const name = readArg0String(ctx.node);
+		const pos = ctx.position(ctx.node.start);
+		ctx.report({
+			file: ctx.file,
+			line: pos.line,
+			column: pos.column,
+			kind: "js-cookie",
+			...(name ? { name } : {}),
+		});
+	},
+};
+
+function readArg0String(call: AnyNode): string | undefined {
+	const arg = (call.arguments as AnyNode[] | undefined)?.[0];
+	if (!arg) return undefined;
+	if (arg.type === "Literal" && typeof arg.value === "string") return arg.value;
+	return undefined;
+}

--- a/packages/vite/src/consent/rules/next-headers.ts
+++ b/packages/vite/src/consent/rules/next-headers.ts
@@ -1,0 +1,111 @@
+import type { AnyNode, ImportInfo, Rule, VisitContext } from "../types";
+
+const cache = new WeakMap<object, Set<string>>();
+
+export const nextHeadersRule: Rule = {
+	name: "next-headers",
+	visit: (ctx) => {
+		if (ctx.node.type !== "CallExpression") return;
+		const callee = ctx.node.callee as AnyNode | undefined;
+		if (!callee) return;
+		if (callee.type !== "StaticMemberExpression" && callee.type !== "MemberExpression") return;
+		const prop = callee.property as AnyNode | undefined;
+		if (prop?.type !== "Identifier") return;
+		const method = prop.name as string;
+		if (method !== "set") return;
+		const obj = callee.object as AnyNode | undefined;
+		if (!isCookiesObject(obj, ctx)) return;
+		const name = readCookieName(ctx.node);
+		const pos = ctx.position(ctx.node.start);
+		ctx.report({
+			file: ctx.file,
+			line: pos.line,
+			column: pos.column,
+			kind: "next-headers",
+			...(name ? { name } : {}),
+		});
+	},
+};
+
+function isCookiesObject(obj: AnyNode | undefined, ctx: VisitContext): boolean {
+	if (!obj) return false;
+	if (obj.type === "ParenthesizedExpression") {
+		return isCookiesObject(obj.expression as AnyNode, ctx);
+	}
+	if (obj.type === "AwaitExpression") return isCookiesObject(obj.argument as AnyNode, ctx);
+	if (obj.type === "CallExpression")
+		return calleeIsCookiesImport(obj.callee as AnyNode | undefined, ctx.imports);
+	if (obj.type === "Identifier") {
+		const bindings = getCookieBindings(ctx);
+		return bindings.has(obj.name as string);
+	}
+	return false;
+}
+
+function calleeIsCookiesImport(
+	callee: AnyNode | undefined,
+	imports: Map<string, ImportInfo>,
+): boolean {
+	if (callee?.type !== "Identifier") return false;
+	const info = imports.get(callee.name as string);
+	return info?.source === "next/headers" && info.imported === "cookies";
+}
+
+function getCookieBindings(ctx: VisitContext): Set<string> {
+	const root = ctx.parents[0] ?? ctx.node;
+	const cached = cache.get(root as object);
+	if (cached) return cached;
+	const out = new Set<string>();
+	collect(root, ctx.imports, out);
+	cache.set(root as object, out);
+	return out;
+}
+
+function collect(node: AnyNode, imports: Map<string, ImportInfo>, out: Set<string>): void {
+	if (node.type === "VariableDeclarator") {
+		let init = node.init as AnyNode | undefined;
+		if (init?.type === "AwaitExpression") init = init.argument as AnyNode | undefined;
+		if (
+			init?.type === "CallExpression" &&
+			calleeIsCookiesImport(init.callee as AnyNode | undefined, imports)
+		) {
+			const id = node.id as AnyNode | undefined;
+			if (id?.type === "Identifier") out.add(id.name as string);
+		}
+	}
+	for (const key in node) {
+		if (key === "type" || key === "start" || key === "end") continue;
+		const child = (node as Record<string, unknown>)[key];
+		if (Array.isArray(child)) {
+			for (const c of child) {
+				if (c && typeof c === "object" && "type" in c) collect(c as AnyNode, imports, out);
+			}
+		} else if (child && typeof child === "object" && "type" in child) {
+			collect(child as AnyNode, imports, out);
+		}
+	}
+}
+
+function readCookieName(call: AnyNode): string | undefined {
+	const args = (call.arguments as AnyNode[] | undefined) ?? [];
+	const first = args[0];
+	if (!first) return undefined;
+	if (first.type === "Literal" && typeof first.value === "string") return first.value;
+	if (first.type === "ObjectExpression") {
+		for (const prop of (first.properties as AnyNode[] | undefined) ?? []) {
+			if (prop.type !== "Property" && prop.type !== "ObjectProperty") continue;
+			const key = prop.key as AnyNode | undefined;
+			const keyName =
+				key?.type === "Identifier"
+					? (key.name as string)
+					: key?.type === "Literal" && typeof key.value === "string"
+						? key.value
+						: undefined;
+			if (keyName === "name") {
+				const v = prop.value as AnyNode | undefined;
+				if (v?.type === "Literal" && typeof v.value === "string") return v.value;
+			}
+		}
+	}
+	return undefined;
+}

--- a/packages/vite/src/consent/rules/react-cookie.ts
+++ b/packages/vite/src/consent/rules/react-cookie.ts
@@ -1,0 +1,68 @@
+import type { AnyNode, Rule, VisitContext } from "../types";
+
+const cache = new WeakMap<object, Set<string>>();
+
+export const reactCookieRule: Rule = {
+	name: "react-cookie",
+	visit: (ctx) => {
+		if (ctx.node.type !== "CallExpression") return;
+		const callee = ctx.node.callee as AnyNode | undefined;
+		if (callee?.type !== "Identifier") return;
+		const setters = getSetters(ctx);
+		if (!setters.has(callee.name as string)) return;
+		const name = readStringArg(ctx.node, 0);
+		const pos = ctx.position(callee.start);
+		ctx.report({
+			file: ctx.file,
+			line: pos.line,
+			column: pos.column,
+			kind: "react-cookie",
+			...(name ? { name } : {}),
+		});
+	},
+};
+
+function getSetters(ctx: VisitContext): Set<string> {
+	const root = ctx.parents[0] ?? ctx.node;
+	const cached = cache.get(root as object);
+	if (cached) return cached;
+	const useCookiesInfo = ctx.imports.get("useCookies");
+	const setters = new Set<string>();
+	if (useCookiesInfo?.source === "react-cookie") collectSetters(root, setters);
+	cache.set(root as object, setters);
+	return setters;
+}
+
+function collectSetters(node: AnyNode, out: Set<string>): void {
+	if (node.type === "VariableDeclarator") {
+		const init = node.init as AnyNode | undefined;
+		if (init?.type === "CallExpression") {
+			const callee = init.callee as AnyNode | undefined;
+			if (callee?.type === "Identifier" && callee.name === "useCookies") {
+				const id = node.id as AnyNode | undefined;
+				if (id?.type === "ArrayPattern") {
+					const elements = id.elements as AnyNode[] | undefined;
+					const second = elements?.[1];
+					if (second?.type === "Identifier") out.add(second.name as string);
+				}
+			}
+		}
+	}
+	for (const key in node) {
+		if (key === "type" || key === "start" || key === "end") continue;
+		const child = (node as Record<string, unknown>)[key];
+		if (Array.isArray(child)) {
+			for (const c of child) {
+				if (c && typeof c === "object" && "type" in c) collectSetters(c as AnyNode, out);
+			}
+		} else if (child && typeof child === "object" && "type" in child) {
+			collectSetters(child as AnyNode, out);
+		}
+	}
+}
+
+function readStringArg(call: AnyNode, idx: number): string | undefined {
+	const arg = (call.arguments as AnyNode[] | undefined)?.[idx];
+	if (arg?.type === "Literal" && typeof arg.value === "string") return arg.value;
+	return undefined;
+}

--- a/packages/vite/src/consent/rules/rules.test.ts
+++ b/packages/vite/src/consent/rules/rules.test.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { loadFixtures, partition } from "../test-helpers";
+import { parseFile } from "../parser";
+import { walk } from "../visit";
+import type { Rule } from "../types";
+import { cookiesNextRule } from "./cookies-next";
+import { jsCookieRule } from "./js-cookie";
+import { nextHeadersRule } from "./next-headers";
+import { reactCookieRule } from "./react-cookie";
+import { setCookieHeaderRule } from "./set-cookie-header";
+
+const RULES_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "__fixtures__", "rules");
+
+const cases: { name: string; rule: Rule }[] = [
+	{ name: "js-cookie", rule: jsCookieRule },
+	{ name: "cookies-next", rule: cookiesNextRule },
+	{ name: "react-cookie", rule: reactCookieRule },
+	{ name: "next-headers", rule: nextHeadersRule },
+	{ name: "set-cookie-header", rule: setCookieHeaderRule },
+];
+
+for (const { name, rule } of cases) {
+	describe(`${name} rule`, () => {
+		for (const fx of loadFixtures(join(RULES_DIR, name))) {
+			it(fx.name, () => {
+				const parsed = parseFile(fx.file, fx.source)!;
+				const { hits } = walk(parsed, [rule], []);
+				const got = partition(hits);
+				expect(got.cookies).toHaveLength(fx.expected.cookies.length);
+				for (let i = 0; i < fx.expected.cookies.length; i++) {
+					expect(got.cookies[i]).toMatchObject(fx.expected.cookies[i]!);
+				}
+			});
+		}
+	});
+}

--- a/packages/vite/src/consent/rules/set-cookie-header.ts
+++ b/packages/vite/src/consent/rules/set-cookie-header.ts
@@ -1,0 +1,70 @@
+import type { AnyNode, Rule, VisitContext } from "../types";
+
+const HEADER_RE = /^set-cookie$/i;
+
+export const setCookieHeaderRule: Rule = {
+	name: "set-cookie-header",
+	visit: (ctx) => {
+		const node = ctx.node;
+		if (node.type === "ObjectExpression") {
+			for (const prop of (node.properties as AnyNode[] | undefined) ?? []) {
+				if (prop.type !== "Property" && prop.type !== "ObjectProperty") continue;
+				const key = prop.key as AnyNode | undefined;
+				const keyText = readKeyText(key);
+				if (!keyText || !HEADER_RE.test(keyText)) continue;
+				if (!isHeadersContext(ctx.parents)) continue;
+				report(ctx, prop.start);
+			}
+			return;
+		}
+		if (node.type === "CallExpression") {
+			const callee = node.callee as AnyNode | undefined;
+			if (callee?.type !== "StaticMemberExpression" && callee?.type !== "MemberExpression") return;
+			const prop = callee.property as AnyNode | undefined;
+			if (prop?.type !== "Identifier") return;
+			const method = prop.name as string;
+			if (method !== "set" && method !== "append") return;
+			const arg0 = (node.arguments as AnyNode[] | undefined)?.[0];
+			if (!arg0 || arg0.type !== "Literal" || typeof arg0.value !== "string") return;
+			if (!HEADER_RE.test(arg0.value)) return;
+			report(ctx, node.start);
+		}
+	},
+};
+
+function readKeyText(key: AnyNode | undefined): string | undefined {
+	if (!key) return undefined;
+	if (key.type === "Identifier") return key.name as string;
+	if (key.type === "Literal" && typeof key.value === "string") return key.value;
+	return undefined;
+}
+
+function isHeadersContext(parents: AnyNode[]): boolean {
+	for (let i = parents.length - 1; i >= 0; i--) {
+		const p = parents[i]!;
+		if (p.type === "Property" || p.type === "ObjectProperty") {
+			const key = p.key as AnyNode | undefined;
+			const k = readKeyText(key);
+			if (k && /^headers$/i.test(k)) return true;
+		}
+		if (p.type === "NewExpression" || p.type === "CallExpression") {
+			const callee = p.callee as AnyNode | undefined;
+			if (callee?.type === "Identifier") {
+				const n = callee.name as string;
+				if (n === "Headers") return true;
+				if (n === "Response" || n === "NextResponse") return true;
+			}
+		}
+	}
+	return false;
+}
+
+function report(ctx: VisitContext, start: number): void {
+	const pos = ctx.position(start);
+	ctx.report({
+		file: ctx.file,
+		line: pos.line,
+		column: pos.column,
+		kind: "set-cookie-header",
+	});
+}

--- a/packages/vite/src/consent/rules/vendor-imports.test.ts
+++ b/packages/vite/src/consent/rules/vendor-imports.test.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import vendors from "../vendors.json";
+import { loadFixtures, partition } from "../test-helpers";
+import { parseFile } from "../parser";
+import { walk } from "../visit";
+import type { VendorRegistry } from "../types";
+import { vendorImportsRule } from "./vendor-imports";
+
+const FIXTURES = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"__fixtures__",
+	"rules",
+	"vendor-imports",
+);
+
+const registry = vendors as VendorRegistry;
+
+describe("vendor-imports rule", () => {
+	for (const fx of loadFixtures(FIXTURES)) {
+		it(fx.name, () => {
+			const parsed = parseFile(fx.file, fx.source)!;
+			const { hits } = walk(parsed, [vendorImportsRule], registry);
+			const got = partition(hits);
+			const expected = fx.expected;
+			expect(got.vendors).toHaveLength(expected.vendors.length);
+			for (let i = 0; i < expected.vendors.length; i++) {
+				expect(got.vendors[i]).toMatchObject(expected.vendors[i]!);
+			}
+		});
+	}
+});

--- a/packages/vite/src/consent/rules/vendor-imports.ts
+++ b/packages/vite/src/consent/rules/vendor-imports.ts
@@ -1,0 +1,90 @@
+import type { AnyNode, Rule, VendorEntry } from "../types";
+
+export const vendorImportsRule: Rule = {
+	name: "vendor-imports",
+	visit: (ctx) => {
+		const node = ctx.node;
+		if (node.type === "ImportDeclaration") {
+			const src = node.source as AnyNode | undefined;
+			if (src?.type !== "Literal" || typeof src.value !== "string") return;
+			const entry = matchImport(ctx.registry, src.value);
+			if (!entry) return;
+			const pos = ctx.position(node.start);
+			ctx.report({
+				file: ctx.file,
+				line: pos.line,
+				column: pos.column,
+				vendor: entry.vendor,
+				category: entry.category,
+				via: "import",
+			});
+			return;
+		}
+		if (node.type === "ImportExpression") {
+			const src = node.source as AnyNode | undefined;
+			if (src?.type === "Literal" && typeof src.value === "string") {
+				const entry = matchImport(ctx.registry, src.value);
+				if (entry) {
+					const pos = ctx.position(node.start);
+					ctx.report({
+						file: ctx.file,
+						line: pos.line,
+						column: pos.column,
+						vendor: entry.vendor,
+						category: entry.category,
+						via: "import",
+					});
+				}
+			}
+			return;
+		}
+		if (node.type === "CallExpression") {
+			const callee = node.callee as AnyNode | undefined;
+			const ident = identifierFor(callee);
+			if (ident) {
+				const name = ident.name as string;
+				if (ctx.localBindings.has(name)) return;
+				const entry = matchGlobal(ctx.registry, name);
+				if (entry) {
+					const pos = ctx.position(ident.start);
+					ctx.report({
+						file: ctx.file,
+						line: pos.line,
+						column: pos.column,
+						vendor: entry.vendor,
+						category: entry.category,
+						via: "global",
+					});
+				}
+			}
+		}
+	},
+};
+
+function matchImport(registry: VendorEntry[], specifier: string): VendorEntry | undefined {
+	for (const entry of registry) {
+		if (!entry.imports) continue;
+		if (entry.imports.includes(specifier)) return entry;
+		for (const prefix of entry.imports) {
+			if (specifier === prefix || specifier.startsWith(`${prefix}/`)) return entry;
+		}
+	}
+	return undefined;
+}
+
+function identifierFor(callee: AnyNode | undefined): AnyNode | undefined {
+	if (!callee) return undefined;
+	if (callee.type === "Identifier") return callee;
+	if (callee.type === "StaticMemberExpression" || callee.type === "MemberExpression") {
+		const obj = callee.object as AnyNode | undefined;
+		if (obj?.type === "Identifier") return obj;
+	}
+	return undefined;
+}
+
+function matchGlobal(registry: VendorEntry[], name: string): VendorEntry | undefined {
+	for (const entry of registry) {
+		if (entry.globals?.includes(name)) return entry;
+	}
+	return undefined;
+}

--- a/packages/vite/src/consent/runner.ts
+++ b/packages/vite/src/consent/runner.ts
@@ -1,0 +1,179 @@
+import { readFile } from "node:fs/promises";
+import { parseFile } from "./parser";
+import { applySuppressions } from "./suppress";
+import { defaultRules, defaultVendors, scan } from "./scan";
+import {
+	formatHitLocation,
+	formatUngated,
+	type Logger,
+	type Mode,
+	report,
+	reportFileDelta,
+} from "./reporter";
+import type { Hit, ScanResult, Ungated } from "./types";
+import { walk } from "./visit";
+
+/**
+ * Co-located OpenCookies consent scanner (PS-19). Structural fold only: this is
+ * a *second, separate* oxc walk + `tinyglobby` discovery living inside the one
+ * `openPolicy()` plugin — it never touches `openpolicy.gen.ts` and contributes
+ * no policy data. Unifying it with the policy walk is PS-25.
+ *
+ * Behaviour preserved verbatim from the old standalone `@opencookies/vite`
+ * plugin: full scan on `buildStart`, per-file delta on dev rescans, and a
+ * build-failing throw from `buildEnd` when `mode === "error"`.
+ */
+export type ConsentRunnerOptions = {
+	root: string;
+	mode: Mode;
+	include?: string[];
+	exclude?: string[];
+};
+
+export type ConsentRunner = {
+	/** Full scan + report. Called from the plugin's `buildStart`. */
+	build(logger: Logger): Promise<void>;
+	/** Single-file rescan + ungated delta. Called from the dev watcher. */
+	hotUpdate(file: string, logger: Logger): Promise<void>;
+	/** Throws on remaining ungated findings when `mode === "error"`. */
+	buildEnd(buildError?: Error): void;
+};
+
+export function createConsentRunner(opts: ConsentRunnerOptions): ConsentRunner {
+	let lastScan: ScanResult | undefined;
+	const ungatedByFile = new Map<string, Ungated[]>();
+	const cookiesByFile = new Map<string, Hit[]>();
+	const vendorsByFile = new Map<string, Hit[]>();
+
+	function indexResult(result: ScanResult): void {
+		ungatedByFile.clear();
+		cookiesByFile.clear();
+		vendorsByFile.clear();
+		for (const u of result.ungated) push(ungatedByFile, u.hit.file, u);
+		for (const c of result.cookies) push(cookiesByFile, c.file, c);
+		for (const v of result.vendors) push(vendorsByFile, v.file, v);
+	}
+
+	return {
+		async build(logger: Logger): Promise<void> {
+			if (opts.mode === "off") return;
+			const result = await scan({
+				cwd: opts.root,
+				include: opts.include,
+				exclude: opts.exclude,
+			});
+			lastScan = result;
+			indexResult(result);
+			report(result, logger, { mode: opts.mode, root: opts.root });
+		},
+
+		async hotUpdate(file: string, logger: Logger): Promise<void> {
+			if (opts.mode === "off") return;
+			if (!shouldScan(file)) return;
+
+			let source: string;
+			try {
+				source = await readFile(file, "utf8");
+			} catch {
+				return;
+			}
+
+			const fileResult = scanOneFile(file, source);
+			if (!fileResult) return;
+
+			const prevUngated = ungatedByFile.get(file) ?? [];
+
+			if (fileResult.cookies.length === 0 && fileResult.vendors.length === 0) {
+				cookiesByFile.delete(file);
+				vendorsByFile.delete(file);
+			} else {
+				cookiesByFile.set(file, fileResult.cookies);
+				vendorsByFile.set(file, fileResult.vendors);
+			}
+			if (fileResult.ungated.length === 0) ungatedByFile.delete(file);
+			else ungatedByFile.set(file, fileResult.ungated);
+
+			lastScan = rebuildResult(cookiesByFile, vendorsByFile, ungatedByFile);
+
+			reportFileDelta(prevUngated, fileResult.ungated, logger, {
+				mode: opts.mode,
+				root: opts.root,
+				file,
+			});
+		},
+
+		buildEnd(buildError?: Error): void {
+			if (buildError) return;
+			if (opts.mode !== "error") return;
+			const result = lastScan;
+			if (!result || result.ungated.length === 0) return;
+			const first = result.ungated[0]!;
+			const loc = formatHitLocation(first.hit, opts.root);
+			const summary = formatUngated(first, opts.root);
+			const more = result.ungated.length > 1 ? ` (+${result.ungated.length - 1} more)` : "";
+			throw new Error(`[opencookies] ungated finding at ${loc}${more}\n${summary}`);
+		},
+	};
+}
+
+function push<T>(map: Map<string, T[]>, key: string, value: T): void {
+	const arr = map.get(key);
+	if (arr) arr.push(value);
+	else map.set(key, [value]);
+}
+
+function shouldScan(file: string): boolean {
+	return /\.(?:[mc]?[jt]sx?|vue|svelte)$/.test(file);
+}
+
+type FileScanResult = {
+	cookies: Hit[];
+	vendors: Hit[];
+	ungated: Ungated[];
+};
+
+function scanOneFile(file: string, source: string): FileScanResult | null {
+	const parsed = parseFile(file, source);
+	if (!parsed) return null;
+	const result = walk(parsed, defaultRules, defaultVendors);
+	const filtered = applySuppressions(result.hits, parsed.comments);
+	const kept = new Set(filtered);
+	const cookies: Hit[] = [];
+	const vendors: Hit[] = [];
+	for (const h of filtered) {
+		if ("kind" in h) cookies.push(h);
+		else vendors.push(h);
+	}
+	const ungated = result.ungated.filter((u: Ungated) => kept.has(u.hit));
+	return { cookies, vendors, ungated };
+}
+
+function rebuildResult(
+	cookiesByFile: Map<string, Hit[]>,
+	vendorsByFile: Map<string, Hit[]>,
+	ungatedByFile: Map<string, Ungated[]>,
+): ScanResult {
+	const cookies: ScanResult["cookies"] = [];
+	const vendors: ScanResult["vendors"] = [];
+	const ungated: Ungated[] = [];
+	for (const arr of cookiesByFile.values()) {
+		for (const h of arr) if ("kind" in h) cookies.push(h);
+	}
+	for (const arr of vendorsByFile.values()) {
+		for (const h of arr) if (!("kind" in h)) vendors.push(h);
+	}
+	for (const arr of ungatedByFile.values()) ungated.push(...arr);
+	cookies.sort(orderHits);
+	vendors.sort(orderHits);
+	ungated.sort((a, b) => (a.file === b.file ? a.line - b.line : a.file.localeCompare(b.file)));
+	return { cookies, vendors, ungated };
+}
+
+function orderHits(
+	a: { file: string; line: number; column: number },
+	b: { file: string; line: number; column: number },
+): number {
+	if (a.file !== b.file) return a.file.localeCompare(b.file);
+	if (a.line !== b.line) return a.line - b.line;
+	return a.column - b.column;
+}

--- a/packages/vite/src/consent/scan.test.ts
+++ b/packages/vite/src/consent/scan.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { scan } from "./scan";
+
+const root = mkdtempSync(join(tmpdir(), "opencookies-scan-"));
+
+function file(rel: string, body: string): void {
+	const full = join(root, rel);
+	const dir = full.slice(0, full.lastIndexOf("/"));
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(full, body);
+}
+
+file("src/a.ts", `document.cookie = 'a=1';\n`);
+file("src/b.ts", `import 'posthog-js';\nposthog.capture('e');\n`);
+file(
+	"src/gated.tsx",
+	`export function Gated() {\n  return (\n    <ConsentGate purpose="analytics">\n      {(() => { document.cookie = 'g=1'; return null; })()}\n    </ConsentGate>\n  );\n}\n`,
+);
+file("src/suppressed.ts", `// opencookies-ignore-next-line\ndocument.cookie = 'c=1';\n`);
+file("src/ignored.d.ts", `declare const foo: any;\n`);
+file("node_modules/lib/index.ts", `document.cookie = 'x=1';\n`);
+
+afterAll(() => {
+	// tmpdir is OS-cleaned; nothing to do
+});
+
+describe("scan", () => {
+	it("finds cookie writes, vendor hits, and skips excluded paths", async () => {
+		const result = await scan({ cwd: root });
+		expect(result.cookies.map((c) => c.kind)).toEqual(["document.cookie", "document.cookie"]);
+		expect(result.vendors.map((v) => v.vendor)).toEqual(["posthog", "posthog"]);
+		expect(result.cookies.every((c) => !c.file.includes("node_modules"))).toBe(true);
+	});
+
+	it("respects // opencookies-ignore-next-line", async () => {
+		const result = await scan({ cwd: root });
+		const fromSuppressed = result.cookies.filter((c) => c.file.endsWith("suppressed.ts"));
+		expect(fromSuppressed).toEqual([]);
+	});
+
+	it("classifies ConsentGate-wrapped writes as gated", async () => {
+		const result = await scan({ cwd: root });
+		const fromGated = result.ungated.filter((u) => u.file.endsWith("gated.tsx"));
+		expect(fromGated).toEqual([]);
+	});
+
+	it("flags top-level cookie writes as ungated", async () => {
+		const result = await scan({ cwd: root });
+		const fromA = result.ungated.filter((u) => u.file.endsWith("/src/a.ts"));
+		expect(fromA).toHaveLength(1);
+		expect(fromA[0]!.reason).toBe("cookie-outside-gate");
+	});
+});

--- a/packages/vite/src/consent/scan.ts
+++ b/packages/vite/src/consent/scan.ts
@@ -1,0 +1,114 @@
+import { readFile } from "node:fs/promises";
+import { availableParallelism } from "node:os";
+import { resolve } from "node:path";
+import { glob } from "tinyglobby";
+import { parseFile } from "./parser";
+import { applySuppressions } from "./suppress";
+import vendorsJson from "./vendors.json";
+import { walk } from "./visit";
+import { cookiesNextRule } from "./rules/cookies-next";
+import { documentCookieRule } from "./rules/document-cookie";
+import { jsCookieRule } from "./rules/js-cookie";
+import { nextHeadersRule } from "./rules/next-headers";
+import { reactCookieRule } from "./rules/react-cookie";
+import { setCookieHeaderRule } from "./rules/set-cookie-header";
+import { vendorImportsRule } from "./rules/vendor-imports";
+import type {
+	Cookie,
+	Hit,
+	Rule,
+	ScanOptions,
+	ScanResult,
+	Ungated,
+	VendorHit,
+	VendorRegistry,
+} from "./types";
+
+const DEFAULT_INCLUDE = ["**/*.{js,jsx,ts,tsx,vue,svelte,mjs,cjs,mts,cts}"];
+const DEFAULT_EXCLUDE = [
+	"**/node_modules/**",
+	"**/dist/**",
+	"**/build/**",
+	"**/.next/**",
+	"**/.nuxt/**",
+	"**/.svelte-kit/**",
+	"**/coverage/**",
+	"**/*.d.ts",
+];
+
+export const defaultRules: Rule[] = [
+	documentCookieRule,
+	jsCookieRule,
+	cookiesNextRule,
+	reactCookieRule,
+	nextHeadersRule,
+	setCookieHeaderRule,
+	vendorImportsRule,
+];
+
+export const defaultVendors: VendorRegistry = vendorsJson as VendorRegistry;
+
+export async function scan(options: ScanOptions): Promise<ScanResult> {
+	const cwd = resolve(options.cwd);
+	const include = options.include ?? DEFAULT_INCLUDE;
+	const exclude = options.exclude ?? DEFAULT_EXCLUDE;
+	const rules = options.rules ?? defaultRules;
+	const registry = options.vendors ?? defaultVendors;
+	const concurrency = Math.max(1, options.concurrency ?? availableParallelism());
+
+	const files = await glob(include, {
+		cwd,
+		ignore: exclude,
+		absolute: true,
+		onlyFiles: true,
+		dot: false,
+	});
+
+	const cookies: Cookie[] = [];
+	const vendors: VendorHit[] = [];
+	const ungated: Ungated[] = [];
+
+	let cursor = 0;
+	async function worker(): Promise<void> {
+		while (true) {
+			const i = cursor++;
+			if (i >= files.length) return;
+			const abs = files[i]!;
+			try {
+				const source = await readFile(abs, "utf8");
+				const parsed = parseFile(abs, source);
+				if (!parsed) continue;
+				const result = walk(parsed, rules, registry);
+				const filtered = applySuppressions(result.hits, parsed.comments);
+				const dropped = new Set<Hit>();
+				if (filtered.length !== result.hits.length) {
+					const kept = new Set(filtered);
+					for (const h of result.hits) if (!kept.has(h)) dropped.add(h);
+				}
+				for (const hit of filtered) {
+					if ("kind" in hit) cookies.push(hit);
+					else vendors.push(hit);
+				}
+				for (const u of result.ungated) {
+					if (!dropped.has(u.hit)) ungated.push(u);
+				}
+			} catch {
+				// unparsable files are skipped silently; the rest of the scan continues
+			}
+		}
+	}
+
+	await Promise.all(Array.from({ length: Math.min(concurrency, files.length) }, () => worker()));
+
+	cookies.sort(orderHits);
+	vendors.sort(orderHits);
+	ungated.sort((a, b) => (a.file === b.file ? a.line - b.line : a.file.localeCompare(b.file)));
+
+	return { cookies, vendors, ungated };
+}
+
+function orderHits(a: { file: string; line: number; column: number }, b: typeof a): number {
+	if (a.file !== b.file) return a.file.localeCompare(b.file);
+	if (a.line !== b.line) return a.line - b.line;
+	return a.column - b.column;
+}

--- a/packages/vite/src/consent/sfc.ts
+++ b/packages/vite/src/consent/sfc.ts
@@ -1,0 +1,40 @@
+import type { Lang } from "./types";
+
+export type ScriptBlock = {
+	source: string;
+	lang: Lang;
+	startLine: number;
+};
+
+const scriptRe = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
+
+export function extractScripts(source: string): ScriptBlock[] {
+	const out: ScriptBlock[] = [];
+	for (const m of source.matchAll(scriptRe)) {
+		const attrs = m[1] ?? "";
+		const inner = m[2] ?? "";
+		const lang = parseLang(attrs);
+		const innerStart = m.index + m[0]!.indexOf(">") + 1;
+		const startLine = countLines(source, innerStart);
+		out.push({ source: inner, lang, startLine });
+	}
+	return out;
+}
+
+function parseLang(attrs: string): Lang {
+	const m = /\blang\s*=\s*"([^"]+)"|\blang\s*=\s*'([^']+)'/i.exec(attrs);
+	const raw = (m?.[1] ?? m?.[2] ?? "").toLowerCase();
+	if (raw === "ts" || raw === "typescript") return "ts";
+	if (raw === "tsx") return "tsx";
+	if (raw === "jsx") return "jsx";
+	if (raw === "js" || raw === "javascript" || raw === "") return "js";
+	return "ts";
+}
+
+function countLines(source: string, offset: number): number {
+	let n = 0;
+	for (let i = 0; i < offset && i < source.length; i++) {
+		if (source.charCodeAt(i) === 10) n++;
+	}
+	return n;
+}

--- a/packages/vite/src/consent/suppress.test.ts
+++ b/packages/vite/src/consent/suppress.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vite-plus/test";
+import { applySuppressions } from "./suppress";
+import type { Hit, ParsedComment } from "./types";
+
+function cookie(line: number): Hit {
+	return { file: "x.ts", line, column: 0, kind: "document.cookie" };
+}
+
+function lineComment(value: string, line: number): ParsedComment {
+	return { type: "Line", value, line };
+}
+
+describe("applySuppressions", () => {
+	it("returns hits unchanged when no comments", () => {
+		const hits = [cookie(5)];
+		expect(applySuppressions(hits, [])).toEqual(hits);
+	});
+
+	it("drops hit on the line after ignore-next-line", () => {
+		const hits = [cookie(5)];
+		const comments = [lineComment(" opencookies-ignore-next-line", 4)];
+		expect(applySuppressions(hits, comments)).toEqual([]);
+	});
+
+	it("does not drop a hit two lines after ignore-next-line", () => {
+		const hits = [cookie(7)];
+		const comments = [lineComment(" opencookies-ignore-next-line", 4)];
+		expect(applySuppressions(hits, comments)).toEqual(hits);
+	});
+
+	it("drops every hit when ignore-file appears in first 10 lines", () => {
+		const hits = [cookie(5), cookie(20)];
+		const comments = [lineComment(" opencookies-ignore-file", 2)];
+		expect(applySuppressions(hits, comments)).toEqual([]);
+	});
+
+	it("ignores ignore-file past line 10", () => {
+		const hits = [cookie(50)];
+		const comments = [lineComment(" opencookies-ignore-file", 20)];
+		expect(applySuppressions(hits, comments)).toEqual(hits);
+	});
+});

--- a/packages/vite/src/consent/suppress.ts
+++ b/packages/vite/src/consent/suppress.ts
@@ -1,0 +1,23 @@
+import type { Hit, ParsedComment } from "./types";
+
+const NEXT_LINE_RE = /opencookies-ignore-next-line/;
+const FILE_RE = /opencookies-ignore-file/;
+
+export function applySuppressions(hits: Hit[], comments: ParsedComment[]): Hit[] {
+	if (hits.length === 0) return hits;
+	if (isFileSuppressed(comments)) return [];
+	const ignoredLines = new Set<number>();
+	for (const c of comments) {
+		if (NEXT_LINE_RE.test(c.value)) ignoredLines.add(c.line + 1);
+	}
+	if (ignoredLines.size === 0) return hits;
+	return hits.filter((h) => !ignoredLines.has(h.line));
+}
+
+function isFileSuppressed(comments: ParsedComment[]): boolean {
+	for (const c of comments) {
+		if (c.line > 10) continue;
+		if (FILE_RE.test(c.value)) return true;
+	}
+	return false;
+}

--- a/packages/vite/src/consent/test-helpers.ts
+++ b/packages/vite/src/consent/test-helpers.ts
@@ -1,0 +1,59 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { basename, extname, join, relative } from "node:path";
+import { parseFile } from "./parser";
+import type { Hit, Rule, ScanResult, Ungated, VendorRegistry } from "./types";
+import { walk } from "./visit";
+
+export function runRule(file: string, source: string, rule: Rule): Hit[] {
+	return runRules(file, source, [rule]);
+}
+
+export function runRules(
+	file: string,
+	source: string,
+	rules: Rule[],
+	registry: VendorRegistry = [],
+): Hit[] {
+	const parsed = parseFile(file, source);
+	if (!parsed) return [];
+	return walk(parsed, rules, registry).hits;
+}
+
+type FixtureCase = {
+	name: string;
+	file: string;
+	source: string;
+	expected: ScanResult;
+};
+
+export function loadFixtures(dir: string): FixtureCase[] {
+	const out: FixtureCase[] = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (!statSync(full).isFile()) continue;
+		if (entry.endsWith(".expected.json")) continue;
+		const ext = extname(entry);
+		if (![".ts", ".tsx", ".js", ".jsx", ".vue", ".svelte"].includes(ext)) continue;
+		const stem = basename(entry, ext);
+		const expectedPath = join(dir, `${stem}.expected.json`);
+		const source = readFileSync(full, "utf8");
+		let expected: ScanResult = { cookies: [], vendors: [], ungated: [] };
+		try {
+			expected = JSON.parse(readFileSync(expectedPath, "utf8")) as ScanResult;
+		} catch {
+			// expected may be omitted for "should-not-match" cases
+		}
+		out.push({ name: stem, file: relative(process.cwd(), full), source, expected });
+	}
+	return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function partition(hits: Hit[], ungated: Ungated[] = []): ScanResult {
+	const cookies: ScanResult["cookies"] = [];
+	const vendors: ScanResult["vendors"] = [];
+	for (const h of hits) {
+		if ("kind" in h) cookies.push(h);
+		else vendors.push(h);
+	}
+	return { cookies, vendors, ungated };
+}

--- a/packages/vite/src/consent/types.ts
+++ b/packages/vite/src/consent/types.ts
@@ -1,0 +1,110 @@
+export type CookieKind =
+	| "document.cookie"
+	| "js-cookie"
+	| "cookies-next"
+	| "react-cookie"
+	| "next-headers"
+	| "set-cookie-header";
+
+export type Cookie = {
+	file: string;
+	line: number;
+	column: number;
+	kind: CookieKind;
+	name?: string;
+	vendor?: string;
+};
+
+export type VendorVia = "import" | "global" | "script-url";
+
+export type VendorHit = {
+	file: string;
+	line: number;
+	column: number;
+	vendor: string;
+	category: string;
+	via: VendorVia;
+};
+
+export type Hit = Cookie | VendorHit;
+
+export type Ungated = {
+	file: string;
+	line: number;
+	reason: "cookie-outside-gate" | "vendor-outside-gate";
+	hit: Hit;
+};
+
+export type ScanResult = {
+	cookies: Cookie[];
+	vendors: VendorHit[];
+	ungated: Ungated[];
+};
+
+export type VendorEntry = {
+	vendor: string;
+	category: string;
+	imports?: string[];
+	globals?: string[];
+	scriptUrls?: string[];
+};
+
+export type VendorRegistry = VendorEntry[];
+
+export type Lang = "js" | "jsx" | "ts" | "tsx";
+
+export type ImportInfo = {
+	source: string;
+	imported: string;
+};
+
+export type ParsedFile = {
+	file: string;
+	source: string;
+	lang: Lang;
+	ast: AnyNode;
+	comments: ParsedComment[];
+	lineOffset: number;
+	localBindings: Set<string>;
+	imports: Map<string, ImportInfo>;
+};
+
+export type ParsedComment = {
+	type: "Line" | "Block";
+	value: string;
+	line: number;
+};
+
+export type AnyNode = {
+	type: string;
+	start: number;
+	end: number;
+	[key: string]: unknown;
+};
+
+export type VisitContext = {
+	file: string;
+	source: string;
+	node: AnyNode;
+	parents: AnyNode[];
+	lineOffset: number;
+	registry: VendorRegistry;
+	localBindings: Set<string>;
+	imports: Map<string, ImportInfo>;
+	report: (hit: Hit) => void;
+	position: (offset: number) => { line: number; column: number };
+};
+
+export type Rule = {
+	name: string;
+	visit: (ctx: VisitContext) => void;
+};
+
+export type ScanOptions = {
+	cwd: string;
+	include?: string[];
+	exclude?: string[];
+	rules?: Rule[];
+	vendors?: VendorRegistry;
+	concurrency?: number;
+};

--- a/packages/vite/src/consent/ungated.test.ts
+++ b/packages/vite/src/consent/ungated.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vite-plus/test";
+import vendors from "./vendors.json";
+import { documentCookieRule } from "./rules/document-cookie";
+import { vendorImportsRule } from "./rules/vendor-imports";
+import { parseFile } from "./parser";
+import type { VendorRegistry } from "./types";
+import { walk } from "./visit";
+
+const registry = vendors as VendorRegistry;
+
+function ungated(source: string, file = "x.tsx"): ReturnType<typeof walk>["ungated"] {
+	const parsed = parseFile(file, source)!;
+	return walk(parsed, [documentCookieRule, vendorImportsRule], registry).ungated;
+}
+
+describe("ungated heuristic", () => {
+	it("flags top-level cookie writes as ungated", () => {
+		const u = ungated("document.cookie = 'a=1';", "x.ts");
+		expect(u).toHaveLength(1);
+		expect(u[0]!.reason).toBe("cookie-outside-gate");
+	});
+
+	it("does not flag hits inside a <ConsentGate>", () => {
+		const src = `
+function App() {
+  return (
+    <ConsentGate purpose="analytics">
+      {(() => { document.cookie = 'a=1'; return null; })()}
+    </ConsentGate>
+  );
+}
+`;
+		expect(ungated(src)).toHaveLength(0);
+	});
+
+	it("does not flag hits inside an if (consent.has(...)) gate", () => {
+		const src = `
+if (consent.has('analytics')) {
+  document.cookie = 'a=1';
+}
+`;
+		expect(ungated(src, "x.ts")).toHaveLength(0);
+	});
+
+	it("does not flag hits inside an acceptAll helper", () => {
+		const src = `
+function acceptAll() {
+  document.cookie = 'a=1';
+}
+`;
+		expect(ungated(src, "x.ts")).toHaveLength(0);
+	});
+
+	it("does not flag hits inside a setSomething helper", () => {
+		const src = `
+function setAnalyticsCookie() {
+  document.cookie = 'a=1';
+}
+`;
+		expect(ungated(src, "x.ts")).toHaveLength(0);
+	});
+
+	it("flags vendor imports as ungated regardless of file location", () => {
+		const u = ungated("import 'posthog-js';", "x.ts");
+		expect(u).toHaveLength(1);
+		expect(u[0]!.reason).toBe("vendor-outside-gate");
+	});
+});

--- a/packages/vite/src/consent/ungated.ts
+++ b/packages/vite/src/consent/ungated.ts
@@ -1,0 +1,69 @@
+import type { AnyNode } from "./types";
+
+const SET_PREFIX_RE = /^set[A-Z_]/;
+const GATE_HELPER_NAMES = new Set(["acceptAll", "acceptNecessary"]);
+
+export function isGated(parents: AnyNode[]): boolean {
+	for (let i = parents.length - 1; i >= 0; i--) {
+		const p = parents[i]!;
+		if (isConsentGateElement(p)) return true;
+		if (isHasCheck(p)) return true;
+		if (isGateHelperFunction(p)) return true;
+	}
+	return false;
+}
+
+function isConsentGateElement(node: AnyNode): boolean {
+	if (node.type !== "JSXElement") return false;
+	const opening = node.openingElement as AnyNode | undefined;
+	if (!opening) return false;
+	const name = opening.name as AnyNode | undefined;
+	if (name?.type !== "JSXIdentifier") return false;
+	return name.name === "ConsentGate";
+}
+
+function isHasCheck(node: AnyNode): boolean {
+	if (node.type !== "IfStatement" && node.type !== "ConditionalExpression") return false;
+	const test = node.test as AnyNode | undefined;
+	return Boolean(test && containsHasCall(test));
+}
+
+function containsHasCall(node: AnyNode): boolean {
+	if (node.type === "CallExpression") {
+		const callee = node.callee as AnyNode | undefined;
+		if (
+			callee &&
+			(callee.type === "StaticMemberExpression" || callee.type === "MemberExpression")
+		) {
+			const prop = callee.property as AnyNode | undefined;
+			if (prop?.type === "Identifier" && prop.name === "has") return true;
+		}
+	}
+	for (const key in node) {
+		if (key === "type" || key === "start" || key === "end") continue;
+		const child = (node as Record<string, unknown>)[key];
+		if (Array.isArray(child)) {
+			for (const c of child) {
+				if (c && typeof c === "object" && "type" in c && containsHasCall(c as AnyNode)) return true;
+			}
+		} else if (child && typeof child === "object" && "type" in child) {
+			if (containsHasCall(child as AnyNode)) return true;
+		}
+	}
+	return false;
+}
+
+function isGateHelperFunction(node: AnyNode): boolean {
+	if (
+		node.type !== "FunctionDeclaration" &&
+		node.type !== "FunctionExpression" &&
+		node.type !== "ArrowFunctionExpression"
+	) {
+		return false;
+	}
+	const id = node.id as AnyNode | undefined;
+	if (id?.type !== "Identifier") return false;
+	const name = id.name as string;
+	if (GATE_HELPER_NAMES.has(name)) return true;
+	return SET_PREFIX_RE.test(name);
+}

--- a/packages/vite/src/consent/vendors.json
+++ b/packages/vite/src/consent/vendors.json
@@ -1,0 +1,93 @@
+[
+	{
+		"vendor": "google-analytics",
+		"category": "analytics",
+		"imports": ["@types/gtag.js", "react-ga4", "react-ga"],
+		"globals": ["gtag", "ga"],
+		"scriptUrls": ["googletagmanager.com/gtag/js", "google-analytics.com/analytics.js"]
+	},
+	{
+		"vendor": "google-tag-manager",
+		"category": "marketing",
+		"scriptUrls": ["googletagmanager.com/gtm.js"]
+	},
+	{
+		"vendor": "meta-pixel",
+		"category": "marketing",
+		"globals": ["fbq"],
+		"scriptUrls": ["connect.facebook.net/en_US/fbevents.js"]
+	},
+	{
+		"vendor": "posthog",
+		"category": "analytics",
+		"imports": ["posthog-js", "posthog-node", "posthog-js/react"],
+		"globals": ["posthog"]
+	},
+	{
+		"vendor": "segment",
+		"category": "analytics",
+		"imports": ["@segment/analytics-next", "@segment/analytics-node", "analytics"],
+		"globals": ["analytics"]
+	},
+	{
+		"vendor": "mixpanel",
+		"category": "analytics",
+		"imports": ["mixpanel-browser", "mixpanel"],
+		"globals": ["mixpanel"]
+	},
+	{
+		"vendor": "hotjar",
+		"category": "analytics",
+		"imports": ["@hotjar/browser"],
+		"globals": ["hj"],
+		"scriptUrls": ["static.hotjar.com"]
+	},
+	{
+		"vendor": "intercom",
+		"category": "marketing",
+		"imports": ["@intercom/messenger-js-sdk"],
+		"globals": ["Intercom"]
+	},
+	{
+		"vendor": "linkedin-insight",
+		"category": "marketing",
+		"globals": ["_linkedin_partner_id", "lintrk"],
+		"scriptUrls": ["snap.licdn.com/li.lms-analytics"]
+	},
+	{
+		"vendor": "twitter-pixel",
+		"category": "marketing",
+		"globals": ["twq"],
+		"scriptUrls": ["static.ads-twitter.com/uwt.js"]
+	},
+	{
+		"vendor": "tiktok-pixel",
+		"category": "marketing",
+		"globals": ["ttq"],
+		"scriptUrls": ["analytics.tiktok.com/i18n/pixel"]
+	},
+	{
+		"vendor": "reddit-pixel",
+		"category": "marketing",
+		"globals": ["rdt"],
+		"scriptUrls": ["www.redditstatic.com/ads/pixel.js"]
+	},
+	{
+		"vendor": "sentry",
+		"category": "essential",
+		"imports": [
+			"@sentry/browser",
+			"@sentry/react",
+			"@sentry/nextjs",
+			"@sentry/node",
+			"@sentry/vue",
+			"@sentry/svelte",
+			"@sentry/solid"
+		]
+	},
+	{
+		"vendor": "datadog",
+		"category": "essential",
+		"imports": ["@datadog/browser-rum", "@datadog/browser-logs", "dd-trace"]
+	}
+]

--- a/packages/vite/src/consent/visit.test.ts
+++ b/packages/vite/src/consent/visit.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseFile } from "./parser";
+import type { Hit, Rule, VisitContext } from "./types";
+import { calleeMatches, getStringArg, isCallTo, walk } from "./visit";
+
+function runRules(file: string, source: string, rules: Rule[]): Hit[] {
+	const parsed = parseFile(file, source)!;
+	return walk(parsed, rules, []).hits;
+}
+
+describe("walk", () => {
+	it("visits every node and exposes a parent stack", () => {
+		const seen: string[] = [];
+		const rule: Rule = {
+			name: "probe",
+			visit: (ctx: VisitContext) => {
+				if (ctx.node.type === "Identifier") {
+					seen.push(`${ctx.node.name as string}@${ctx.parents.map((p) => p.type).join(",")}`);
+				}
+			},
+		};
+		runRules("a.ts", "const x = y;", [rule]);
+		expect(seen.some((s) => s.startsWith("x@"))).toBe(true);
+		expect(seen.some((s) => s.startsWith("y@"))).toBe(true);
+	});
+
+	it("offsets positions by lineOffset for SFC files", () => {
+		const src = `<template></template>\n<script>\ndocument.cookie = 'a';\n</script>`;
+		const parsed = parseFile("a.vue", src)!;
+		let line = 0;
+		walk(
+			parsed,
+			[
+				{
+					name: "p",
+					visit: (ctx) => {
+						if (ctx.node.type === "AssignmentExpression") {
+							line = ctx.position(ctx.node.start).line;
+						}
+					},
+				},
+			],
+			[],
+		);
+		expect(line).toBe(3);
+	});
+});
+
+describe("isCallTo / calleeMatches", () => {
+	it("matches dotted member expressions", () => {
+		const parsed = parseFile("a.ts", "Cookies.set('a', 'b');")!;
+		let matched = false;
+		walk(
+			parsed,
+			[
+				{
+					name: "p",
+					visit: (ctx) => {
+						if (isCallTo(ctx.node, "Cookies.set")) matched = true;
+					},
+				},
+			],
+			[],
+		);
+		expect(matched).toBe(true);
+	});
+
+	it("does not match similar-looking calls", () => {
+		const parsed = parseFile("a.ts", "Cookies.delete('a');")!;
+		let matched = false;
+		walk(
+			parsed,
+			[
+				{
+					name: "p",
+					visit: (ctx) => {
+						if (isCallTo(ctx.node, "Cookies.set")) matched = true;
+					},
+				},
+			],
+			[],
+		);
+		expect(matched).toBe(false);
+	});
+
+	it("matches plain identifier calls", () => {
+		const parsed = parseFile("a.ts", "gtag('event', 'x');")!;
+		let matched = false;
+		walk(
+			parsed,
+			[
+				{
+					name: "p",
+					visit: (ctx) => {
+						if (isCallTo(ctx.node, "gtag")) matched = true;
+					},
+				},
+			],
+			[],
+		);
+		expect(matched).toBe(true);
+	});
+});
+
+describe("getStringArg", () => {
+	it("reads literal string args", () => {
+		const parsed = parseFile("a.ts", "f('hello', 'world');")!;
+		let v: string | undefined;
+		walk(
+			parsed,
+			[
+				{
+					name: "p",
+					visit: (ctx) => {
+						if (isCallTo(ctx.node, "f")) v = getStringArg(ctx.node, 0);
+					},
+				},
+			],
+			[],
+		);
+		expect(v).toBe("hello");
+	});
+
+	it("reads simple template literals", () => {
+		const parsed = parseFile("a.ts", "f(`hello`);")!;
+		let v: string | undefined;
+		walk(
+			parsed,
+			[
+				{
+					name: "p",
+					visit: (ctx) => {
+						if (isCallTo(ctx.node, "f")) v = getStringArg(ctx.node, 0);
+					},
+				},
+			],
+			[],
+		);
+		expect(v).toBe("hello");
+	});
+
+	it("returns undefined for interpolated templates", () => {
+		const parsed = parseFile("a.ts", "f(`hi ${name}`);")!;
+		let v: string | undefined = "x";
+		walk(
+			parsed,
+			[
+				{
+					name: "p",
+					visit: (ctx) => {
+						if (isCallTo(ctx.node, "f")) v = getStringArg(ctx.node, 0);
+					},
+				},
+			],
+			[],
+		);
+		expect(v).toBeUndefined();
+	});
+});
+
+// helper used: silence unused warning
+void calleeMatches;

--- a/packages/vite/src/consent/visit.ts
+++ b/packages/vite/src/consent/visit.ts
@@ -1,0 +1,117 @@
+import type {
+	AnyNode,
+	Hit,
+	ParsedFile,
+	Rule,
+	Ungated,
+	VendorRegistry,
+	VisitContext,
+} from "./types";
+import { isGated } from "./ungated";
+
+const skipKeys = new Set(["loc", "range", "type", "start", "end"]);
+
+export type WalkResult = {
+	hits: Hit[];
+	ungated: Ungated[];
+};
+
+export function walk(parsed: ParsedFile, rules: Rule[], registry: VendorRegistry): WalkResult {
+	const hits: Hit[] = [];
+	const ungated: Ungated[] = [];
+	const parents: AnyNode[] = [];
+
+	const ctxBase = {
+		file: parsed.file,
+		source: parsed.source,
+		lineOffset: parsed.lineOffset,
+		registry,
+		localBindings: parsed.localBindings,
+		imports: parsed.imports,
+		position: (offset: number) => positionFor(parsed.source, offset, parsed.lineOffset),
+	};
+
+	function visit(node: AnyNode | null | undefined): void {
+		if (!node || typeof node !== "object" || typeof node.type !== "string") return;
+		const ctx: VisitContext = {
+			...ctxBase,
+			node,
+			parents,
+			report: (hit: Hit) => {
+				hits.push(hit);
+				if (!isGated(parents)) {
+					ungated.push({
+						file: hit.file,
+						line: hit.line,
+						reason: "kind" in hit ? "cookie-outside-gate" : "vendor-outside-gate",
+						hit,
+					});
+				}
+			},
+		};
+		for (const rule of rules) rule.visit(ctx);
+		parents.push(node);
+		for (const key in node) {
+			if (skipKeys.has(key)) continue;
+			const child = node[key];
+			if (Array.isArray(child)) {
+				for (const c of child) visit(c as AnyNode);
+			} else if (child && typeof child === "object" && "type" in child) {
+				visit(child as AnyNode);
+			}
+		}
+		parents.pop();
+	}
+
+	visit(parsed.ast);
+	return { hits, ungated };
+}
+
+function positionFor(
+	source: string,
+	offset: number,
+	lineOffset: number,
+): { line: number; column: number } {
+	let line = 1;
+	let lastNl = -1;
+	for (let i = 0; i < offset && i < source.length; i++) {
+		if (source.charCodeAt(i) === 10) {
+			line++;
+			lastNl = i;
+		}
+	}
+	return { line: line + lineOffset, column: offset - lastNl - 1 };
+}
+
+export function isCallTo(node: AnyNode, name: string): boolean {
+	if (node.type !== "CallExpression") return false;
+	return calleeMatches(node.callee as AnyNode | undefined, name);
+}
+
+export function calleeMatches(callee: AnyNode | null | undefined, name: string): boolean {
+	if (!callee) return false;
+	const parts = name.split(".");
+	if (parts.length === 1) {
+		return callee.type === "Identifier" && callee.name === parts[0];
+	}
+	if (callee.type !== "StaticMemberExpression" && callee.type !== "MemberExpression") return false;
+	const prop = callee.property as AnyNode | undefined;
+	if (!prop || prop.type !== "Identifier" || prop.name !== parts[parts.length - 1]) return false;
+	return calleeMatches(callee.object as AnyNode | undefined, parts.slice(0, -1).join("."));
+}
+
+export function getStringArg(node: AnyNode, index: number): string | undefined {
+	const args = node.arguments as AnyNode[] | undefined;
+	if (!args || !args[index]) return undefined;
+	const arg = args[index];
+	if (arg.type === "Literal" && typeof arg.value === "string") return arg.value;
+	if (arg.type === "TemplateLiteral") {
+		const quasis = arg.quasis as AnyNode[] | undefined;
+		const exprs = arg.expressions as AnyNode[] | undefined;
+		if (quasis && quasis.length === 1 && (!exprs || exprs.length === 0)) {
+			const cooked = (quasis[0] as { value?: { cooked?: string } } | undefined)?.value?.cooked;
+			if (typeof cooked === "string") return cooked;
+		}
+	}
+	return undefined;
+}

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -20,6 +20,8 @@ import {
 	loadAndValidateConfig,
 	type ValidatedConfig,
 } from "./validate";
+import type { Logger, Mode } from "./consent/reporter";
+import { type ConsentRunner, createConsentRunner } from "./consent/runner";
 
 export type OpenPolicyOptions = {
 	/**
@@ -74,6 +76,32 @@ export type OpenPolicyOptions = {
 	 * failures. Defaults to `[]`.
 	 */
 	suppress?: IssueCode[];
+
+	/**
+	 * Opt-in OpenCookies consent scanner (folded in by PS-19). When this key
+	 * is present, the same plugin also runs a *separate* oxc walk that flags
+	 * ungated cookie writes / tracking-vendor usage. Omit it entirely to skip
+	 * the consent scan — existing policy behaviour is unaffected.
+	 *
+	 * This is structural co-location only: the consent walk never contributes
+	 * to `openpolicy.gen.ts` and is independent of `validate()` / `strict` /
+	 * `suppress`. A single unified walk + declared-vs-used cross-check is
+	 * PS-25.
+	 */
+	consent?: {
+		/**
+		 * `"error"` fails `vite build` on ungated findings (thrown from
+		 * `buildEnd`); `"warn"` logs them; `"off"` disables the scan while
+		 * keeping the option present. Defaults to `"error"` on `vite build`
+		 * and `"warn"` on `vite dev`.
+		 */
+		mode?: Mode;
+		/** Glob(s) of files to scan. Defaults to the consent scanner's own
+		 * source globs (js/ts/jsx/tsx/vue/svelte). */
+		include?: string[];
+		/** Glob(s) to exclude. Defaults to node_modules/dist/build/etc. */
+		exclude?: string[];
+	};
 };
 
 /**
@@ -169,6 +197,10 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 	let resolvedConfigDir: string;
 	let resolvedConfigFile: string | null = null;
 	let resolvedCommand: "build" | "serve" = "build";
+	// Opt-in OpenCookies consent scanner (PS-19). Stays null unless
+	// `options.consent` is set, so existing policy-only users see no change.
+	let consentRunner: ConsentRunner | null = null;
+	let consentLogger: Logger | null = null;
 	// Resolver-backed SDK matcher, built from `this.resolve` in `buildStart`.
 	// Defaults are the pure dual-scope predicate so an out-of-order or
 	// resolver-less call (test stubs, a dev rescan that somehow beats
@@ -386,6 +418,19 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			resolvedRoot = config.root;
 			resolvedSrcDir = resolve(config.root, srcDirOpt);
 			resolvedCommand = config.command;
+			if (options.consent) {
+				const mode: Mode = options.consent.mode ?? (config.command === "build" ? "error" : "warn");
+				// Report through Vite's logger (captured here), never via
+				// `this.error` — the consent scan must only abort the build
+				// from `buildEnd`, exactly like the old @opencookies/vite.
+				consentLogger = config.logger;
+				consentRunner = createConsentRunner({
+					root: config.root,
+					mode,
+					include: options.consent.include,
+					exclude: options.consent.exclude,
+				});
+			}
 		},
 		async buildStart() {
 			const found = await findConfig(resolvedRoot);
@@ -454,6 +499,17 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 					}
 				}
 			}
+			// Co-located OpenCookies consent scan (PS-19). Runs *after*
+			// policy validation, so a policy `this.error()` abort still
+			// short-circuits it. Reports through Vite's logger; only
+			// `buildEnd` fails the build — `build()` never rethrows.
+			if (consentRunner && consentLogger) {
+				try {
+					await consentRunner.build(consentLogger);
+				} catch (err) {
+					consentLogger.warn(`[opencookies] consent scan failed: ${err}`);
+				}
+			}
 		},
 		configureServer(server) {
 			// Make sure chokidar watches the whole src tree, not just files
@@ -467,6 +523,15 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			if (resolvedConfigFile) server.watcher.add(resolvedConfigFile);
 
 			const handler = async (file: string): Promise<void> => {
+				// Consent rescan runs on its own broader gate (vue/svelte,
+				// files outside srcDir) *before* the policy early-return.
+				if (consentRunner) {
+					try {
+						await consentRunner.hotUpdate(file, server.config.logger);
+					} catch (error) {
+						server.config.logger.error(`[opencookies] consent rescan failed: ${error}`);
+					}
+				}
 				const tracked = isTrackedSource(file);
 				const isConfig = resolvedConfigFile !== null && file === resolvedConfigFile;
 				if (!tracked && !isConfig) return;
@@ -489,6 +554,12 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			// the terminal in the same way — so we re-emit through the
 			// server logger for visibility on `vite dev` startup.
 			void runValidationDev(server);
+		},
+		// Consent build-fail seam (PS-19): mirrors the old @opencookies/vite
+		// — throws on remaining ungated findings when mode === "error".
+		// Policy still fails separately via `this.error()` in buildStart.
+		buildEnd(err?: Error) {
+			consentRunner?.buildEnd(err);
 		},
 	};
 }

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -1,7 +1,9 @@
 {
 	"extends": "@openpolicy/tooling/base",
 	"include": ["src"],
+	"exclude": ["src/consent/__fixtures__"],
 	"compilerOptions": {
-		"outDir": "dist"
+		"outDir": "dist",
+		"resolveJsonModule": true
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       oxc-parser:
         specifier: ^0.124.0
         version: 0.124.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      tinyglobby:
+        specifier: ^0.2.0
+        version: 0.2.16
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@latest
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,13 @@ import { defineConfig } from "vite-plus";
 export default defineConfig({
 	fmt: {
 		useTabs: true,
-		ignorePatterns: ["**/*.gen.ts", "**/CHANGELOG.md"],
+		// `**/__fixtures__/**`: vendored OpenCookies consent-scanner fixtures
+		// (PS-19) are intentionally messy sample sources with frozen
+		// `.expected.json` snapshots — never reformat them.
+		ignorePatterns: ["**/*.gen.ts", "**/CHANGELOG.md", "**/__fixtures__/**"],
+	},
+	lint: {
+		ignorePatterns: ["**/__fixtures__/**"],
 	},
 	test: {
 		exclude: ["**/node_modules/**", "**/dist/**"],


### PR DESCRIPTION
Closes PS-19. Targets **`v1`** (PS-* work must not target `main`).

## What

Structural co-location only — **one** Vite plugin now carries both rule sets. The OpenCookies scanner (7 ungated-usage rules + `vendors.json` + parser/visit/ungated/suppress/sfc) is vendored into `packages/vite/src/consent/` as a self-contained island and wired into the existing `openPolicy()` lifecycle.

- **Opt-in** new `OpenPolicyOptions.consent?: { mode, include, exclude }`. Omitting it is a no-op for existing policy-only users (zero blast radius). Default `mode`: build→`error`, serve→`warn`; `off` disables.
- **One plugin object** (`name: "openpolicy"`): `configResolved` (mode/logger), `buildStart` (consent scan *after* policy validation, never rethrows), `configureServer` watcher (broader-gated rescan before the policy gate), and a new `buildEnd` seam that throws on ungated findings when `mode === "error"`. Reports via Vite's logger, never `this.error`. The PS-5 `openpolicy.gen.ts` path is untouched (consent never writes it).
- `runner.ts` carries the old `@opencookies/vite` plugin logic; `reporter.ts` owns the `Mode` type.

## Why

PS-16 folded OpenCookies *core* into `@openpolicy/core/consent`; PS-19 brings the *scanner* in so there's one plugin instead of two. Per the approved plan and the "cut scope for v1" steer, this is co-location only.

## oxc-parser 0.40 → 0.124

**Zero scanner code changes** — the scanner was already ESTree/`preserveParens`-compatible (`parseSync(f,s,{lang})`, `comments[].{type,value,start}`, dual `MemberExpression`/`StaticMemberExpression` guards). The 64 vendored tests + byte-for-byte `.expected.json` fixtures are the regression net.

## Mechanical edits (no behaviour change)

Stripped `.ts` import extensions (base tsconfig is bundler, no `allowImportingTsExtensions`), dropped `with { type: "json" }`, `packages/vite/tsconfig.json` += `resolveJsonModule` + excludes `src/consent/__fixtures__`, ported test imports `vitest`→`vite-plus/test`, fixture-path `..` depth −1, root `vite.config.ts` ignores `**/__fixtures__/**` for fmt+lint, added `tinyglobby` dep.

## Verification

- `vp run -r build` (13 pkgs) ✓ · `examples/tanstack` `vp build` ✓ (consent opt-out → unaffected)
- `@openpolicy/vite` **192/192** tests (existing policy + 64 consent + `example-green` + `plugin-fold` one-plugin assertion)
- `vp check` ✓ (381 formatted, 0 lint errors) · `vp run -r check-types` ✓ (0 errors, 11 pkgs)

## Reviewer notes

- `packages/solid/src/index.test.tsx` (15 fails) is **pre-existing on `v1`** and untouched by this PR (solid-js/happy-dom test-env); acceptable per CLAUDE.md.
- Deferred to **PS-25**: single unified oxc walk, declared-vs-used cross-check, merged vendor registry, full `rules`/`vendors` option surface, `autosync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)