### PR TITLE
feat(web): cookie consent banner + analytics gated behind consent

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
 		"@databuddy/sdk": "^2.4.11",
 		"@jxdltd/tanstack": "^0.0.1",
 		"@offstage/react": "^0.0.2",
+		"@openpolicy/core": "workspace:*",
 		"@openpolicy/react": "workspace:*",
 		"@openpolicy/sdk": "workspace:*",
 		"@phosphor-icons/react": "^2.1.10",

--- a/apps/web/src/components/CookieBanner.tsx
+++ b/apps/web/src/components/CookieBanner.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useConsent } from "@openpolicy/react/consent";
+
+const primaryButton =
+	"inline-flex items-center justify-center border-2 border-black bg-black px-4 py-2 text-xs tracking-wide text-white uppercase hover:bg-white hover:text-black focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black";
+
+const secondaryButton =
+	"inline-flex items-center justify-center border-2 border-black bg-canvas px-4 py-2 text-xs tracking-wide text-ink uppercase hover:bg-ink hover:text-canvas focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black";
+
+export function CookieBanner() {
+	const { route, acceptAll, acceptNecessary, setRoute } = useConsent();
+
+	// The store reads localStorage during the first client render, so a returning
+	// visitor's first client render disagrees with SSR (route "closed" vs
+	// "cookie"). Holding the UI until after hydration avoids the mismatch and the
+	// banner-flash for visitors who already decided.
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => setMounted(true), []);
+
+	if (!mounted || route !== "cookie") return null;
+
+	return (
+		<div
+			role="region"
+			aria-label="Cookie consent"
+			className="fixed inset-x-4 bottom-4 z-50 border-2 border-black bg-canvas p-5 sm:inset-x-auto sm:right-4 sm:max-w-md"
+		>
+			<p className="text-sm text-pretty text-mute">
+				We use cookies to keep the site running and, with your permission, to measure how it's used.
+				You can change this anytime via Cookie settings in the footer.
+			</p>
+			<div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end">
+				<button type="button" onClick={() => acceptNecessary()} className={secondaryButton}>
+					Necessary only
+				</button>
+				<button type="button" onClick={() => setRoute("preferences")} className={secondaryButton}>
+					Customize
+				</button>
+				<button type="button" onClick={() => acceptAll()} className={primaryButton}>
+					Accept all
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/CookiePreferences.tsx
+++ b/apps/web/src/components/CookiePreferences.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { XIcon } from "@phosphor-icons/react";
+import { useCategory, useConsent } from "@openpolicy/react/consent";
+import type { Category } from "@openpolicy/core/consent";
+
+const primaryButton =
+	"inline-flex items-center justify-center border-2 border-black bg-black px-4 py-2 text-xs tracking-wide text-white uppercase hover:bg-white hover:text-black focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black";
+
+const secondaryButton =
+	"inline-flex items-center justify-center border-2 border-black bg-canvas px-4 py-2 text-xs tracking-wide text-ink uppercase hover:bg-ink hover:text-canvas focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black";
+
+const DESCRIPTIONS: Record<string, string> = {
+	essential:
+		"Required for the site to work — security, session, and your consent choice itself. Always on.",
+	analytics:
+		"Lets us measure which pages are used so we can improve the site. Off until you allow it.",
+	marketing: "Used to personalise and measure marketing. Off until you allow it.",
+};
+
+function CategoryRow({ category }: { category: Category }) {
+	const { granted, toggle } = useCategory(category.key);
+	const inputId = `consent-${category.key}`;
+	const description = category.description ?? DESCRIPTIONS[category.key] ?? "";
+
+	return (
+		<li className="flex items-start justify-between gap-4 border-t-2 border-black py-4 first:border-t-0">
+			<div className="min-w-0">
+				<label htmlFor={inputId} className="text-sm tracking-wide text-ink uppercase">
+					{category.label}
+				</label>
+				{description && <p className="mt-1 text-xs text-pretty text-mute">{description}</p>}
+			</div>
+			<span className="relative inline-flex h-6 w-12 shrink-0 border-2 border-black">
+				<input
+					id={inputId}
+					name={category.key}
+					type="checkbox"
+					checked={granted}
+					disabled={category.locked}
+					onChange={() => toggle()}
+					aria-label={category.label}
+					className="peer absolute inset-0 z-10 size-full cursor-pointer appearance-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black disabled:cursor-not-allowed"
+				/>
+				<span
+					aria-hidden="true"
+					className="absolute inset-0 bg-canvas peer-checked:bg-black peer-disabled:peer-checked:bg-mute"
+				/>
+				<span
+					aria-hidden="true"
+					className="absolute top-0.5 left-1 size-4 bg-black transition-transform duration-150 ease-in-out peer-checked:translate-x-5 peer-checked:bg-canvas"
+				/>
+			</span>
+		</li>
+	);
+}
+
+export function CookiePreferences() {
+	const { route, categories, save, setRoute } = useConsent();
+	const panelRef = useRef<HTMLDivElement>(null);
+
+	// Match CookieBanner: hold the UI until after hydration so a returning
+	// visitor's localStorage-derived state never disagrees with SSR.
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => setMounted(true), []);
+
+	const open = mounted && route === "preferences";
+
+	useEffect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") setRoute("cookie");
+		};
+		document.addEventListener("keydown", onKey);
+		return () => document.removeEventListener("keydown", onKey);
+	}, [open, setRoute]);
+
+	useEffect(() => {
+		if (open) panelRef.current?.focus();
+	}, [open]);
+
+	if (!open) return null;
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+			<button
+				type="button"
+				aria-label="Close cookie preferences"
+				onClick={() => setRoute("cookie")}
+				className="absolute inset-0 size-full cursor-default bg-black/60"
+			/>
+			<div
+				ref={panelRef}
+				tabIndex={-1}
+				role="dialog"
+				aria-modal="true"
+				aria-label="Cookie preferences"
+				className="relative w-full max-w-lg border-2 border-black bg-canvas outline-none"
+			>
+				<div className="flex items-center justify-between border-b-2 border-black px-6 py-4">
+					<h2 className="text-sm tracking-wide text-ink uppercase">Cookie preferences</h2>
+					<button
+						type="button"
+						onClick={() => setRoute("cookie")}
+						className="inline-flex items-center gap-2 text-xs tracking-wide uppercase hover:text-mute"
+						aria-label="Close cookie preferences"
+					>
+						<XIcon weight="bold" className="size-4 shrink-0" aria-hidden="true" />
+						Close
+					</button>
+				</div>
+
+				<ul role="list" className="max-h-[60dvh] overflow-y-auto px-6">
+					{categories.map((category) => (
+						<CategoryRow key={category.key} category={category} />
+					))}
+				</ul>
+
+				<div className="flex flex-col gap-2 border-t-2 border-black px-6 py-4 sm:flex-row sm:justify-end">
+					<button type="button" onClick={() => setRoute("cookie")} className={secondaryButton}>
+						Back
+					</button>
+					<button type="button" onClick={() => save()} className={primaryButton}>
+						Save choices
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/CookieSettingsLink.tsx
+++ b/apps/web/src/components/CookieSettingsLink.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useConsent } from "@openpolicy/react/consent";
+
+// Persistent re-entry point: lets a visitor reopen the preferences modal after
+// they've already made (or to revise) a choice. Rendered inside the footer's
+// "legal" list so it inherits the footer link styling.
+export function CookieSettingsLink() {
+	const { setRoute } = useConsent();
+	return (
+		<li>
+			<button
+				type="button"
+				onClick={() => setRoute("preferences")}
+				className="text-left hover:text-ink"
+			>
+				Cookie settings
+			</button>
+		</li>
+	);
+}

