### PR TITLE
Implement §4.2 jurisdiction posture: opt-in/opt-out defaults

### DIFF
--- a/packages/core/src/consent/gpc.test.ts
+++ b/packages/core/src/consent/gpc.test.ts
@@ -96,6 +96,7 @@ describe("applyGPC", () => {
 			source: "default",
 			repromptReason: null,
 			canWithdraw: false,
+			consentModel: "opt-out",
 			...overrides,
 		};
 	}

--- a/packages/core/src/consent/index.ts
+++ b/packages/core/src/consent/index.ts
@@ -9,6 +9,12 @@ export {
 	manualResolver,
 	timezoneResolver,
 } from "./jurisdiction";
+export {
+	type ConsentModel,
+	jurisdictionPosture,
+	postureDecisions,
+	toJurisdictionId,
+} from "./posture";
 export { defineScript, gateScript, gateScripts } from "./scripts";
 export { createConsentStore } from "./store";
 export type {

--- a/packages/core/src/consent/posture.test.ts
+++ b/packages/core/src/consent/posture.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vite-plus/test";
+import { consentModelFor, JURISDICTION_IDS } from "../jurisdiction-id";
+import { jurisdictionPosture, postureDecisions, toJurisdictionId } from "./posture";
+import type { Category, Jurisdiction } from "./types";
+
+describe("consentModelFor — all 11 canonical jurisdictions", () => {
+	const OPT_OUT = ["us", "us-ca", "us-co", "us-ct", "us-va"];
+
+	it("us/us-* are opt-out; eea/uk/ch/br/ca/row are opt-in (per JURISDICTION_TABLE)", () => {
+		for (const id of JURISDICTION_IDS) {
+			expect(consentModelFor(id)).toBe(OPT_OUT.includes(id) ? "opt-out" : "opt-in");
+		}
+	});
+
+	it("covers exactly the 11 frozen ids", () => {
+		expect(JURISDICTION_IDS).toHaveLength(11);
+	});
+});
+
+describe("toJurisdictionId — runtime Jurisdiction → canonical id", () => {
+	it("maps the recognised uppercase runtime codes", () => {
+		expect(toJurisdictionId("EEA")).toBe("eea");
+		expect(toJurisdictionId("UK")).toBe("uk");
+		expect(toJurisdictionId("CH")).toBe("ch");
+		expect(toJurisdictionId("BR")).toBe("br");
+		expect(toJurisdictionId("CA")).toBe("ca");
+		expect(toJurisdictionId("US")).toBe("us");
+		expect(toJurisdictionId("US-CA")).toBe("us-ca");
+		expect(toJurisdictionId("ROW")).toBe("row");
+	});
+
+	it("folds the unlisted US-state tail to `us`", () => {
+		expect(toJurisdictionId("US-FL")).toBe("us");
+		expect(toJurisdictionId("US-TX")).toBe("us");
+	});
+
+	it("falls back to `row` for null, AU, and anything unrecognised", () => {
+		expect(toJurisdictionId(null)).toBe("row");
+		// "AU" exists in the runtime union but has no canonical `au` member.
+		expect(toJurisdictionId("AU")).toBe("row");
+		expect(toJurisdictionId("XX" as Jurisdiction)).toBe("row");
+	});
+});
+
+describe("jurisdictionPosture — resolved visitor → posture", () => {
+	it("opt-in for EEA/UK/CH/BR/CA/AU/null/ROW (conservative)", () => {
+		for (const j of ["EEA", "UK", "CH", "BR", "CA", "AU", "ROW", null] as (Jurisdiction | null)[]) {
+			expect(jurisdictionPosture(j)).toBe("opt-in");
+		}
+	});
+
+	it("opt-out for US and US states (listed + unlisted tail)", () => {
+		for (const j of ["US", "US-CA", "US-CO", "US-CT", "US-VA", "US-FL"] as Jurisdiction[]) {
+			expect(jurisdictionPosture(j)).toBe("opt-out");
+		}
+	});
+});
+
+describe("postureDecisions — composes with the §4.1 locked bridge", () => {
+	const cats: Category[] = [
+		{ key: "essential", label: "Essential", locked: true },
+		{ key: "analytics", label: "Analytics" },
+		{ key: "marketing", label: "Marketing" },
+	];
+
+	it("opt-in: locked granted, consent-gated off until consent", () => {
+		expect(postureDecisions(cats, "opt-in")).toEqual({
+			essential: true,
+			analytics: false,
+			marketing: false,
+		});
+	});
+
+	it("opt-out: locked granted, consent-gated on by default (gated by Do-Not-Sell/GPC)", () => {
+		expect(postureDecisions(cats, "opt-out")).toEqual({
+			essential: true,
+			analytics: true,
+			marketing: true,
+		});
+	});
+
+	it("gating keys only on `locked` — lawfulBasis/vendor/purpose metadata is inert", () => {
+		const meta: Category[] = [
+			{ key: "essential", label: "Essential", locked: true, lawfulBasis: "consent" },
+			{
+				key: "analytics",
+				label: "Analytics",
+				lawfulBasis: "legitimate_interests",
+				vendor: "Acme",
+				purpose: "metrics",
+			},
+		];
+		expect(postureDecisions(meta, "opt-in")).toEqual({ essential: true, analytics: false });
+		expect(postureDecisions(meta, "opt-out")).toEqual({ essential: true, analytics: true });
+	});
+});

--- a/packages/core/src/consent/posture.ts
+++ b/packages/core/src/consent/posture.ts
@@ -1,0 +1,45 @@
+import {
+	type ConsentModel,
+	consentModelFor,
+	type JurisdictionId,
+	resolveJurisdiction,
+} from "../jurisdiction-id";
+import type { Category, Jurisdiction } from "./types";
+
+export type { ConsentModel };
+
+/**
+ * Bridge the runtime uppercase `Jurisdiction` onto a canonical `JurisdictionId`.
+ * Lowercasing maps `"US-CA"`→`us-ca`, `"EEA"`→`eea`, `"ROW"`→`row`;
+ * `resolveJurisdiction` folds the long US-state tail (`"US-FL"`) → `us`. A
+ * `null` resolve, `"AU"` (runtime-only — no canonical `au`), or anything
+ * unrecognised falls back to `row` (conservative opt-in, per §4.2).
+ */
+export function toJurisdictionId(j: Jurisdiction | null): JurisdictionId {
+	if (j === null) return "row";
+	return resolveJurisdiction(j.toLowerCase()) ?? "row";
+}
+
+/**
+ * The §4.2 flagship: the resolved visitor's jurisdiction → its default consent
+ * posture, read from the same `JURISDICTION_TABLE` as the policy text.
+ */
+export function jurisdictionPosture(j: Jurisdiction | null): ConsentModel {
+	return consentModelFor(toJurisdictionId(j));
+}
+
+/**
+ * Turn a posture into the initial `decisions` map. Composes with the §4.1
+ * lawful-basis bridge rather than duplicating it: a `locked` category (built
+ * on a non-consent lawful basis — a standing legal ground) is always granted;
+ * a consent-gated category takes the posture default — opt-out ⇒ on by
+ * default (gated only by Do-Not-Sell/GPC), opt-in ⇒ off until affirmative
+ * consent.
+ */
+export function postureDecisions(
+	categories: Category[],
+	model: ConsentModel,
+): Record<string, boolean> {
+	const on = model === "opt-out";
+	return Object.fromEntries(categories.map((c) => [c.key, c.locked === true ? true : on]));
+}

--- a/packages/core/src/consent/storage/record.test.ts
+++ b/packages/core/src/consent/storage/record.test.ts
@@ -15,6 +15,7 @@ const baseState: ConsentState = {
 	source: "user",
 	repromptReason: null,
 	canWithdraw: false,
+	consentModel: "opt-in",
 };
 
 const v1: ConsentRecord = {

--- a/packages/core/src/consent/store.test.ts
+++ b/packages/core/src/consent/store.test.ts
@@ -109,6 +109,116 @@ describe("createConsentStore", () => {
 		});
 	});
 
