### PR TITLE
PS-26: Normalize locale to canonical Locale type with deprecation warning

### DIFF
--- a/packages/core/src/consent/locale.test.ts
+++ b/packages/core/src/consent/locale.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { LOCALES } from "../i18n/locales";
+import { normalizeLocale, resolveLocale } from "./locale";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("normalizeLocale", () => {
+	it("passes canonical locales through with no warning", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		for (const locale of LOCALES) expect(normalizeLocale(locale)).toBe(locale);
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("maps a region/script-tagged locale to its primary subtag, with a warning", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		expect(normalizeLocale("en-GB")).toBe("en");
+		expect(normalizeLocale("fr_FR")).toBe("fr");
+		expect(normalizeLocale("DE-AT")).toBe("de");
+		expect(warn).toHaveBeenCalledTimes(3);
+		expect(warn.mock.calls[0]?.[0]).toContain("PS-36");
+	});
+
+	it("falls back to 'en' for an unmappable locale, with a warning", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		expect(normalizeLocale("pt")).toBe("en");
+		expect(normalizeLocale("zz-ZZ")).toBe("en");
+		expect(normalizeLocale("")).toBe("en");
+		expect(warn).toHaveBeenCalledTimes(3);
+		expect(warn.mock.calls[0]?.[0]).toContain("PS-36");
+	});
+});
+
+describe("resolveLocale", () => {
+	it("normalizes an explicit config.locale (with a warning) and prefers it", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		expect(resolveLocale({ categories: [], locale: "fr-FR" })).toBe("fr");
+		expect(warn).toHaveBeenCalled();
+	});
+
+	it("passes a canonical explicit config.locale through with no warning", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		expect(resolveLocale({ categories: [], locale: "es" })).toBe("es");
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("silently coerces navigator.language (no deprecation warning)", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const original = (globalThis as { navigator?: unknown }).navigator;
+		Object.defineProperty(globalThis, "navigator", {
+			value: { language: "de-CH" },
+			configurable: true,
+		});
+		try {
+			expect(resolveLocale({ categories: [] })).toBe("de");
+			expect(warn).not.toHaveBeenCalled();
+		} finally {
+			Object.defineProperty(globalThis, "navigator", {
+				value: original,
+				configurable: true,
+			});
+		}
+	});
+
+	it("defaults to 'en' when no config.locale and no navigator", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const original = (globalThis as { navigator?: unknown }).navigator;
+		Object.defineProperty(globalThis, "navigator", {
+			value: undefined,
+			configurable: true,
+		});
+		try {
+			expect(resolveLocale({ categories: [] })).toBe("en");
+			expect(warn).not.toHaveBeenCalled();
+		} finally {
+			Object.defineProperty(globalThis, "navigator", {
+				value: original,
+				configurable: true,
+			});
+		}
+	});
+});

--- a/packages/core/src/consent/locale.ts
+++ b/packages/core/src/consent/locale.ts
@@ -1,7 +1,55 @@
+import type { Locale } from "../types";
 import type { OpenCookiesConfig } from "./types";
 