--- a/apps/web/src/lib/consent.ts
+++ b/apps/web/src/lib/consent.ts
@@ -1,0 +1,20 @@
+import { timezoneResolver } from "@openpolicy/core/consent";
+import { localStorageAdapter } from "@openpolicy/core/consent/storage/local-storage";
+import type { OpenCookiesConfig } from "@openpolicy/core/consent";
+import { toOpenCookiesConfig } from "@openpolicy/sdk/consent";
+
+import policy from "../openpolicy";
+
+// The site's own policy is the single source of truth for cookie categories.
+// `toOpenCookiesConfig` derives the categories + `locked` flags from the policy's
+// lawful bases (analytics is `Consent` ⇒ a real opt-in toggle; essential stays
+// locked) and wires the `policyVersionChanged` re-prompt off `cookieVersion`.
+//
+// We pass this `config` to <OpenCookiesProvider> rather than a shared module
+// store: the provider memoizes one store per component instance, so each SSR
+// request gets its own store instead of leaking consent state across requests.
+export const consentConfig: OpenCookiesConfig = {
+	...toOpenCookiesConfig(policy),
+	adapter: localStorageAdapter(),
+	jurisdictionResolver: timezoneResolver(),
+};

--- a/apps/web/src/openpolicy.ts
+++ b/apps/web/src/openpolicy.ts
@@ -46,7 +46,7 @@ export default defineConfig({
 		},
 		context: {
 			essential: { lawfulBasis: LegalBases.LegalObligation },
-			analytics: { lawfulBasis: LegalBases.LegitimateInterests },
+			analytics: { lawfulBasis: LegalBases.Consent },
 			marketing: { lawfulBasis: LegalBases.Consent },
 		},
 	},

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,11 +4,16 @@ import { TanStackDevtools } from "@tanstack/react-devtools";
 import { Databuddy } from "@databuddy/sdk/react";
 import { OffstageProvider } from "@offstage/react";
 import { ArrowRightIcon, ArrowUpRightIcon } from "@phosphor-icons/react";
