### PR TITLE
Add sharing() call scanner for data-egress edge detection

### DIFF
--- a/examples/tanstack/src/lib/stripe.ts
+++ b/examples/tanstack/src/lib/stripe.ts
@@ -1,5 +1,11 @@
-import { thirdParty } from "@openpolicy/sdk";
+import { sharing, thirdParty } from "@openpolicy/sdk";
 
 thirdParty("Stripe", "Payment processing", "https://stripe.com/privacy");
 
 // Mock Stripe calls
+export async function reportCharge(email: string, amountCents: number) {
+	return fetch("https://api.stripe.com/v1/charges", {
+		method: "POST",
+		body: JSON.stringify(sharing("Account Information", "Stripe", { email, amountCents })),
+	});
+}

--- a/examples/tanstack/src/openpolicy.gen.ts
+++ b/examples/tanstack/src/openpolicy.gen.ts
@@ -4,6 +4,7 @@ import type { ScannedCollectionKeys } from "@openpolicy/sdk";
 export const dataCollected: Record<keyof ScannedCollectionKeys & string, string[]> = {"Account Information":["Name","Email"],"Usage Data":["Pages visited","Browser type"]};
 export const thirdParties: { name: string; purpose: string; policyUrl: string }[] = [{"name":"Stripe","purpose":"Payment processing","policyUrl":"https://stripe.com/privacy"}];
 export const cookies: { essential: true; [key: string]: boolean } = {"essential":true};
