### PR TITLE
Add canWithdraw support and consent mechanism validation

### DIFF
--- a/packages/core/src/consent/gpc.test.ts
+++ b/packages/core/src/consent/gpc.test.ts
@@ -95,6 +95,7 @@ describe("applyGPC", () => {
 			decidedAt: null,
 			source: "default",
 			repromptReason: null,
+			canWithdraw: false,
 			...overrides,
 		};
 	}

--- a/packages/core/src/consent/storage/record.test.ts
+++ b/packages/core/src/consent/storage/record.test.ts
@@ -14,6 +14,7 @@ const baseState: ConsentState = {
 	decidedAt: "2026-04-29T00:00:00.000Z",
 	source: "user",
 	repromptReason: null,
+	canWithdraw: false,
 };
 
 const v1: ConsentRecord = {

--- a/packages/core/src/consent/store.test.ts
+++ b/packages/core/src/consent/store.test.ts
@@ -74,6 +74,39 @@ describe("createConsentStore", () => {
 		it("jurisdiction is null when no resolver is configured", () => {
 			expect(createConsentStore(makeConfig()).getState().jurisdiction).toBeNull();
 		});
+
+		it("canWithdraw reflects config and defaults to false", () => {
+			expect(createConsentStore(makeConfig()).getState().canWithdraw).toBe(false);
+			expect(createConsentStore(makeConfig({ canWithdraw: true })).getState().canWithdraw).toBe(
+				true,
+			);
+		});
+
+		it("canWithdraw survives a policyVersion reprompt", () => {
+			const adapter: StorageAdapter = {
+				read: () => ({
+					schemaVersion: 1,
+					decisions: { essential: true, analytics: true, marketing: true },
+					policyVersion: "old",
+					decidedAt: "2026-01-01T00:00:00.000Z",
+					jurisdiction: null,
+					locale: "en",
+					source: "banner",
+				}),
+				write: () => {},
+				clear: () => {},
+			};
+			const store = createConsentStore(
+				makeConfig({
+					canWithdraw: true,
+					policyVersion: "new",
+					triggers: { policyVersionChanged: true },
+					adapter,
+				}),
+			);
+			expect(store.getState().repromptReason).toBe("policyVersion");
+			expect(store.getState().canWithdraw).toBe(true);
+		});
 	});
 
 	describe("jurisdiction resolver", () => {

--- a/packages/core/src/consent/store.ts
+++ b/packages/core/src/consent/store.ts
@@ -35,6 +35,7 @@ export function createConsentStore(config: OpenCookiesConfig): ConsentStore {
 		decidedAt: null,
 		source: "default",
 		repromptReason: null,
+		canWithdraw: config.canWithdraw ?? false,
 	};
 
 	let state: ConsentState;

--- a/packages/core/src/consent/types.ts
+++ b/packages/core/src/consent/types.ts
@@ -50,6 +50,11 @@ export type ConsentState = {
 	decidedAt: string | null;
 	source: ConsentSource;
 	repromptReason: RepromptReason | null;
+	// Whether consent can be withdrawn/managed after the initial decision —
+	// derived from `consentMechanism.canWithdraw` by the §4.1 bridge. UI
+	// adapters read this to decide whether to surface a preferences-route
+	// (withdraw/manage) affordance.
+	canWithdraw: boolean;
 };
 
 export type RepromptReason = "policyVersion" | "categoriesAdded" | "expired" | "jurisdiction";
@@ -93,6 +98,7 @@ export type OpenCookiesConfig = {
 	gpc?: GPCConfig;
 	adapter?: StorageAdapter;
 	triggers?: RepromptTriggers;
+	canWithdraw?: boolean;
 };
 
 export type ActionOptions = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,7 +90,7 @@ export type {
 	TrackingTechnology,
 	UserRight,
 } from "./types";
-export { isOpenPolicyConfig } from "./types";
+export { isOpenPolicyConfig, LAWFUL_BASIS_CONSENT_GATED, isConsentGated } from "./types";
 export { Contractual, ContractPrerequisite, Statutory, Voluntary } from "./provision";
 export { computeCookieVersion, computePrivacyVersion } from "./policy-version";
 export { deriveUserRights } from "./user-rights";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,6 +30,28 @@ export type LegalBasis =
 	| "public_task"
 	| "legitimate_interests";
 
+// The explicit shared-config bridge (§4.1): a total, compiler-checked mapping
+// from every Article 6 lawful basis to whether a category built on it is
+// consent-gated. `Record<LegalBasis, …>` makes omitting a basis a type error,
+// so this is a reviewable table rather than a lossy string heuristic. Only
+// `consent` is gated; every other basis is a standing legal ground that does
+// not require (and cannot be revoked by) a consent decision.
+export const LAWFUL_BASIS_CONSENT_GATED: Record<LegalBasis, boolean> = {
+	consent: true,
+	contract: false,
+	legal_obligation: false,
+	vital_interests: false,
+	public_task: false,
+	legitimate_interests: false,
+};
+
+// A missing basis is treated as gated — the privacy-safe default for a config
+// the bridge may run before validation (validate() hard-errors a missing basis
+// via `cookie-lawful-basis-missing`).
+export function isConsentGated(basis: LegalBasis | undefined): boolean {
+	return basis == null ? true : LAWFUL_BASIS_CONSENT_GATED[basis];
+}
+
 // GDPR Art. 13(2)(f) requires disclosing each automated-decision-making
 // or profiling activity (Art. 22) — the existence, the logic involved,
 // and the significance and envisaged consequences for the data subject.
@@ -238,6 +260,8 @@ export type IssueCode =
 	| "cookie-lawful-basis-missing" //      error   — enabled cookie lacks lawful basis
 	| "consent-mechanism-undeclared" //     warning — consentMechanism absent
 	| "consent-withdrawal-required" //      warning — withdrawal not enabled under GDPR/UK
+	| "consent-banner-required" //          warning — gated category but consentMechanism.hasBanner false
+	| "consent-preference-panel-required" //warning — canWithdraw true but hasPreferencePanel false
 	| "jurisdiction-generic-policy-text"; //warning — declared jurisdiction ships only equivalent (parent) policy text
 
 export type Issue = {

--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -575,6 +575,68 @@ test("validate: EU/UK + canWithdraw:false warns; canWithdraw:true does not", () 
 	expect(can.some((i) => i.code === "consent-withdrawal-required")).toBe(false);
 });
 
+test("validate: hasBanner:false with a consent-gated category warns", () => {
+	const gated = validate({
+		...baseConfig,
+		cookies: {
+			used: { essential: true, analytics: true },
+			context: {
+				essential: { lawfulBasis: "legal_obligation" },
+				analytics: { lawfulBasis: "consent" },
+			},
+		},
+		consentMechanism: { hasBanner: false, hasPreferencePanel: true, canWithdraw: true },
+	});
+	expect(gated.some((i) => i.code === "consent-banner-required" && i.level === "warning")).toBe(
+		true,
+	);
+});
+
+test("validate: hasBanner:false with no consent-gated category does not warn", () => {
+	const notGated = validate({
+		...baseConfig,
+		cookies: {
+			used: { essential: true },
+			context: { essential: { lawfulBasis: "legal_obligation" } },
+		},
+		consentMechanism: { hasBanner: false, hasPreferencePanel: true, canWithdraw: true },
+	});
+	expect(notGated.some((i) => i.code === "consent-banner-required")).toBe(false);
+});
+
+test("validate: a wired banner does not warn even with gated categories", () => {
+	const wired = validate({
+		...baseConfig,
+		cookies: {
+			used: { essential: true, analytics: true },
+			context: {
+				essential: { lawfulBasis: "legal_obligation" },
+				analytics: { lawfulBasis: "consent" },
+			},
+		},
+		consentMechanism: { hasBanner: true, hasPreferencePanel: true, canWithdraw: true },
+	});
+	expect(wired.some((i) => i.code === "consent-banner-required")).toBe(false);
+});
+
+test("validate: canWithdraw:true with hasPreferencePanel:false warns", () => {
+	const issues = validate({
+		...baseConfig,
+		consentMechanism: { hasBanner: true, hasPreferencePanel: false, canWithdraw: true },
+	});
+	expect(
+		issues.some((i) => i.code === "consent-preference-panel-required" && i.level === "warning"),
+	).toBe(true);
+});
+
+test("validate: canWithdraw:false does not require a preference panel", () => {
+	const issues = validate({
+		...baseConfig,
+		consentMechanism: { hasBanner: true, hasPreferencePanel: false, canWithdraw: false },
+	});
+	expect(issues.some((i) => i.code === "consent-preference-panel-required")).toBe(false);
+});
+
 // --- emission gating ---
 
 test("validate: errors when the config produces no policy", () => {

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -2,6 +2,7 @@ import { isLocale, LOCALES } from "./i18n";
 import { shouldEmit } from "./index";
 import { JURISDICTION_IDS, JURISDICTION_TABLE, resolveJurisdiction } from "./jurisdiction-id";
 import type { Issue, OpenPolicyConfig } from "./types";
+import { isConsentGated } from "./types";
 
 /**
  * The single validator. Pure `(config) => Issue[]` over the flat, public
@@ -275,6 +276,36 @@ export function validate(config: OpenPolicyConfig): Issue[] {
 				message:
 					"GDPR and UK-GDPR require that users can withdraw cookie consent — consider setting consentMechanism.canWithdraw to true",
 			});
+		}
+
+		// Cross-check the declared consentMechanism against the runtime the
+		// §4.1 bridge will wire: consent-gated categories need a banner to
+		// collect affirmative consent, and withdrawal needs a panel to do it
+		// in. Warnings — the bridge still derives a runtime, but the declared
+		// mechanism contradicts it.
+		if (config.consentMechanism) {
+			const hasGatedCategory = enabledKeys.some((key) =>
+				isConsentGated(config.cookies?.context?.[key]?.lawfulBasis),
+			);
+			if (config.consentMechanism.hasBanner === false && hasGatedCategory) {
+				issues.push({
+					code: "consent-banner-required",
+					level: "warning",
+					message:
+						"consentMechanism.hasBanner is false but at least one cookie category is consent-gated — a banner is needed to collect affirmative consent for the wired runtime.",
+				});
+			}
+			if (
+				config.consentMechanism.hasPreferencePanel === false &&
+				config.consentMechanism.canWithdraw === true
+			) {
+				issues.push({
+					code: "consent-preference-panel-required",
+					level: "warning",
+					message:
+						"consentMechanism.canWithdraw is true but hasPreferencePanel is false — withdrawal/management has no preference panel in the wired runtime.",
+				});
+			}
 		}
 	}
 

--- a/packages/sdk/src/consent.test.ts
+++ b/packages/sdk/src/consent.test.ts
@@ -143,3 +143,46 @@ test("enabled cookie with no context entry is gated with no lawfulBasis", () => 
 	expect(analytics?.lawfulBasis).toBeUndefined();
 	expect(analytics?.locked).toBe(false);
 });
+
+test("derives canWithdraw from policy.consentMechanism.canWithdraw", () => {
+	const can = toOpenCookiesConfig({
+		...policy,
+		consentMechanism: { hasBanner: true, hasPreferencePanel: true, canWithdraw: true },
+	});
+	expect(can.canWithdraw).toBe(true);
+
+	const cannot = toOpenCookiesConfig({
+		...policy,
+		consentMechanism: { hasBanner: true, hasPreferencePanel: false, canWithdraw: false },
+	});
+	expect(cannot.canWithdraw).toBe(false);
+});
+
+test("canWithdraw is unset when no consentMechanism is declared", () => {
+	const config = toOpenCookiesConfig(policy);
+	expect(config.canWithdraw).toBeUndefined();
+});
+
+test("explicit canWithdraw option overrides policy.consentMechanism", () => {
+	const config = toOpenCookiesConfig(
+		{
+			...policy,
+			consentMechanism: { hasBanner: true, hasPreferencePanel: true, canWithdraw: true },
+		},
+		{ canWithdraw: false },
+	);
+	expect(config.canWithdraw).toBe(false);
+});
+
+test("defaults triggers.policyVersionChanged on for automatic re-prompt", () => {
+	const config = toOpenCookiesConfig({ ...policy, cookieVersion: "abc12345" });
+	expect(config.triggers?.policyVersionChanged).toBe(true);
+});
+
+test("options.triggers merges over the policyVersionChanged default", () => {
+	const config = toOpenCookiesConfig(policy, {
+		triggers: { policyVersionChanged: false, jurisdictionChanged: true },
+	});
+	expect(config.triggers?.policyVersionChanged).toBe(false);
+	expect(config.triggers?.jurisdictionChanged).toBe(true);
+});

--- a/packages/sdk/src/consent.ts
+++ b/packages/sdk/src/consent.ts
@@ -1,4 +1,5 @@
 import type { OpenPolicyConfig } from "@openpolicy/core";
+import { isConsentGated } from "@openpolicy/core";
 import type { Category, OpenCookiesConfig } from "@openpolicy/core/consent";
 
 export type ToOpenCookiesConfigOptions = Omit<OpenCookiesConfig, "categories">;
@@ -16,16 +17,28 @@ export function toOpenCookiesConfig(
 			return {
 				key,
 				label: key.charAt(0).toUpperCase() + key.slice(1),
-				// `consent` ⇒ consent-gated (not locked). Any other lawful basis
-				// ⇒ not gated. An unknown/missing basis stays gated — the bridge
-				// may run on an unvalidated config (validate() flags it as
-				// cookie-lawful-basis-missing); defaulting to gated is the
-				// privacy-safe choice. The basis itself rides on the Category so
-				// the §4.2 posture resolver and audit keep the full signal.
-				locked: lawfulBasis != null && lawfulBasis !== "consent",
+				// Gating is the explicit, exhaustive bridge table (§4.1) — not a
+				// `=== "consent"` string heuristic. `consent` ⇒ gated (not
+				// locked); every other basis ⇒ locked; a missing basis stays
+				// gated (privacy-safe; validate() hard-errors it separately).
+				// The basis itself rides on the Category so the §4.2 posture
+				// resolver and audit keep the full signal.
+				locked: !isConsentGated(lawfulBasis),
 				...(lawfulBasis ? { lawfulBasis } : {}),
 			};
 		});
 	const policyVersion = options?.policyVersion ?? policy.cookieVersion;
-	return { ...options, ...(policyVersion ? { policyVersion } : {}), categories };
+	const canWithdraw = options?.canWithdraw ?? policy.consentMechanism?.canWithdraw;
+	// The OpenPolicy version hash drives an automatic re-prompt on policy
+	// change: default `policyVersionChanged` on so a changed `cookieVersion`
+	// actually invalidates stored consent. Callers can still override any
+	// individual trigger via `options.triggers`.
+	const triggers = { policyVersionChanged: true, ...options?.triggers };
+	return {
+		...options,
+		...(policyVersion ? { policyVersion } : {}),
+		...(canWithdraw != null ? { canWithdraw } : {}),
+		triggers,
+		categories,
+	};
 }


### PR DESCRIPTION
## Summary

This PR adds support for the `canWithdraw` configuration option and implements validation rules for the declared consent mechanism against the runtime bridge. It ensures that consent-gated categories have a banner to collect affirmative consent, and that withdrawal/management has a preference panel when enabled.

## Changes

- **New `canWithdraw` field** in `OpenCookiesConfig` and `ConsentState` to track whether users can withdraw or manage their consent after the initial decision. Derived from `consentMechanism.canWithdraw` by the §4.1 bridge.

- **Consent mechanism validation** in `validate()`:
  - Warns when `hasBanner: false` but at least one cookie category is consent-gated (code: `consent-banner-required`)
  - Warns when `canWithdraw: true` but `hasPreferencePanel: false` (code: `consent-preference-panel-required`)

- **Explicit lawful basis gating table** (`LAWFUL_BASIS_CONSENT_GATED`) and helper function (`isConsentGated()`) that define which Article 6 bases require consent-gated categories. Only `consent` is gated; all other bases are standing legal grounds. Replaces the previous string heuristic with a compiler-checked mapping.

- **SDK bridge updates** in `toOpenCookiesConfig()`:
  - Derives `canWithdraw` from `policy.consentMechanism.canWithdraw` (overridable via options)
  - Defaults `triggers.policyVersionChanged` to `true` for automatic re-prompt on policy version change
  - Uses `isConsentGated()` for category locking logic

- **Test coverage** for all new validation rules, consent state persistence across reprompts, and SDK bridge behavior.

## Test Plan

Added comprehensive unit tests covering:
- Validation warnings for missing banner with gated categories
- Validation warnings for withdrawal without preference panel
- `canWithdraw` derivation from policy and option overrides
- `canWithdraw` persistence across policy version reprompts
- Default `policyVersionChanged` trigger behavior
- Lawful basis gating table and helper function

All existing tests updated to include the new `canWithdraw` field in test fixtures.

https://claude.ai/code/session_01Nj1afZDj3x4MpyFxMafAzw