+import { ConsentGate, OpenCookiesProvider } from "@openpolicy/react/consent";
 
 import favicon from "../assets/favicon.svg?url";
 import appCss from "../styles.css?url";
 import { SITE_NAME, SITE_URL } from "../lib/seo";
+import { consentConfig } from "../lib/consent";
 import { NotFound } from "../components/NotFound";
+import { CookieBanner } from "../components/CookieBanner";
+import { CookiePreferences } from "../components/CookiePreferences";
+import { CookieSettingsLink } from "../components/CookieSettingsLink";
 
 const ORG_JSON_LD = {
 	"@context": "https://schema.org",
@@ -61,13 +66,25 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 				<HeadContent />
 			</head>
 			<body className="bg-canvas font-sans text-ink">
-				<OffstageProvider apiKey="pk_live_IeaDz82n3CMK_bXICW_Q1aGfN96as_HZ">
+				<OpenCookiesProvider config={consentConfig}>
 					<div id="app" className="isolate flex min-h-dvh flex-col">
 						<SiteHeader />
 						<main className="flex-1">{children ?? <Outlet />}</main>
 						<SiteFooter />
 					</div>
-				</OffstageProvider>
+					<CookieBanner />
+					<CookiePreferences />
+					{/* Analytics only loads once the visitor allows it. Offstage has
+					    no context consumers in this app, so gating it as a sibling
+					    (rather than wrapping #app) keeps the app from remounting
+					    when consent is toggled. */}
+					<ConsentGate requires="analytics">
+						<OffstageProvider apiKey="pk_live_IeaDz82n3CMK_bXICW_Q1aGfN96as_HZ">
+							<></>
+						</OffstageProvider>
+						<Databuddy clientId="831fa430-6fdb-4fe2-ab59-867bdc90847a" />
+					</ConsentGate>
+				</OpenCookiesProvider>
 				<TanStackDevtools
 					config={{ position: "bottom-right" }}
 					plugins={[
@@ -77,7 +94,6 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 						},
 					]}
 				/>
-				<Databuddy clientId="831fa430-6fdb-4fe2-ab59-867bdc90847a" />
 				<Scripts />
 			</body>
 		</html>
@@ -205,7 +221,17 @@ function SiteFooter() {
 						{ href: "mailto:jamie@openpolicy.sh", label: "Contact" },
 					]}
 				/>