-export function resolveLocale(config: OpenCookiesConfig): string {
-	if (config.locale) return config.locale;
+// Canonical locale codes, kept dependency-free on purpose: importing the i18n
+// locale registry would drag the policy dictionaries into the lean consent
+// runtime. `satisfies` ties this list to the frozen `Locale` union (../types)
+// — the single source of truth — so a stray code here is a compile error.
+const CANONICAL_LOCALES = ["en", "fr", "de", "nl", "es"] as const satisfies readonly Locale[];
+
+function isCanonicalLocale(value: string): value is Locale {
+	return (CANONICAL_LOCALES as readonly string[]).includes(value);
+}
+
+// Silent best-effort mapping for environmental input (navigator.language).
+// That is not a deprecated *configuration* — it is the runtime default and is
+// almost always region-tagged (e.g. "en-US") — so it must not warn. Outlives
+// the freeze (navigator.language stays a free string after PS-36).
+function coerceLocale(input: string): Locale {
+	if (isCanonicalLocale(input)) return input;
+	const primary = input.toLowerCase().split(/[-_]/)[0] ?? "";
+	return isCanonicalLocale(primary) ? primary : "en";
+}
+
+// ─── PS-26 warn-and-map migration shim — remove pre-freeze, PS-36 ───
+// OpenCookies historically accepted a free-string `locale` (e.g. "en-GB",
+// "fr_FR", "pt"). PolicyStack 1.0 freezes `Locale` to the closed union. This
+// warns only for an explicitly *configured* free-string `locale` — the thing
+// PS-36 will reject — mapping the primary subtag onto the canonical Locale so
+// integrators migrate. PS-36 deletes this shim and tightens the surface to
+// `Locale`; the silent `coerceLocale` (navigator fallback) survives.
+export function normalizeLocale(input: string): Locale {
+	if (isCanonicalLocale(input)) return input;
+	const primary = input.toLowerCase().split(/[-_]/)[0] ?? "";
+	if (isCanonicalLocale(primary)) {
+		console.warn(
+			`[opencookies] locale "${input}" is not a supported PolicyStack locale; ` +
+				`mapping to "${primary}". Free-string locales are deprecated and will ` +
+				`be rejected when Locale is frozen (PS-36). Use one of: ${CANONICAL_LOCALES.join(", ")}.`,
+		);
+		return primary;
+	}
+	console.warn(
+		`[opencookies] locale "${input}" is not a supported PolicyStack locale; ` +
+			`falling back to "en". Free-string locales are deprecated and will be ` +
+			`rejected when Locale is frozen (PS-36). Use one of: ${CANONICAL_LOCALES.join(", ")}.`,
+	);
+	return "en";
+}
+// ─── end PS-26 shim ───
+
+export function resolveLocale(config: OpenCookiesConfig): Locale {
+	if (config.locale) return normalizeLocale(config.locale);
 	const nav = (globalThis as { navigator?: { language?: string } }).navigator;
-	return nav?.language ?? "en";
+	return coerceLocale(nav?.language ?? "en");
 }

--- a/packages/core/src/consent/storage/record.test.ts
+++ b/packages/core/src/consent/storage/record.test.ts
@@ -17,6 +17,9 @@ const baseState: ConsentState = {
 	canWithdraw: false,
 };
 
+// `locale: "en-GB"` exercises read-side legacy tolerance (ConsentRecord.locale
+// stays `string` at rest — see PS-26 / PS-36). The write side (toRecord) only
+// accepts a canonical `Locale`, so write-side fixtures use "en".
 const v1: ConsentRecord = {
 	schemaVersion: 1,
 	decisions: { essential: true, analytics: true },
@@ -27,19 +30,21 @@ const v1: ConsentRecord = {
 	source: "banner",
 };
 
+const canonical: ConsentRecord = { ...v1, locale: "en" };
+
 describe("toRecord", () => {
-	it("emits a v1 record from state + source + locale", () => {
-		expect(toRecord(baseState, "banner", "en-GB")).toEqual(v1);
+	it("emits a v1 record from state + source + canonical locale", () => {
+		expect(toRecord(baseState, "banner", "en")).toEqual(canonical);
 	});
 
 	it("clones decisions (no aliasing)", () => {
-		const record = toRecord(baseState, "banner", "en-GB");
+		const record = toRecord(baseState, "banner", "en");
 		record.decisions.analytics = false;
 		expect(baseState.decisions.analytics).toBe(true);
 	});
 
 	it("throws when state has no decidedAt", () => {
-		expect(() => toRecord({ ...baseState, decidedAt: null }, "banner", "en-GB")).toThrow();
+		expect(() => toRecord({ ...baseState, decidedAt: null }, "banner", "en")).toThrow();
 	});
 });
 

--- a/packages/core/src/consent/storage/record.ts
+++ b/packages/core/src/consent/storage/record.ts
@@ -1,3 +1,4 @@
+import type { Locale } from "../../types";
 import type { ConsentRecord, ConsentRecordSource, ConsentState, Jurisdiction } from "../types";
 
 const RECORD_SOURCES: ReadonlySet<ConsentRecordSource> = new Set([
@@ -7,10 +8,13 @@ const RECORD_SOURCES: ReadonlySet<ConsentRecordSource> = new Set([
 	"import",
 ]);
 
+// PS-26: write side is canonical Locale; ConsentRecord.locale stays `string`
+// at rest for legacy tolerance. Read tolerance (fromUnknown) is deliberately
+// untouched — see PS-36 for the eventual freeze.
 export function toRecord(
 	state: ConsentState,
 	source: ConsentRecordSource,
-	locale: string,
+	locale: Locale,
 ): ConsentRecord {
 	if (state.decidedAt === null) {
 		throw new Error("toRecord called before a decision was made");

--- a/packages/core/src/consent/store.test.ts
+++ b/packages/core/src/consent/store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { GPC_LEGALLY_REQUIRED_JURISDICTIONS } from "./gpc";
 import { manualResolver } from "./jurisdiction";
 import { createConsentStore } from "./store";
@@ -688,13 +688,13 @@ describe("createConsentStore", () => {
 
 		it("does not write back the just-hydrated record (no-op on init)", () => {
 			const { adapter, writes } = makeAdapter(v1Record({ policyVersion: "v1" }));
-			createConsentStore(makeConfig({ adapter, policyVersion: "v1", locale: "en-GB" }));
+			createConsentStore(makeConfig({ adapter, policyVersion: "v1", locale: "en" }));
 			expect(writes).toEqual([]);
 		});
 
 		it("persists each user decision via adapter.write", () => {
 			const { adapter, writes } = makeAdapter();
-			const store = createConsentStore(makeConfig({ adapter, locale: "en-GB" }));
+			const store = createConsentStore(makeConfig({ adapter, locale: "en" }));
 			store.acceptAll();
 			expect(writes).toHaveLength(1);
 			expect(writes[0]?.decisions).toEqual({
@@ -703,12 +703,23 @@ describe("createConsentStore", () => {
 				marketing: true,
 			});
 			expect(writes[0]?.schemaVersion).toBe(1);
-			expect(writes[0]?.locale).toBe("en-GB");
+			expect(writes[0]?.locale).toBe("en");
 			expect(writes[0]?.source).toBe("banner");
 
 			store.toggle("marketing");
 			expect(writes).toHaveLength(2);
 			expect(writes[1]?.decisions.marketing).toBe(false);
+		});
+
+		it("writes the canonical Locale to the persisted record (PS-26 shim)", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const { adapter, writes } = makeAdapter();
+			const store = createConsentStore(makeConfig({ adapter, locale: "en-GB" }));
+			store.acceptAll();
+			expect(writes).toHaveLength(1);
+			expect(writes[0]?.locale).toBe("en");
+			expect(warn).toHaveBeenCalled();
+			warn.mockRestore();
 		});
 
 		it("does not write when the record is unchanged (e.g. setRoute)", () => {
@@ -796,12 +807,12 @@ describe("createConsentStore", () => {
 				write: () => {},
 				clear: () => {},
 			};
-			const store = createConsentStore(makeConfig({ adapter, locale: "en-GB" }));
+			const store = createConsentStore(makeConfig({ adapter, locale: "en" }));
 			const record = store.getConsentRecord();
 			expect(record).not.toBeNull();
 			expect(record?.schemaVersion).toBe(1);
 			expect(record?.source).toBe("banner");
-			expect(record?.locale).toBe("en-GB");
+			expect(record?.locale).toBe("en");
 		});
 
 		it("hydrating from a malformed record (decidedAt missing) surfaces no record", () => {
@@ -827,12 +838,12 @@ describe("createConsentStore", () => {
 		});
 
 		it("returns a v1 record after acceptAll with route-inferred source 'banner'", () => {
-			const store = createConsentStore(makeConfig({ locale: "en-GB", policyVersion: "v2" }));
+			const store = createConsentStore(makeConfig({ locale: "en", policyVersion: "v2" }));
 			store.acceptAll();
 			const r = store.getConsentRecord();
 			expect(r).not.toBeNull();
 			expect(r?.schemaVersion).toBe(1);
-			expect(r?.locale).toBe("en-GB");
+			expect(r?.locale).toBe("en");
 			expect(r?.policyVersion).toBe("v2");
 			expect(r?.source).toBe("banner");
 			expect(r?.decisions).toEqual({ essential: true, analytics: true, marketing: true });
@@ -895,28 +906,50 @@ describe("createConsentStore", () => {
 	});
 
 	describe("locale resolution", () => {
+		// Earlier blocks (e.g. "storage adapter") spy console.warn without
+		// restoring; vi.spyOn on an already-spied method returns the same spy
+		// with its prior call history. Restore before each test so the
+		// no-warn assertions below see a clean slate.
+		beforeEach(() => {
+			vi.restoreAllMocks();
+		});
 		afterEach(() => {
 			vi.unstubAllGlobals();
+			vi.restoreAllMocks();
 		});
 
-		it("uses config.locale when provided", () => {
+		it("passes a canonical config.locale through unchanged with no warning", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const store = createConsentStore(makeConfig({ locale: "es" }));
+			store.acceptAll();
+			expect(store.getConsentRecord()?.locale).toBe("es");
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		it("normalizes a region-tagged config.locale to the canonical Locale (PS-26 shim)", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 			const store = createConsentStore(makeConfig({ locale: "fr-FR" }));
 			store.acceptAll();
-			expect(store.getConsentRecord()?.locale).toBe("fr-FR");
+			expect(store.getConsentRecord()?.locale).toBe("fr");
+			expect(warn).toHaveBeenCalled();
 		});
 
-		it("falls back to navigator.language when config.locale is unset", () => {
+		it("silently coerces navigator.language (environmental, not a deprecated config)", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 			vi.stubGlobal("navigator", { language: "de-DE" });
 			const store = createConsentStore(makeConfig());
 			store.acceptAll();
-			expect(store.getConsentRecord()?.locale).toBe("de-DE");
+			expect(store.getConsentRecord()?.locale).toBe("de");
+			expect(warn).not.toHaveBeenCalled();
 		});
 
 		it("defaults to 'en' when neither config.locale nor navigator.language is available", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 			vi.stubGlobal("navigator", {});
 			const store = createConsentStore(makeConfig());
 			store.acceptAll();
 			expect(store.getConsentRecord()?.locale).toBe("en");
+			expect(warn).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/core/src/documents/index.ts
+++ b/packages/core/src/documents/index.ts
@@ -1,11 +1,12 @@
 import { createT } from "../i18n";
+import type { Dictionary } from "../i18n";
 import type { PolicyInput } from "../types";
 import { compileCookieDocument } from "./cookie";
 import { compilePrivacyDocument } from "./privacy";
 import { AST_VERSION, type Document } from "./types";
 
-export function compile(input: PolicyInput): Document {
-	const t = createT(input.locale);
+export function compile(input: PolicyInput, dictionary?: Dictionary): Document {
+	const t = createT(input.locale, dictionary);
 	if (input.type === "privacy") {
 		const { type: _, ...config } = input;
 		return {

--- a/packages/core/src/i18n/i18n.test.ts
+++ b/packages/core/src/i18n/i18n.test.ts
@@ -20,6 +20,36 @@ test("createT falls back to English for an unknown locale", () => {
 	expect(t.privacy.introduction.heading()).toBe("Introduction");
 });
 
+const customDictionary: typeof en = {
+	...en,
+	privacy: {
+		...en.privacy,
+		introduction: {
+			...en.privacy.introduction,
+			heading: () => "CUSTOM_INTRO_HEADING_XYZ",
+		},
+	},
+};
+
+test("createT returns a caller-supplied dictionary verbatim (full replacement)", () => {
+	expect(createT("en", customDictionary).privacy.introduction.heading()).toBe(
+		"CUSTOM_INTRO_HEADING_XYZ",
+	);
+	// The locale argument is irrelevant to string content once a custom
+	// dictionary is supplied — it is used verbatim regardless of locale.
+	expect(createT("fr", customDictionary).privacy.introduction.heading()).toBe(
+		"CUSTOM_INTRO_HEADING_XYZ",
+	);
+});
+
+test("compile uses a custom dictionary for emitted strings; locale still drives dates", () => {
+	const doc = compile(buildPrivacyInput("fr"), customDictionary);
+	const blob = JSON.stringify(doc);
+	expect(blob).toContain("CUSTOM_INTRO_HEADING_XYZ");
+	// `locale: "fr"` still governs date formatting independently of the dictionary.
+	expect(blob).toContain("1 janvier 2026");
+});
+
 test("isLocale accepts registered locales and rejects others", () => {
 	for (const locale of LOCALES) expect(isLocale(locale)).toBe(true);
 	expect(isLocale("it")).toBe(false);

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -4,8 +4,8 @@ import type { Dictionary } from "./types";
 
 export type T = Dictionary;
 
-export function createT(locale: Locale): T {
-	return dictionaries[locale] ?? dictionaries.en;
+export function createT(locale: Locale, dictionary?: Dictionary): T {
+	return dictionary ?? dictionaries[locale] ?? dictionaries.en;
 }
 
 export { formatDate } from "./format";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,9 +95,12 @@ export { Contractual, ContractPrerequisite, Statutory, Voluntary } from "./provi
 export { computeCookieVersion, computePrivacyVersion } from "./policy-version";
 export { deriveUserRights } from "./user-rights";
 export { validate } from "./validate";
+export { createT } from "./i18n";
+export type { Dictionary, T } from "./i18n";
 
 import { compile } from "./documents";
 import type { Document } from "./documents";
+import type { Dictionary } from "./i18n";
 import type {
 	CookiePolicyCookies,
 	DataConfig,
@@ -174,12 +177,18 @@ export function expandOpenPolicyConfig(config: OpenPolicyConfig): PolicyInput[] 
 	return inputs;
 }
 
-export function compilePrivacyPolicy(config: OpenPolicyConfig): Document | null {
+export function compilePrivacyPolicy(
+	config: OpenPolicyConfig,
+	dictionary?: Dictionary,
+): Document | null {
 	const input = buildPrivacyInput(config);
-	return input ? compile(input) : null;
+	return input ? compile(input, dictionary) : null;
 }
 
-export function compileCookiePolicy(config: OpenPolicyConfig): Document | null {
+export function compileCookiePolicy(
+	config: OpenPolicyConfig,
+	dictionary?: Dictionary,
+): Document | null {
 	const input = buildCookieInput(config);
-	return input ? compile(input) : null;
+	return input ? compile(input, dictionary) : null;
 }

--- a/packages/react/src/components/CookiePolicy.tsx
+++ b/packages/react/src/components/CookiePolicy.tsx
@@ -2,6 +2,7 @@ import {
 	compile,
 	compileCookiePolicy,
 	type CookiePolicyConfig,
+	type Dictionary,
 	isOpenPolicyConfig,
 	type Locale,
 	type OpenPolicyConfig,
@@ -15,18 +16,25 @@ import { DefaultRoot } from "./defaults";
 type CookiePolicyProps = {
 	config?: OpenPolicyConfig | CookiePolicyConfig;
 	locale?: Locale;
+	dictionary?: Dictionary;
 	components?: PolicyComponents;
 	style?: unknown;
 };
 
-export function CookiePolicy({ config: configProp, locale, components, style }: CookiePolicyProps) {
+export function CookiePolicy({
+	config: configProp,
+	locale,
+	dictionary,
+	components,
+	style,
+}: CookiePolicyProps) {
 	const { config: contextConfig } = useContext(OpenPolicyContext);
 	const baseConfig = configProp ?? contextConfig ?? undefined;
 	if (!baseConfig) return null;
 	const config = locale ? { ...baseConfig, locale } : baseConfig;
 	const doc = isOpenPolicyConfig(config)
-		? compileCookiePolicy(config)
-		: compile({ type: "cookie", ...config });
+		? compileCookiePolicy(config, dictionary)
+		: compile({ type: "cookie", ...config }, dictionary);
 	if (!doc) return null;
 	const Root = components?.Root ?? DefaultRoot;
 	return (

--- a/packages/react/src/components/PrivacyPolicy.tsx
+++ b/packages/react/src/components/PrivacyPolicy.tsx
@@ -1,6 +1,7 @@
 import {
 	compile,
 	compilePrivacyPolicy,
+	type Dictionary,
 	isOpenPolicyConfig,
 	type Locale,
 	type OpenPolicyConfig,
@@ -15,6 +16,7 @@ import { DefaultRoot } from "./defaults";
 type PrivacyPolicyProps = {
 	config?: OpenPolicyConfig | PrivacyPolicyConfig;
 	locale?: Locale;
+	dictionary?: Dictionary;
 	components?: PolicyComponents;
 	style?: unknown;
 };
@@ -22,6 +24,7 @@ type PrivacyPolicyProps = {
 export function PrivacyPolicy({
 	config: configProp,
 	locale,
+	dictionary,
 	components,
 	style,
 }: PrivacyPolicyProps) {
@@ -30,8 +33,8 @@ export function PrivacyPolicy({
 	if (!baseConfig) return null;
 	const config = locale ? { ...baseConfig, locale } : baseConfig;
 	const doc = isOpenPolicyConfig(config)
-		? compilePrivacyPolicy(config)
-		: compile({ type: "privacy", ...config });
+		? compilePrivacyPolicy(config, dictionary)
+		: compile({ type: "privacy", ...config }, dictionary);
 	if (!doc) return null;
 	const Root = components?.Root ?? DefaultRoot;
 	return (

--- a/packages/sdk/src/consent.test.ts
+++ b/packages/sdk/src/consent.test.ts
@@ -186,3 +186,18 @@ test("options.triggers merges over the policyVersionChanged default", () => {
 	expect(config.triggers?.policyVersionChanged).toBe(false);
 	expect(config.triggers?.jurisdictionChanged).toBe(true);
 });
+
+test("carries policy.locale into the OpenCookies config (one shared Locale)", () => {
+	const config = toOpenCookiesConfig({ ...policy, locale: "fr" });
+	expect(config.locale).toBe("fr");
+});
+
+test("explicit options.locale overrides policy.locale", () => {
+	const config = toOpenCookiesConfig({ ...policy, locale: "fr" }, { locale: "de" });
+	expect(config.locale).toBe("de");
+});
+
+test("locale is omitted when neither policy nor options provide one", () => {
+	const config = toOpenCookiesConfig(policy);
+	expect(config.locale).toBeUndefined();
+});

--- a/packages/sdk/src/consent.ts
+++ b/packages/sdk/src/consent.ts
@@ -34,10 +34,15 @@ export function toOpenCookiesConfig(
 	// actually invalidates stored consent. Callers can still override any
 	// individual trigger via `options.triggers`.
 	const triggers = { policyVersionChanged: true, ...options?.triggers };
+	// PS-26: one shared Locale — the policy's canonical Locale flows into the
+	// OpenCookies config so policy text and consent UI agree. An explicit
+	// options.locale still wins (same override convention as policyVersion).
+	const locale = options?.locale ?? policy.locale;
 	return {
 		...options,
 		...(policyVersion ? { policyVersion } : {}),
 		...(canWithdraw != null ? { canWithdraw } : {}),
+		...(locale ? { locale } : {}),
 		triggers,
 		categories,
 	};

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -17,6 +17,7 @@ export type {
 	DataConfig,
 	DataContext,
 	DataContextEntry,
+	Dictionary,
 	Dpo,
 	EffectiveDate,
 	EuRepresentative,
@@ -36,6 +37,7 @@ export {
 	computePrivacyVersion,
 	Contractual,
 	ContractPrerequisite,
+	createT,
 	Statutory,
 	Voluntary,
 } from "@openpolicy/core";


### PR DESCRIPTION
## Summary

Implements the PS-26 migration shim to normalize free-string locale configurations to the canonical `Locale` union (`"en" | "fr" | "de" | "nl" | "es"`). This prepares for PS-36, which will freeze `Locale` as a closed type and reject non-canonical values.

The change introduces two locale-handling functions:
- **`normalizeLocale()`** — warns and maps explicitly configured locales (e.g., `"en-GB"` → `"en"`), falling back to `"en"` for unmappable values. This is the PS-26 deprecation shim.
- **`coerceLocale()`** — silently maps environmental input like `navigator.language` without warnings, since it is not a deprecated configuration.

Consent records now persist the canonical `Locale` rather than the raw input, ensuring policy text and consent UI agree on language.

## Changes

- **`packages/core/src/consent/locale.ts`** — Added `normalizeLocale()` (PS-26 shim with deprecation warning) and `coerceLocale()` (silent environmental fallback); updated `resolveLocale()` to use both
- **`packages/core/src/consent/locale.test.ts`** — New test file covering normalization, coercion, and resolution logic
- **`packages/core/src/consent/store.test.ts`** — Updated locale test fixtures to use canonical `"en"` instead of `"en-GB"`; added test verifying canonical locale is persisted (PS-26 shim)
- **`packages/core/src/consent/storage/record.ts`** — Updated `toRecord()` signature to accept `Locale` (canonical) instead of `string`
- **`packages/core/src/consent/storage/record.test.ts`** — Updated fixtures to use canonical `"en"`; added comment explaining legacy read-side tolerance
- **`packages/core/src/i18n/index.ts`** — Updated `createT()` to accept optional `dictionary` parameter for custom translations
- **`packages/core/src/i18n/i18n.test.ts`** — Added tests for custom dictionary support
- **`packages/core/src/documents/index.ts`** — Updated `compile()` to accept optional `dictionary` parameter
- **`packages/core/src/index.ts`** — Exported `createT`, `Dictionary`, and `T` types; updated `compilePrivacyPolicy()` and `compileCookiePolicy()` to accept optional `dictionary`
- **`packages/sdk/src/consent.ts`** — Updated `toOpenCookiesConfig()` to flow `policy.locale` into OpenCookies config (one shared canonical Locale)
- **`packages/sdk/src/index.ts`** — Exported `Dictionary` and `createT`
- **`packages/react/src/components/PrivacyPolicy.tsx`** and **`CookiePolicy.tsx`** — Added `dictionary` prop and passed it through to `compile()` functions

## Test Plan

All changes are covered by automated tests:
- New `locale.test.ts` validates normalization, coercion, and resolution behavior
- Updated `store.test.ts` confirms canonical locales are persisted and non-canonical input triggers warnings
- Updated `i18n.test.ts` validates custom dictionary support
- Existing test suite passes with updated fixtures

https://claude.ai/code/session_01Gx5ed83J4QhgdXv98a31mK