+export const sharing: { key: string; recipient: string }[] = [{"key":"Account Information","recipient":"Stripe"}];
 
 declare module "@openpolicy/sdk" {
 	interface ScannedCollectionKeys {
@@ -12,5 +13,8 @@ declare module "@openpolicy/sdk" {
 	}
 	interface ScannedCookieKeys {
 		"essential": true;
+	}
+	interface ScannedSharingKeys {
+		"Account Information": true;
 	}
 }

--- a/packages/sdk/src/auto-collected.ts
+++ b/packages/sdk/src/auto-collected.ts
@@ -5,9 +5,9 @@
  * require a `data.context` entry (with `purpose`, `lawfulBasis`, `retention`,
  * and `provision`) for every scanned key.
  *
- * The scanned *values* (`dataCollected`, `thirdParties`, `cookies`) are no
- * longer exported from `@openpolicy/sdk`; import them explicitly from your
- * generated `./openpolicy.gen` module instead.
+ * The scanned *values* (`dataCollected`, `thirdParties`, `cookies`,
+ * `sharing`) are no longer exported from `@openpolicy/sdk`; import them
+ * explicitly from your generated `./openpolicy.gen` module instead.
  */
 // biome-ignore lint/suspicious/noEmptyInterface: augmented by codegen
 export interface ScannedCollectionKeys {}
@@ -20,3 +20,15 @@ export interface ScannedCollectionKeys {}
  */
 // biome-ignore lint/suspicious/noEmptyInterface: augmented by codegen
 export interface ScannedCookieKeys {}
+
+/**
+ * Augmented by `openpolicy.gen.ts` (emitted by `@openpolicy/vite` alongside
+ * your config, meant to be committed) with one key per scanned `sharing()`
+ * data category — the personal-data categories that *leave* to a third party.
+ * It is a typed seam: the §4.3 declared-vs-used cross-check keys off it to
+ * verify every shared category is also declared. The full
+ * (`key` → `recipient`) edges are carried by the generated `sharing` value
+ * export.
+ */
+// biome-ignore lint/suspicious/noEmptyInterface: augmented by codegen
+export interface ScannedSharingKeys {}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -40,12 +40,17 @@ export {
 	Voluntary,
 } from "@openpolicy/core";
 
-export type { ScannedCollectionKeys, ScannedCookieKeys } from "./auto-collected";
+export type {
+	ScannedCollectionKeys,
+	ScannedCookieKeys,
+	ScannedSharingKeys,
+} from "./auto-collected";
 export { collecting, Ignore } from "./collecting";
 export { Compliance } from "./compliance";
 export { DataCategories, LegalBases, Retention } from "./data";
 export { defineCookie } from "./define-cookie";
 export { Providers } from "./providers";
+export { sharing } from "./sharing";
 export { thirdParty } from "./third-parties";
 
 type ScannedDataKey = keyof ScannedCollectionKeys & string;

--- a/packages/sdk/src/sharing.test.ts
+++ b/packages/sdk/src/sharing.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vite-plus/test";
+import { sharing } from "./sharing";
+
+test("returns the exact same reference as value", () => {
+	const value = { email: "ada@example.com", amountCents: 500 };
+	const result = sharing("Account Information", "Stripe", value);
+	expect(result).toBe(value);
+});
+
+test("key and recipient are never evaluated at runtime", () => {
+	const value = { email: "ada@example.com" };
+	const result = sharing("Account Information", "Stripe", value);
+	expect(result).toBe(value);
+});
+
+test("returns the payload unchanged for primitives", () => {
+	expect(sharing("Usage Data", "PostHog", 42)).toBe(42);
+	expect(sharing("Usage Data", "PostHog", "raw")).toBe("raw");
+});
+
+test("works when value is an empty object", () => {
+	const value = {};
+	const result = sharing("Empty", "Nobody", value);
+	expect(result).toBe(value);
+});
+
+test("preserves branded/opaque payload types without degrading inference", () => {
+	type Payload = { readonly __brand: "Payload"; email: string };
+	const payload = {
+		__brand: "Payload",
+		email: "ada@example.com",
+	} as unknown as Payload;
+
+	// Compile-time check: the generic should infer `Payload` so the return
+	// type is `Payload`.
+	const result: Payload = sharing("Account Information", "Stripe", payload);
+	expect(result).toBe(payload);
+});

--- a/packages/sdk/src/sharing.ts
+++ b/packages/sdk/src/sharing.ts
@@ -1,0 +1,42 @@
+/**
+ * Marks personal data **leaving** to a third party, at the exact point it
+ * leaves. Returns `value` unchanged at runtime — the Vite plugin / CLI static
+ * analyser scans `sharing()` calls at build time and records the
+ * (`key` → `recipient`) edge.
+ *
+ * This is the data-flow **edge**, not a vendor declaration. It is deliberately
+ * distinct from {@link thirdParty}:
+ *
+ *   - `thirdParty(name, purpose, policyUrl)` declares that a vendor *exists*
+ *     in your stack and why — the static "who we work with" recipient list.
+ *     It says nothing about which personal data actually reaches that vendor.
+ *   - `sharing(key, recipient, value)` records that a specific category of
+ *     personal data (`key`) is actually disclosed to `recipient` on *this*
+ *     code path. Its presence is the CCPA/CPRA "sell/share" signal: a vendor
+ *     in your `thirdParty()` list may be a pure processor and receive no
+ *     personal data, so vendor existence alone cannot prove a sale or share.
+ *
+ * Place it at the egress point — wrap the outbound payload — not at module
+ * scope. `key` is the data category being shared (it should match a
+ * `collecting()` category); `recipient` is the third party (it should match a
+ * `thirdParty()` name). Both must be **string literals** — dynamic values are
+ * silently skipped by the analyser. `value` is returned untouched and is never
+ * read at build time.
+ *
+ * @example
+ * ```ts
+ * import { sharing } from "@openpolicy/sdk";
+ *
+ * export async function reportPurchase(email: string, amountCents: number) {
+ *   return fetch("https://api.stripe.com/v1/charges", {
+ *     method: "POST",
+ *     body: JSON.stringify(
+ *       sharing("Account Information", "Stripe", { email, amountCents }),
+ *     ),
+ *   });
+ * }
+ * ```
+ */
+export function sharing<T>(_key: string, _recipient: string, value: T): T {
+	return value;
+}

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -1,8 +1,8 @@
 # `@openpolicy/vite`
 
-> Vite plugin that scans source files for [OpenPolicy](https://openpolicy.sh) `collecting()` and `thirdParty()` calls and populates the SDK's auto-collected registry at build time.
+> Vite plugin that scans source files for [OpenPolicy](https://openpolicy.sh) `collecting()`, `thirdParty()`, `defineCookie()`, and `sharing()` calls and populates the SDK's auto-collected registry at build time.
 
-At `buildStart` the plugin walks your `srcDir`, extracts every `collecting()` / `thirdParty()` call from `@openpolicy/sdk`, and exposes the merged result as `dataCollected` / `thirdParties` on `@openpolicy/sdk`. Your policy config spreads those values into the runtime-rendered policy — no files are written to disk.
+At `buildStart` the plugin walks your `srcDir`, extracts every `collecting()` / `thirdParty()` / `defineCookie()` / `sharing()` call from `@openpolicy/sdk`, and emits the merged result (`dataCollected` / `thirdParties` / `cookies` / `sharing`) into the on-disk `openpolicy.gen.ts` your config imports. `sharing(key, recipient, value)` marks personal data _leaving_ to a third party at the egress point — the data-flow edge that feeds the CCPA/CPRA sell/share posture, distinct from `thirdParty()` which only declares that a vendor exists.
 
 ## Install
 
@@ -30,7 +30,7 @@ Astro users: add it the same way under `vite.plugins` in `astro.config.mjs`.
 
 | Option                        | Type          | Default           | Description                                                                                                                                     |
 | ----------------------------- | ------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `srcDir`                      | `string`      | `"src"`           | Directory walked for `collecting()` / `thirdParty()` calls, relative to the Vite root.                                                          |
+| `srcDir`                      | `string`      | `"src"`           | Directory walked for `collecting()` / `thirdParty()` / `defineCookie()` / `sharing()` calls, relative to the Vite root.                         |
 | `extensions`                  | `string[]`    | `[".ts", ".tsx"]` | File extensions to scan.                                                                                                                        |
 | `ignore`                      | `string[]`    | `[]`              | Extra directory basenames to skip (appended to the built-in list: `node_modules`, `dist`, `.git`, `.next`, `.output`, `.svelte-kit`, `.cache`). |
 | `thirdParties.usePackageJson` | `boolean`     | `false`           | Auto-detect third-party services from `package.json` dependencies against the built-in registry (Stripe, Sentry, PostHog, etc.).                |

--- a/packages/vite/src/analyse.test.ts
+++ b/packages/vite/src/analyse.test.ts
@@ -563,6 +563,151 @@ test("cookies + collecting + thirdParty coexist in one file", () => {
 });
 
 // ---------------------------------------------------------------------------
+// sharing() — data-egress edge detection
+// ---------------------------------------------------------------------------
+
+test("sharing: canonical case with 2 string literals + a value", () => {
+	const code = `
+		import { sharing } from "@openpolicy/sdk";
+		sharing("Account Information", "Stripe", { email });
+	`;
+	expect(extractFromFile("a.ts", code).sharing).toEqual([
+		{ key: "Account Information", recipient: "Stripe" },
+	]);
+});
+
+test("sharing: renamed import", () => {
+	const code = `
+		import { sharing as shareWith } from "@openpolicy/sdk";
+		shareWith("Usage Data", "PostHog", payload);
+	`;
+	expect(extractFromFile("a.ts", code).sharing).toEqual([
+		{ key: "Usage Data", recipient: "PostHog" },
+	]);
+});
+
+test("sharing: ignored if imported from non-SDK module", () => {
+	const code = `
+		import { sharing } from "./local-sharing";
+		sharing("Account Information", "Stripe", v);
+	`;
+	expect(extractFromFile("a.ts", code).sharing).toEqual([]);
+});
+
+test("sharing: ignored for type-only imports", () => {
+	const code = `
+		import type { sharing } from "@openpolicy/sdk";
+		sharing("Account Information", "Stripe", v);
+	`;
+	expect(extractFromFile("a.ts", code).sharing).toEqual([]);
+});
+
+test("sharing with fewer than 3 args is diagnosed", () => {
+	const code = `
+		import { sharing } from "@openpolicy/sdk";
+		sharing("Account Information", "Stripe");
+	`;
+	const result = extractFromFile("a.ts", code);
+	expect(result.sharing).toEqual([]);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "missing-arguments",
+			message: "sharing() requires 3 arguments (key, recipient, value)",
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+	]);
+});
+
+test("sharing with a non-literal key is diagnosed", () => {
+	const code = `
+		import { sharing } from "@openpolicy/sdk";
+		const key = "Account Information";
+		sharing(key, "Stripe", v);
+	`;
+	const result = extractFromFile("a.ts", code);
+	expect(result.sharing).toEqual([]);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-argument",
+			message: "sharing() key must be a string literal",
+			file: "a.ts",
+			line: 4,
+			column: 3,
+		},
+	]);
+});
+
+test("sharing with a non-literal recipient is diagnosed", () => {
+	const code = `
+		import { sharing } from "@openpolicy/sdk";
+		sharing("Account Information", getRecipient(), v);
+	`;
+	const result = extractFromFile("a.ts", code);
+	expect(result.sharing).toEqual([]);
+	expect(result.diagnostics).toEqual([
+		{
+			code: "non-literal-argument",
+			message: "sharing() recipient must be a string literal",
+			file: "a.ts",
+			line: 3,
+			column: 3,
+		},
+	]);
+});
+
+test("sharing: the value argument is never scanned and never diagnosed", () => {
+	const code = `
+		import { sharing } from "@openpolicy/sdk";
+		sharing("Account Information", "Stripe", buildPayload(user, opts));
+	`;
+	const result = extractFromFile("a.ts", code);
+	expect(result.sharing).toEqual([{ key: "Account Information", recipient: "Stripe" }]);
+	expect(result.diagnostics).toEqual([]);
+});
+
+test("sharing: identical (key, recipient) in same file appears once, no diagnostic", () => {
+	const code = `
+		import { sharing } from "@openpolicy/sdk";
+		sharing("Account Information", "Stripe", a);
+		sharing("Account Information", "Stripe", b);
+	`;
+	const result = extractFromFile("a.ts", code);
+	expect(result.sharing).toEqual([{ key: "Account Information", recipient: "Stripe" }]);
+	// Within-file duplicate edge is intentional dedup, not data loss.
+	expect(result.diagnostics).toEqual([]);
+});
+
+test("sharing: same key to different recipients are distinct edges", () => {
+	const code = `
+		import { sharing } from "@openpolicy/sdk";
+		sharing("Usage Data", "PostHog", a);
+		sharing("Usage Data", "Stripe", b);
+	`;
+	expect(extractFromFile("a.ts", code).sharing).toEqual([
+		{ key: "Usage Data", recipient: "PostHog" },
+		{ key: "Usage Data", recipient: "Stripe" },
+	]);
+});
+
+test("all four call-site helpers coexist in one file", () => {
+	const code = `
+		import { collecting, thirdParty, defineCookie, sharing } from "@openpolicy/sdk";
+		collecting("Account Information", v, { name: "Name" });
+		thirdParty("Stripe", "Payments", "https://stripe.com/privacy");
+		defineCookie("analytics");
+		sharing("Account Information", "Stripe", v);
+	`;
+	const result = extractFromFile("a.tsx", code);
+	expect(result.dataCollected).toEqual({ "Account Information": ["Name"] });
+	expect(result.thirdParties).toHaveLength(1);
+	expect(result.cookies).toEqual(["analytics"]);
+	expect(result.sharing).toEqual([{ key: "Account Information", recipient: "Stripe" }]);
+	expect(result.diagnostics).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
 // diagnostic location + aggregation
 // ---------------------------------------------------------------------------
 

--- a/packages/vite/src/analyse.ts
+++ b/packages/vite/src/analyse.ts
@@ -5,6 +5,7 @@ const COLLECTING_NAME = "collecting";
 const THIRD_PARTY_NAME = "thirdParty";
 const IGNORE_NAME = "Ignore";
 const DEFINE_COOKIE_NAME = "defineCookie";
+const SHARING_NAME = "sharing";
 
 type AnyNode = { type: string; [key: string]: unknown };
 
@@ -12,6 +13,17 @@ export type ThirdPartyEntry = {
 	name: string;
 	purpose: string;
 	policyUrl: string;
+};
+
+/**
+ * One scanned `sharing(key, recipient, value)` edge: the personal-data
+ * category (`key`) that leaves to `recipient`. The data-flow edge powering the
+ * CCPA/CPRA sell/share posture and the §4.3 declared-vs-used cross-check —
+ * distinct from {@link ThirdPartyEntry}, which is only the vendor declaration.
+ */
+export type SharingEntry = {
+	key: string;
+	recipient: string;
 };
 
 /**
@@ -45,11 +57,12 @@ type ExtractResult = {
 	dataCollected: Record<string, string[]>;
 	thirdParties: ThirdPartyEntry[];
 	cookies: string[];
+	sharing: SharingEntry[];
 	diagnostics: ScannerDiagnostic[];
 };
 
 function emptyResult(): ExtractResult {
-	return { dataCollected: {}, thirdParties: [], cookies: [], diagnostics: [] };
+	return { dataCollected: {}, thirdParties: [], cookies: [], sharing: [], diagnostics: [] };
 }
 
 /**
@@ -114,15 +127,15 @@ function collectImportSources(program: AnyNode): string[] {
 }
 
 /**
- * Extract `collecting()`, `thirdParty()`, and `defineCookie()` call metadata
- * from a single source file.
+ * Extract `collecting()`, `thirdParty()`, `defineCookie()`, and `sharing()`
+ * call metadata from a single source file.
  *
  * Returns an `ExtractResult` with `dataCollected` (category → labels),
  * `thirdParties` (array of third-party entries), `cookies` (array of
- * category names), and `diagnostics` — one located warning for every
- * recognized call that couldn't be read statically (so no recognized call is
- * ever dropped silently). Files with no matching calls — or that fail to
- * parse — return empty defaults.
+ * category names), `sharing` (array of key → recipient edges), and
+ * `diagnostics` — one located warning for every recognized call that couldn't
+ * be read statically (so no recognized call is ever dropped silently). Files
+ * with no matching calls — or that fail to parse — return empty defaults.
  *
  * `isSdkSpecifier` decides whether an import source is the SDK. It defaults
  * to {@link isCanonicalSdkSpecifier} (exact dual-scope match) so direct
@@ -148,8 +161,8 @@ export function extractFromFile(
  *
  * Runs in two phases:
  * 1. Collect local names bound to `collecting` / `thirdParty` / `defineCookie`
- *    imported from an SDK specifier (handles renamed imports, skips type-only
- *    imports, ignores look-alikes from other modules).
+ *    / `sharing` imported from an SDK specifier (handles renamed imports, skips
+ *    type-only imports, ignores look-alikes from other modules).
  * 2. Walk the program body and inspect `CallExpression` nodes whose target
  *    is one of those tracked local names.
  */
@@ -162,13 +175,21 @@ export function extractFromParsed(
 	const thirdPartyNames = collectBindings(program, isSdkSpecifier, THIRD_PARTY_NAME);
 	const ignoreNames = collectBindings(program, isSdkSpecifier, IGNORE_NAME);
 	const defineCookieNames = collectBindings(program, isSdkSpecifier, DEFINE_COOKIE_NAME);
-	if (collectingNames.size === 0 && thirdPartyNames.size === 0 && defineCookieNames.size === 0)
+	const sharingNames = collectBindings(program, isSdkSpecifier, SHARING_NAME);
+	if (
+		collectingNames.size === 0 &&
+		thirdPartyNames.size === 0 &&
+		defineCookieNames.size === 0 &&
+		sharingNames.size === 0
+	)
 		return emptyResult();
 
 	const dataCollected: Record<string, string[]> = {};
 	const thirdParties: ThirdPartyEntry[] = [];
 	const seenThirdParties = new Set<string>();
 	const cookieSet = new Set<string>();
+	const sharing: SharingEntry[] = [];
+	const seenSharing = new Set<string>();
 	const diagnostics: ScannerDiagnostic[] = [];
 	const locate = makeLineLocator(code);
 	const record: RecordFn = (skipCode, message, node) => {
@@ -263,10 +284,37 @@ export function extractFromParsed(
 				return;
 			}
 			cookieSet.add(category);
+			return;
+		}
+
+		if (sharingNames.has(calleeName)) {
+			if (!args || args.length < 3) {
+				record("missing-arguments", "sharing() requires 3 arguments (key, recipient, value)", node);
+				return;
+			}
+			const key = extractStringLiteral(args[0]);
+			if (key === null) {
+				record("non-literal-argument", "sharing() key must be a string literal", node);
+				return;
+			}
+			const recipient = extractStringLiteral(args[1]);
+			if (recipient === null) {
+				record("non-literal-argument", "sharing() recipient must be a string literal", node);
+				return;
+			}
+			// args[2] is the payload — returned unchanged at runtime, never read
+			// statically (same as collecting()'s value argument).
+			// Within-file duplicate of an already-captured edge — intentional
+			// dedup, the data is not lost, so no diagnostic. JSON tuple key so
+			// a space in either string can't alias a different (key, recipient).
+			const dedup = JSON.stringify([key, recipient]);
+			if (seenSharing.has(dedup)) return;
+			seenSharing.add(dedup);
+			sharing.push({ key, recipient });
 		}
 	});
 
-	return { dataCollected, thirdParties, cookies: [...cookieSet], diagnostics };
+	return { dataCollected, thirdParties, cookies: [...cookieSet], sharing, diagnostics };
 }
 
 /**

--- a/packages/vite/src/index.test.ts
+++ b/packages/vite/src/index.test.ts
@@ -97,6 +97,7 @@ type ScannedResult = {
 	dataCollected: Record<string, string[]>;
 	thirdParties: ThirdPartyEntry[];
 	cookies: { essential: boolean; [key: string]: boolean };
+	sharing: { key: string; recipient: string }[];
 };
 
 /**
@@ -119,6 +120,7 @@ async function readScanned(root: string): Promise<ScannedResult> {
 		dataCollected: parse<Record<string, string[]>>("dataCollected"),
 		thirdParties: parse<ThirdPartyEntry[]>("thirdParties"),
 		cookies: parse<{ essential: boolean; [key: string]: boolean }>("cookies"),
+		sharing: parse<{ key: string; recipient: string }[]>("sharing"),
 	};
 }
 
@@ -610,6 +612,56 @@ test("thirdParty() deduplication across files — same name in two files yields 
 	]);
 });
 
+test("sharing() calls are scanned and appear in the gen module sharing export", async () => {
+	await touch(
+		"src/payments.ts",
+		`
+		import { sharing } from "@openpolicy/sdk";
+		export const charge = (email: string) =>
+			fetch("/x", { body: JSON.stringify(sharing("Account Information", "Stripe", { email })) });
+		`,
+	);
+
+	const plugin = openPolicy();
+	await runPluginBuildStart(plugin, tmp);
+
+	expect((await readScanned(tmp)).sharing).toEqual([
+		{ key: "Account Information", recipient: "Stripe" },
+	]);
+
+	// The data-category axis is also surfaced as the ScannedSharingKeys seam.
+	const dts = await readFile(join(tmp, "openpolicy.gen.ts"), "utf8");
+	expect(dts).toContain("interface ScannedSharingKeys");
+	expect(dts).toContain('"Account Information": true');
+});
+
+test("sharing() dedup across files — same (key, recipient) in two files yields one edge", async () => {
+	// Files are walked in sorted order: a-file.ts before b-file.ts.
+	await touch(
+		"src/a-file.ts",
+		`
+		import { sharing } from "@openpolicy/sdk";
+		sharing("Account Information", "Stripe", a);
+		`,
+	);
+	await touch(
+		"src/b-file.ts",
+		`
+		import { sharing } from "@openpolicy/sdk";
+		sharing("Account Information", "Stripe", b);
+		sharing("Usage Data", "PostHog", c);
+		`,
+	);
+
+	const plugin = openPolicy();
+	await runPluginBuildStart(plugin, tmp);
+
+	expect((await readScanned(tmp)).sharing).toEqual([
+		{ key: "Account Information", recipient: "Stripe" },
+		{ key: "Usage Data", recipient: "PostHog" },
+	]);
+});
+
 test("dev watcher triggers reload when thirdParty() call is added", async () => {
 	await touch("src/payments.ts", `export const x = 1;\n`);
 
@@ -875,6 +927,8 @@ test("buildStart writes openpolicy.gen.ts with scanned keys", async () => {
 	expect(dts).toContain("export const dataCollected:");
 	expect(dts).toContain("export const thirdParties:");
 	expect(dts).toContain("export const cookies:");
+	expect(dts).toContain("export const sharing:");
+	expect(dts).toContain("interface ScannedSharingKeys");
 	expect(dts).not.toContain("export {};");
 	// The emitted values round-trip back through the reader.
 	expect((await readScanned(tmp)).dataCollected).toEqual({

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -7,6 +7,7 @@ import {
 	parseModule,
 	type ParsedModule,
 	type ScannerDiagnostic,
+	type SharingEntry,
 	type ThirdPartyEntry,
 } from "./analyse";
 import { KNOWN_COOKIE_PACKAGES, KNOWN_PACKAGES } from "./known-packages";
@@ -214,6 +215,7 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 		dataCollected: {},
 		thirdParties: [],
 		cookies: { essential: true },
+		sharing: [],
 		diagnostics: [],
 	};
 
@@ -267,6 +269,8 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 		const mergedParties: ThirdPartyEntry[] = [];
 		const seenParties = new Set<string>();
 		const cookieSet = new Set<string>();
+		const mergedSharing: SharingEntry[] = [];
+		const seenSharing = new Set<string>();
 		const diagnostics: ScannerDiagnostic[] = [];
 		const genFile = resolvedConfigDir ? resolve(resolvedConfigDir, GEN_FILENAME) : null;
 		// Phase 1: parse every file once and collect the union of import
@@ -311,6 +315,12 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 				}
 			}
 			for (const cat of extracted.cookies) cookieSet.add(cat);
+			for (const edge of extracted.sharing) {
+				const dedup = JSON.stringify([edge.key, edge.recipient]);
+				if (seenSharing.has(dedup)) continue;
+				seenSharing.add(dedup);
+				mergedSharing.push(edge);
+			}
 		}
 		if (usePackageJsonOpt) {
 			const pkgEntries = await detectThirdPartiesFromPackageJson(resolvedRoot);
@@ -334,6 +344,7 @@ export function openPolicy(options: OpenPolicyOptions = {}): Plugin {
 			dataCollected: mergedData,
 			thirdParties: mergedParties,
 			cookies,
+			sharing: mergedSharing,
 			diagnostics,
 		};
 	}

--- a/packages/vite/src/scanned.ts
+++ b/packages/vite/src/scanned.ts
@@ -1,4 +1,4 @@
-import type { ScannerDiagnostic, ThirdPartyEntry } from "./analyse";
+import type { ScannerDiagnostic, SharingEntry, ThirdPartyEntry } from "./analyse";
 
 export type CookieMap = { essential: boolean; [key: string]: boolean };
 
@@ -6,6 +6,7 @@ export type Scanned = {
 	dataCollected: Record<string, string[]>;
 	thirdParties: ThirdPartyEntry[];
 	cookies: CookieMap;
+	sharing: SharingEntry[];
 	/**
 	 * Located warnings for recognized calls that couldn't be read statically.
 	 * Carried through the scan but never rendered into the generated module.
@@ -19,13 +20,14 @@ export type Scanned = {
  * config and carries two things:
  *
  *  1. The scanned runtime values (`dataCollected` / `thirdParties` /
- *     `cookies`), annotated with the exact public types `@openpolicy/sdk`
- *     used to export so `defineConfig`'s generic inference is unchanged. The
- *     values are emitted as JSON, which is valid TypeScript.
+ *     `cookies` / `sharing`), annotated with the exact public types
+ *     `@openpolicy/sdk` used to export so `defineConfig`'s generic inference
+ *     is unchanged. The values are emitted as JSON, which is valid TypeScript.
  *  2. A `declare module "@openpolicy/sdk"` augmentation of
  *     `ScannedCollectionKeys` / `ScannedCookieKeys` so `defineConfig` requires
  *     a sibling `data.context` / `cookies.context` entry for every scanned
- *     key.
+ *     key, plus `ScannedSharingKeys` (one key per shared data category) — a
+ *     typed seam the §4.3 declared-vs-used cross-check keys off.
  *
  * The augmentation keys are sorted so the committed file is deterministic.
  * The file is excluded from formatting (`fmt.ignorePatterns`), so the compact
@@ -37,6 +39,10 @@ export function renderGenModule(scanned: Scanned): string {
 		.map((k) => `\t\t${JSON.stringify(k)}: true;`)
 		.join("\n");
 	const cookieAugment = Object.keys(scanned.cookies)
+		.sort()
+		.map((k) => `\t\t${JSON.stringify(k)}: true;`)
+		.join("\n");
+	const sharingAugment = [...new Set(scanned.sharing.map((s) => s.key))]
 		.sort()
 		.map((k) => `\t\t${JSON.stringify(k)}: true;`)
 		.join("\n");
@@ -54,6 +60,9 @@ export function renderGenModule(scanned: Scanned): string {
 		`export const cookies: { essential: true; [key: string]: boolean } = ${JSON.stringify(
 			scanned.cookies,
 		)};\n` +
+		`export const sharing: { key: string; recipient: string }[] = ${JSON.stringify(
+			scanned.sharing,
+		)};\n` +
 		`\n` +
 		`declare module "@openpolicy/sdk" {\n` +
 		`\tinterface ScannedCollectionKeys {\n` +
@@ -61,6 +70,9 @@ export function renderGenModule(scanned: Scanned): string {
 		`\t}\n` +
 		`\tinterface ScannedCookieKeys {\n` +
 		(cookieAugment ? `${cookieAugment}\n` : "") +
+		`\t}\n` +
+		`\tinterface ScannedSharingKeys {\n` +
+		(sharingAugment ? `${sharingAugment}\n` : "") +
 		`\t}\n` +
 		`}\n`
 	);

--- a/packages/vite/src/validate.test.ts
+++ b/packages/vite/src/validate.test.ts
@@ -129,6 +129,7 @@ export default defineConfig({
 		dataCollected: { "Browser Telemetry": ["User-Agent"] },
 		thirdParties: [],
 		cookies: { essential: true },
+		sharing: [],
 		diagnostics: [],
 	});
 	const result = await loadAndValidateConfig({ configFile: file });


### PR DESCRIPTION
## Summary

Adds support for scanning `sharing(key, recipient, value)` calls to detect personal-data egress edges to third parties. This enables CCPA/CPRA sell/share posture analysis and the §4.3 declared-vs-used cross-check by recording which data categories actually leave to which recipients.

The `sharing()` function is distinct from `thirdParty()`: it marks the exact point data leaves (the egress edge), while `thirdParty()` declares vendor existence. A vendor may be listed but receive no personal data, so `sharing()` edges are necessary to prove a sale or share occurred.

## Changes

- **New `sharing()` SDK function** (`packages/sdk/src/sharing.ts`): Returns its value argument unchanged at runtime; the Vite plugin scans it at build time to extract `(key, recipient)` edges.

- **Scanner support** (`packages/vite/src/analyse.ts`):
  - Added `SharingEntry` type for `{ key: string; recipient: string }` edges
  - Extended `extractFromFile()` and `extractFromParsed()` to recognize `sharing()` calls imported from `@openpolicy/sdk`
  - Validates that both `key` and `recipient` are string literals; diagnoses missing arguments or non-literal values
  - Deduplicates identical `(key, recipient)` pairs within and across files
  - The third argument (payload) is never scanned, matching `collecting()`'s behavior

- **Plugin integration** (`packages/vite/src/index.ts`):
  - Merges `sharing` edges across all scanned files with cross-file deduplication
  - Exposes merged edges in the virtual module and `openpolicy.gen.ts`

- **Generated module** (`packages/vite/src/scanned.ts`):
  - Exports `sharing` array in `openpolicy.gen.ts`
  - Augments `ScannedSharingKeys` interface with one key per scanned data category (the categories that leave), enabling the §4.3 declared-vs-used cross-check

- **Public API** (`packages/sdk/src/index.ts`, `packages/sdk/src/auto-collected.ts`):
  - Exports `sharing()` function and `ScannedSharingKeys` type
  - Updated documentation to reflect the new seam

- **Example** (`examples/tanstack/src/lib/stripe.ts`): Added `reportCharge()` demonstrating `sharing()` at the egress point.

- **Tests**: Comprehensive unit tests covering canonical usage, renamed imports, validation errors, deduplication, and coexistence with other call-site helpers. Integration tests verify scanning across files and generation of the augmented interface.

https://claude.ai/code/session_01HAHckVWRu8k8ESCx9JL8z7