-				<FooterCol title="legal" links={[{ to: "/privacy", label: "Privacy" }]} />
+				<div>
+					<h3 className="text-xs tracking-wide text-ink uppercase">legal</h3>
+					<ul role="list" className="mt-6 space-y-4 text-sm text-mute">
+						<li>
+							<Link to="/privacy" className="hover:text-ink">
+								Privacy
+							</Link>
+						</li>
+						<CookieSettingsLink />
+					</ul>
+				</div>
 			</div>
 			<div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-x-6 gap-y-2 px-8 py-6 text-xs tracking-wide text-mute uppercase">
 				<span>© {new Date().getFullYear()} PolicyStack Ltd — apache-2.0 where noted</span>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       '@offstage/react':
         specifier: ^0.0.2
         version: 0.0.2(react@19.2.6)
+      '@openpolicy/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@openpolicy/react':
         specifier: workspace:*
         version: link:../../packages/react


### PR DESCRIPTION
## Summary

The PolicyStack website shipped **no consent UI** and loaded Offstage + Databuddy unconditionally — a compliance gap and a missed dogfooding opportunity for a site that ships a consent product. This adds a headless cookie banner built from the project's own primitives (`@openpolicy/react/consent` + `@openpolicy/core/consent`), wired to the existing `apps/web/src/openpolicy.ts` policy via the `toOpenCookiesConfig` bridge, and gates the existing analytics behind the `analytics` consent category so the banner is truthful.

The library is headless by design — no prebuilt UI — so the banner is built with the site's own brutalist Tailwind tokens (`border-2 border-black`, `bg-canvas`, uppercase mono), matching the published walkthrough in `content/blog/tanstack-cookie-banner.mdx`.

## Changes

- **`apps/web/src/openpolicy.ts`** — analytics lawful basis `LegitimateInterests` → `Consent` so the bridge produces a real opt-in toggle. Result: **Essential** (locked, always-on) + **Analytics** (opt-in). Marketing stays `used: false` (not shown).
- **`apps/web/src/lib/consent.ts`** (new) — builds the OpenCookies config from the policy + `localStorageAdapter()` + `timezoneResolver()`. Passed as `config` (not a shared store) so each SSR request gets its own store.
- **`CookieBanner.tsx`** (new) — bottom banner: Accept all (primary) / Necessary only / Customize (secondary). Client-only mount gate prevents the SSR hydration mismatch / returning-visitor flash.
- **`CookiePreferences.tsx`** (new) — modal with a CSS-only square toggle per category (Essential locked, Analytics toggleable), Escape-to-close, focus management; modeled on the existing `DocsMobileNav` dialog.
- **`CookieSettingsLink.tsx`** (new) — persistent "Cookie settings" re-entry button in the footer's legal column.
- **`apps/web/src/routes/__root.tsx`** — body wrapped in `OpenCookiesProvider`; Offstage + Databuddy moved out of wrapping `#app` into `<ConsentGate requires="analytics">` as siblings, so analytics only loads after consent and the app never remounts on toggle; footer legal column rebuilt to include the settings link.
- **`apps/web/package.json`** / `pnpm-lock.yaml` — add `@openpolicy/core` workspace dependency.

## Reviewer notes

- **Base is `v1`**, not `main` — this is PolicyStack 1.0 work (`apps/web` is part of v1). **No changeset** added, per the 1.0 versioning convention. No Linear ticket associated.
- Offstage is gated as a *sibling* (not wrapping `#app`) because nothing in `apps/web/src` consumes its context — verified by grep — so the app tree never unmounts when consent toggles.
- Verified: `vp check --no-fmt apps/web/src` (lint + types) passes; full `vp run -F web build` (SSR/prod + nitro + search index) passes; SSR smoke test confirms the provider works server-side and the banner is correctly client-only (absent from SSR HTML → no hydration mismatch).
- The pre-existing `content-collections` tsc errors are unrelated/environmental (codegen not run by bare `tsc`); `vp check` runs the codegen first and passes.
- **Manual browser verification still recommended** (needs DevTools): no Offstage/Databuddy network requests before deciding; "Necessary only" persists with no analytics; "Accept all" fires analytics; footer link reopens the modal; toggling Analytics off + Save stops analytics on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)