+	describe("jurisdiction posture (§4.2 flagship)", () => {
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		it("opt-out jurisdiction: non-essential defaults ON, consentModel opt-out", () => {
+			const s = createConsentStore(
+				makeConfig({ jurisdictionResolver: manualResolver("US") }),
+			).getState();
+			expect(s.decisions).toEqual({ essential: true, analytics: true, marketing: true });
+			expect(s.consentModel).toBe("opt-out");
+		});
+
+		it("opt-in jurisdiction: non-essential defaults OFF, consentModel opt-in", () => {
+			const s = createConsentStore(
+				makeConfig({ jurisdictionResolver: manualResolver("EEA") }),
+			).getState();
+			expect(s.decisions).toEqual({ essential: true, analytics: false, marketing: false });
+			expect(s.consentModel).toBe("opt-in");
+		});
+
+		it("no resolver → conservative opt-in (row) — regression guard", () => {
+			const s = createConsentStore(makeConfig()).getState();
+			expect(s.decisions).toEqual({ essential: true, analytics: false, marketing: false });
+			expect(s.consentModel).toBe("opt-in");
+		});
+
+		it("async resolver: opt-in until resolved, opt-out after (footgun gone for async)", async () => {
+			const store = createConsentStore(
+				makeConfig({ jurisdictionResolver: { resolve: () => Promise.resolve("US") } }),
+			);
+			expect(store.getState().decisions).toEqual({
+				essential: true,
+				analytics: false,
+				marketing: false,
+			});
+			expect(store.getState().consentModel).toBe("opt-in");
+			await flushMicrotasks();
+			expect(store.getState().decisions).toEqual({
+				essential: true,
+				analytics: true,
+				marketing: true,
+			});
+			expect(store.getState().consentModel).toBe("opt-out");
+		});
+
+		it("GPC is the opt-out: opt-out posture set ON, GPC flips it back OFF", () => {
+			const s = createConsentStore(
+				makeConfig({ jurisdictionResolver: manualResolver("US"), gpc: { signal: true } }),
+			).getState();
+			expect(s.decisions).toEqual({ essential: true, analytics: false, marketing: false });
+			expect(s.source).toBe("gpc");
+			expect(s.consentModel).toBe("opt-out");
+		});
+
+		it("a prior user decision is never overridden by a later jurisdiction change", async () => {
+			let where: "EEA" | "US" = "EEA";
+			const store = createConsentStore(
+				makeConfig({ jurisdictionResolver: { resolve: () => where } }),
+			);
+			store.acceptNecessary();
+			expect(store.getState().decisions).toEqual({
+				essential: true,
+				analytics: false,
+				marketing: false,
+			});
+			where = "US";
+			await store.refreshJurisdiction();
+			expect(store.getState().jurisdiction).toBe("US");
+			// decisions stay the user's; only the UI hint tracks the new jurisdiction.
+			expect(store.getState().decisions).toEqual({
+				essential: true,
+				analytics: false,
+				marketing: false,
+			});
+			expect(store.getState().consentModel).toBe("opt-out");
+		});
+
+		it("a jurisdictionChanged reprompt re-defaults to the NEW jurisdiction's posture", async () => {
+			const adapter: StorageAdapter = {
+				read: () => ({
+					schemaVersion: 1,
+					decisions: { essential: true, analytics: false, marketing: false },
+					policyVersion: "",
+					decidedAt: "2026-01-01T00:00:00.000Z",
+					jurisdiction: "EEA",
+					locale: "en",
+					source: "banner",
+				}),
+				write: () => {},
+				clear: () => {},
+			};
+			const store = createConsentStore(
+				makeConfig({
+					jurisdictionResolver: { resolve: () => Promise.resolve("US") },
+					triggers: { jurisdictionChanged: true },
+					adapter,
+				}),
+			);
+			await flushMicrotasks();
+			expect(store.getState().repromptReason).toBe("jurisdiction");
+			expect(store.getState().decisions).toEqual({
+				essential: true,
+				analytics: true,
+				marketing: true,
+			});
+			expect(store.getState().consentModel).toBe("opt-out");
+		});
+	});
+
 	describe("jurisdiction resolver", () => {
 		afterEach(() => {
 			vi.restoreAllMocks();

--- a/packages/core/src/consent/store.ts
+++ b/packages/core/src/consent/store.ts
@@ -1,6 +1,7 @@
 import { evaluate } from "./expr";
 import { applyGPC } from "./gpc";
 import { resolveLocale } from "./locale";
+import { jurisdictionPosture, postureDecisions } from "./posture";
 import { fromUnknown, recordEquals, toRecord } from "./storage/record";
 import { evaluateTriggers } from "./triggers";
 import type {
@@ -26,16 +27,18 @@ export function createConsentStore(config: OpenCookiesConfig): ConsentStore {
 	const initialJurisdiction = resolveSync(config, config.request);
 	const initialRecord = readSync(config, locale);
 
+	const initialModel = jurisdictionPosture(initialJurisdiction.value);
 	const baseState: ConsentState = {
 		route: config.initialRoute ?? "cookie",
 		categories: config.categories,
-		decisions: Object.fromEntries(config.categories.map((c) => [c.key, c.locked === true])),
+		decisions: postureDecisions(config.categories, initialModel),
 		jurisdiction: initialJurisdiction.value,
 		policyVersion: config.policyVersion ?? "",
 		decidedAt: null,
 		source: "default",
 		repromptReason: null,
 		canWithdraw: config.canWithdraw ?? false,
+		consentModel: initialModel,
 	};
 
 	let state: ConsentState;
@@ -100,7 +103,16 @@ export function createConsentStore(config: OpenCookiesConfig): ConsentStore {
 	}
 
 	function handleJurisdictionChange(value: Jurisdiction | null): void {
-		let next: ConsentState = { ...state, jurisdiction: value };
+		const model = jurisdictionPosture(value);
+		let next: ConsentState = { ...state, jurisdiction: value, consentModel: model };
+		// While pristine (no user decision, no stored record, no pending
+		// reprompt) re-default to the resolved jurisdiction's posture — this
+		// closes the silent-opt-in footgun for async resolvers. applyGPC
+		// re-runs at commit, so an opt-out default still composes with GPC.
+		// A user decision or stored record is never overridden here.
+		if (state.decidedAt === null && lastWritten === null && state.repromptReason === null) {
+			next = { ...next, decisions: postureDecisions(next.categories, model) };
+		}
 		if (state.repromptReason === null && lastWritten !== null) {
 			const reason = evaluateTriggers({
 				record: lastWritten,
@@ -134,13 +146,18 @@ export function createConsentStore(config: OpenCookiesConfig): ConsentStore {
 	}
 
 	function invalidate(current: ConsentState, reason: RepromptReason): ConsentState {
+		// Re-default to the posture of where the visitor is *now* (current.jurisdiction
+		// is already the post-change value on the jurisdiction-change path), so a
+		// reprompt never falls back to stale opt-in.
+		const model = jurisdictionPosture(current.jurisdiction);
 		return {
 			...current,
-			decisions: Object.fromEntries(current.categories.map((c) => [c.key, c.locked === true])),
+			decisions: postureDecisions(current.categories, model),
 			decidedAt: null,
 			route: "cookie",
 			source: "default",
 			repromptReason: reason,
+			consentModel: model,
 		};
 	}
 
@@ -398,14 +415,18 @@ function mergeRecord(state: ConsentState, record: ConsentRecord | null): Consent
 			decisions[c.key] = record.decisions[c.key] === true;
 		}
 	}
+	const jurisdiction = record.jurisdiction ?? state.jurisdiction;
 	return {
 		...state,
 		decisions,
-		jurisdiction: record.jurisdiction ?? state.jurisdiction,
+		jurisdiction,
 		policyVersion: record.policyVersion || state.policyVersion,
 		decidedAt: record.decidedAt,
 		route: state.route === "cookie" ? "closed" : state.route,
 		source: "user",
 		repromptReason: null,
+		// Decisions stay the user's; the UI hint still tracks the resolved
+		// jurisdiction so the banner/preferences render the right affordance.
+		consentModel: jurisdictionPosture(jurisdiction),
 	};
 }

--- a/packages/core/src/consent/types.ts
+++ b/packages/core/src/consent/types.ts
@@ -1,3 +1,4 @@
+import type { ConsentModel } from "../jurisdiction-id";
 import type { LegalBasis } from "../types";
 
 export type Route = "cookie" | "preferences" | "closed";
@@ -55,6 +56,11 @@ export type ConsentState = {
 	// adapters read this to decide whether to surface a preferences-route
 	// (withdraw/manage) affordance.
 	canWithdraw: boolean;
+	// Resolved §4.2 posture for the current jurisdiction, read from the same
+	// JURISDICTION_TABLE as the policy text so prose and banner provably
+	// agree. UI adapters render an opt-out "Do Not Sell/Share" affordance vs
+	// an opt-in consent prompt off this; the route stays "cookie" in both.
+	consentModel: ConsentModel;
 };
 
 export type RepromptReason = "policyVersion" | "categoriesAdded" | "expired" | "jurisdiction";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,8 +46,14 @@ export {
 	ul,
 	visit,
 } from "./documents";
-export type { JurisdictionCapability, JurisdictionId, JurisdictionTable } from "./jurisdiction-id";
+export type {
+	ConsentModel,
+	JurisdictionCapability,
+	JurisdictionId,
+	JurisdictionTable,
+} from "./jurisdiction-id";
 export {
+	consentModelFor,
 	isJurisdictionId,
 	JURISDICTION_IDS,
 	JURISDICTION_TABLE,

--- a/packages/core/src/jurisdiction-id.ts
+++ b/packages/core/src/jurisdiction-id.ts
@@ -36,6 +36,9 @@ export type JurisdictionCapability = {
 
 export type JurisdictionTable = Readonly<Record<JurisdictionId, JurisdictionCapability>>;
 
+/** §4.2 default consent posture for a jurisdiction. */
+export type ConsentModel = "opt-in" | "opt-out";
+
 /**
  * 3 `specific` (hand-authored: `eea`, `uk`, `us-ca`) + 8 `equivalent`
  * (posture-correct + parent text + a suppressible diagnostic — a legitimate,
@@ -93,6 +96,16 @@ export function resolveJurisdiction(code: string): JurisdictionId | null {
 	if (isJurisdictionId(code)) return code;
 	if (code.startsWith("us-")) return "us";
 	return null;
+}
+
+/**
+ * The §4.2 posture for a canonical jurisdiction. The single seam the policy
+ * renderer and the consent runtime both read, so policy prose and banner
+ * behaviour provably agree (they cannot disagree about a jurisdiction's
+ * posture if they consult the same table row).
+ */
+export function consentModelFor(id: JurisdictionId): ConsentModel {
+	return JURISDICTION_TABLE[id].consentModel;
 }
 
 export { JURISDICTION_IDS };


### PR DESCRIPTION
## Summary

Implements the §4.2 flagship feature: jurisdiction-aware default consent posture. Visitors in opt-out jurisdictions (US and US states) now have non-essential cookies enabled by default (gated only by Do-Not-Sell/GPC), while visitors in opt-in jurisdictions (EEA, UK, CH, BR, CA, ROW) have them disabled by default pending affirmative consent. The `consentModel` is now exposed in `ConsentState` so UI adapters can render the appropriate affordance (opt-out "Do Not Sell/Share" vs opt-in consent prompt).

## Changes

- **New module `packages/core/src/consent/posture.ts`**: Bridges runtime `Jurisdiction` codes to canonical `JurisdictionId`, reads posture from `JURISDICTION_TABLE`, and computes initial decisions based on posture and category `locked` status.
  - `toJurisdictionId()` — maps uppercase runtime codes to lowercase canonical ids, folds unlisted US states to `us`, falls back to `row` (conservative opt-in)
  - `jurisdictionPosture()` — resolves visitor's jurisdiction to its default posture
  - `postureDecisions()` — turns posture into initial decisions map: locked categories always granted, consent-gated categories follow posture default

- **Updated `packages/core/src/consent/store.ts`**: Integrates posture into store lifecycle
  - Initial state now calls `postureDecisions()` instead of hardcoding locked-only defaults
  - `handleJurisdictionChange()` re-defaults pristine state to new jurisdiction's posture (closes silent opt-in footgun for async resolvers)
  - `invalidate()` re-defaults reprompt state to current jurisdiction's posture
  - `mergeRecord()` preserves user decisions but updates `consentModel` hint to current jurisdiction

- **Updated `packages/core/src/jurisdiction-id.ts`**: Exports new `ConsentModel` type and `consentModelFor()` function to read posture from the canonical jurisdiction table

- **Updated `packages/core/src/consent/types.ts`**: Adds `consentModel: ConsentModel` field to `ConsentState` so UI adapters can render jurisdiction-appropriate affordances

- **Updated exports** in `packages/core/src/index.ts` and `packages/core/src/consent/index.ts` to expose posture utilities and `ConsentModel` type

- **Comprehensive test coverage**:
  - `packages/core/src/consent/posture.test.ts` — unit tests for posture resolution, jurisdiction mapping, and decision computation
  - `packages/core/src/consent/store.test.ts` — integration tests covering opt-in/opt-out defaults, async resolver behavior, GPC interaction, user decision preservation, and reprompt re-defaulting
  - Updated existing tests to include `consentModel` in mock state

## Test Plan

All new functionality is covered by unit and integration tests:
- `posture.test.ts` validates jurisdiction-to-posture mapping for all 11 canonical jurisdictions
- `store.test.ts` validates store behavior across opt-in/opt-out transitions, async resolution, GPC override, and user decision preservation
- Existing tests updated to include `consentModel` field

Run `vp test` to verify all tests pass.

https://claude.ai/code/session_01SjwstPb2hETrt97uvUAqUz