### PR TITLE
PS-27: Generate llms.txt from SDK types; ship in-package + site + CLI

### DIFF
--- a/apps/web/src/lib/llms.ts
+++ b/apps/web/src/lib/llms.ts
@@ -89,6 +89,10 @@ export function renderLlmsTxt() {
 		`- [OpenCookies](${SITE}/opencookies.md): Sub-4kb headless cookie-consent state machine`,
 		`- [PolicyCloud](${SITE}/policycloud.md): Hosted policy versioning and consent analytics (early access)`,
 		"",
+		"## SDK",
+		"",
+		`- [SDK reference (llms.txt)](${SITE}/sdk.txt): Type-generated \`@openpolicy/sdk\` API surface — feed it to a coding agent to produce a correct openpolicy.ts`,
+		"",
 		"## Documentation",
 		"",
 	];

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SdkDottxtRouteImport } from './routes/sdk[.]txt'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as PolicycloudDotmdRouteImport } from './routes/policycloud[.]md'
 import { Route as PolicycloudRouteImport } from './routes/policycloud'
@@ -28,6 +29,11 @@ import { Route as OgSplatRouteImport } from './routes/og/$'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as BlogSlugRouteImport } from './routes/blog_.$slug'
 
+const SdkDottxtRoute = SdkDottxtRouteImport.update({
+  id: '/sdk.txt',
+  path: '/sdk.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PrivacyRoute = PrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
@@ -134,6 +140,7 @@ export interface FileRoutesByFullPath {
   '/policycloud': typeof PolicycloudRoute
   '/policycloud.md': typeof PolicycloudDotmdRoute
   '/privacy': typeof PrivacyRoute
+  '/sdk.txt': typeof SdkDottxtRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
   '/og/$': typeof OgSplatRoute
@@ -153,6 +160,7 @@ export interface FileRoutesByTo {
   '/policycloud': typeof PolicycloudRoute
   '/policycloud.md': typeof PolicycloudDotmdRoute
   '/privacy': typeof PrivacyRoute
+  '/sdk.txt': typeof SdkDottxtRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
   '/og/$': typeof OgSplatRoute
@@ -174,6 +182,7 @@ export interface FileRoutesById {
   '/policycloud': typeof PolicycloudRoute
   '/policycloud.md': typeof PolicycloudDotmdRoute
   '/privacy': typeof PrivacyRoute
+  '/sdk.txt': typeof SdkDottxtRoute
   '/blog_/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
   '/og/$': typeof OgSplatRoute
@@ -196,6 +205,7 @@ export interface FileRouteTypes {
     | '/policycloud'
     | '/policycloud.md'
     | '/privacy'
+    | '/sdk.txt'
     | '/blog/$slug'
     | '/docs/$'
     | '/og/$'
@@ -215,6 +225,7 @@ export interface FileRouteTypes {
     | '/policycloud'
     | '/policycloud.md'
     | '/privacy'
+    | '/sdk.txt'
     | '/blog/$slug'
     | '/docs/$'
     | '/og/$'
@@ -235,6 +246,7 @@ export interface FileRouteTypes {
     | '/policycloud'
     | '/policycloud.md'
     | '/privacy'
+    | '/sdk.txt'
     | '/blog_/$slug'
     | '/docs/$'
     | '/og/$'
@@ -256,12 +268,20 @@ export interface RootRouteChildren {
   PolicycloudRoute: typeof PolicycloudRoute
   PolicycloudDotmdRoute: typeof PolicycloudDotmdRoute
   PrivacyRoute: typeof PrivacyRoute
+  SdkDottxtRoute: typeof SdkDottxtRoute
   BlogSlugRoute: typeof BlogSlugRoute
   OgSplatRoute: typeof OgSplatRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/sdk.txt': {
+      id: '/sdk.txt'
+      path: '/sdk.txt'
+      fullPath: '/sdk.txt'
+      preLoaderRoute: typeof SdkDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/privacy': {
       id: '/privacy'
       path: '/privacy'
@@ -420,6 +440,7 @@ const rootRouteChildren: RootRouteChildren = {
   PolicycloudRoute: PolicycloudRoute,
   PolicycloudDotmdRoute: PolicycloudDotmdRoute,
   PrivacyRoute: PrivacyRoute,
+  SdkDottxtRoute: SdkDottxtRoute,
   BlogSlugRoute: BlogSlugRoute,
   OgSplatRoute: OgSplatRoute,
 }

--- a/apps/web/src/routes/sdk[.]txt.ts
+++ b/apps/web/src/routes/sdk[.]txt.ts
@@ -1,0 +1,14 @@
+import { renderLlmsTxt } from "@openpolicy/sdk";
+import { createFileRoute } from "@tanstack/react-router";
+import { PLAIN_HEADERS } from "../lib/llms";
+
+// The canonical, type-generated SDK reference (PS-27). `renderLlmsTxt()` is the
+// single source of truth — the same function the `@openpolicy/sdk` package
+// snapshots into its shipped `llms.txt` and the CLI writes into a project.
+export const Route = createFileRoute("/sdk.txt")({
+	server: {
+		handlers: {
+			GET: () => new Response(renderLlmsTxt(), { headers: PLAIN_HEADERS }),
+		},
+	},
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
 		"test": "vp test"
 	},
 	"devDependencies": {
+		"@openpolicy/sdk": "workspace:*",
 		"@openpolicy/tooling": "workspace:*",
 		"citty": "^0.1.6",
 		"consola": "^3.4.2",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,8 +2,9 @@ import { existsSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { defineCommand } from "citty";
 import consola from "consola";
-import { AGENT_PROMPT } from "../prompt";
+import { buildAgentPrompt } from "../prompt";
 import { detectIntegrations, type Integration } from "../utils/detect-integrations";
+import { resolveLlmsPath, writeLlms } from "../utils/llms";
 import {
 	detectPackageManager,
 	type PackageManager,
@@ -25,10 +26,10 @@ type InitArgs = {
 	force: boolean;
 };
 
-function printPrompt() {
+function printPrompt(prompt: string) {
 	const top = "─── Copy the prompt below into your coding agent ───";
 	const bottom = "─── End of prompt ───";
-	process.stdout.write(`\n${top}\n\n${AGENT_PROMPT}\n${bottom}\n\n`);
+	process.stdout.write(`\n${top}\n\n${prompt}\n${bottom}\n\n`);
 }
 
 function summarize(
@@ -109,19 +110,24 @@ export async function runInit(args: InitArgs): Promise<void> {
 		}
 	}
 
+	const llmsPath = resolveLlmsPath(stubPath);
+	const stubRel = relative(cwd, stubPath) || stubPath;
+	const llmsRel = relative(cwd, llmsPath) || llmsPath;
+
 	if (args.dryRun) {
 		consola.info("Dry run — no files written.");
 	} else {
-		const result = await writeStub(stubPath, args.force);
-		const rel = relative(cwd, result.path) || result.path;
-		if (result.written) {
-			consola.success(`Created ${rel}`);
+		const stub = await writeStub(stubPath, args.force);
+		if (stub.written) {
+			consola.success(`Created ${stubRel}`);
 		} else {
-			consola.info(`Kept existing ${rel}`);
+			consola.info(`Kept existing ${stubRel}`);
 		}
+		const llms = await writeLlms(llmsPath);
+		consola.success(`${llms.written ? "Created" : "Updated"} ${llmsRel}`);
 	}
 
-	printPrompt();
+	printPrompt(buildAgentPrompt({ stubRel, llmsRel }));
 
 	consola.success(
 		"Paste the prompt above into your coding agent (Claude Code, Cursor, etc.) to finish setup.",

--- a/packages/cli/src/prompt.ts
+++ b/packages/cli/src/prompt.ts
@@ -1,15 +1,20 @@
-// Keep this string in sync with apps/www/src/snippets/prompt.txt.
-export const AGENT_PROMPT = `Read this codebase carefully, then generate an openpolicy.ts using the OpenPolicy SDK.
+/**
+ * The setup prompt printed by `init`. The SDK reference is written into the
+ * project as a local file (PS-27) — the prompt points the agent at that file,
+ * not a remote URL, so it works offline and matches the installed version.
+ */
+export function buildAgentPrompt(opts: { stubRel: string; llmsRel: string }): string {
+	return `Read this codebase carefully, then generate ${opts.stubRel} using the OpenPolicy SDK.
 
-SDK reference: https://docs.openpolicy.sh/llms.txt
+SDK reference: ${opts.llmsRel} — read this file first. It is the complete, type-generated API surface (config shape, valid jurisdiction codes, lawful bases, and the merged policy + consent surface).
 
 Your output should capture:
 - Every category of data collected and why
 - All third-party services integrated and their purpose
-- The applicable jurisdictions as region codes (e.g. "eea", "uk", "us-ca" — see https://docs.openpolicy.sh/references/jurisdictions)
-- Legal basis for processing
-- User rights supported
+- The applicable jurisdictions, as codes from the SDK reference
+- The lawful basis for each data category and each cookie
 - Cookie usage (essential, analytics, marketing) and consent categories
 
-Output only a single openpolicy.ts using defineConfig(). No explanations.
+Output only a single ${opts.stubRel} using defineConfig(). No explanations.
 `;
+}

--- a/packages/cli/src/utils/llms.test.ts
+++ b/packages/cli/src/utils/llms.test.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, test } from "vite-plus/test";
+import { resolveLlmsPath, writeLlms } from "./llms";
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "op-llms-"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test("resolveLlmsPath sits next to the stub", () => {
+	expect(resolveLlmsPath(join(dir, "src", "openpolicy.ts"))).toBe(
+		join(dir, "src", "openpolicy.llms.txt"),
+	);
+});
+
+test("writeLlms writes the canonical reference and reports create vs update", async () => {
+	const path = resolveLlmsPath(join(dir, "openpolicy.ts"));
+
+	const first = await writeLlms(path);
+	expect(first.written).toBe(true);
+	expect(readFileSync(path, "utf8")).toContain("# PolicyStack SDK reference (llms.txt)");
+
+	const second = await writeLlms(path);
+	expect(second.written).toBe(false);
+});

--- a/packages/cli/src/utils/llms.ts
+++ b/packages/cli/src/utils/llms.ts
@@ -1,0 +1,22 @@
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { renderLlmsTxt } from "@openpolicy/sdk";
+
+// The SDK reference is written next to the stub so a project-relative path in
+// the prompt resolves regardless of where the stub lands (root or src/).
+export function resolveLlmsPath(stubPath: string): string {
+	return join(dirname(stubPath), "openpolicy.llms.txt");
+}
+
+type WriteLlmsResult = { path: string; written: boolean };
+
+// `renderLlmsTxt()` is the single source of truth — the same function the
+// `@openpolicy/sdk` package snapshots and `apps/web` serves. Bundling it here
+// (not reading node_modules) keeps the write working under --skip-install.
+// Always refreshed so an upgraded CLI overwrites a stale local copy.
+export async function writeLlms(path: string): Promise<WriteLlmsResult> {
+	const written = !existsSync(path);
+	await writeFile(path, renderLlmsTxt());
+	return { path, written };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,7 +101,7 @@ export { Contractual, ContractPrerequisite, Statutory, Voluntary } from "./provi
 export { computeCookieVersion, computePrivacyVersion } from "./policy-version";
 export { deriveUserRights } from "./user-rights";
 export { validate } from "./validate";
-export { createT } from "./i18n";
+export { createT, isLocale, LOCALES } from "./i18n";
 export type { Dictionary, T } from "./i18n";
 
 import { compile } from "./documents";

--- a/packages/sdk/llms.txt
+++ b/packages/sdk/llms.txt
@@ -1,0 +1,149 @@
+# PolicyStack SDK reference (llms.txt)
+
+> Generated from `@openpolicy/sdk` types — do not edit by hand. Feed this file
+> to a coding agent so it can write a correct `openpolicy.ts`. One typed
+> `defineConfig()` call is the single source of truth: it produces the privacy
+> policy, the cookie policy, and — via the §4.1 bridge — the consent runtime.
+
+## Entry point
+
+```ts
+import { defineConfig } from "@openpolicy/sdk";
+
+export default defineConfig({ /* OpenPolicyConfig */ });
+```
+
+`defineConfig(config)` returns the config with `privacyVersion` and
+`cookieVersion` filled in (stable content hashes) unless you set them yourself.
+Output only a single `openpolicy.ts` — no explanations.
+
+## OpenPolicyConfig shape
+
+Required:
+
+- `company`: `{ name, legalName, address, contact: { email, phone? }, dpo?, euRepresentative? }`
+- `effectiveDate`: `"YYYY-MM-DD"`
+- `jurisdictions`: non-empty array of jurisdiction ids (see below)
+- `data`: `{ collected, context }` — the data posture (an empty `collected`
+  is valid for a brochure site but emits a `data-collected-empty` warning)
+
+Optional:
+
+- `locale`: one of `de`, `en`, `es`, `fr`, `nl` (default `"en"`) — governs only
+  OpenPolicy-emitted boilerplate; your own strings pass through untouched
+- `children`: `{ underAge: number, noticeUrl? }`
+- `thirdParties`: `{ name, purpose, policyUrl? }[]`
+- `automatedDecisionMaking`: `{ name, logic, significance }[]` (GDPR Art. 22)
+- `cookies`: `{ used, context }` — see "Cookies & consent" below
+- `trackingTechnologies`: `string[]`
+- `consentMechanism`: `{ hasBanner, hasPreferencePanel, canWithdraw }`
+- `policies`: explicit `("privacy" | "cookie")[]` opt-out of auto-detection
+- `privacyVersion` / `cookieVersion`: override the auto-computed hash
+
+`userRights` is **not** authored — it is derived from `jurisdictions`.
+
+## data.collected & data.context (symmetric per-key)
+
+`data.collected` maps a human category label to the list of fields collected.
+Every category key must have a matching `data.context` entry:
+
+```ts
+data: {
+  collected: { "Account Information": ["Name", "Email address"] },
+  context: {
+    "Account Information": {
+      purpose: "Operate your account",
+      lawfulBasis: "contract",          // a lawful basis (see below)
+      retention: "Until account deletion",
+      provision: Contractual("You cannot create an account without it."),
+    },
+  },
+}
+```
+
+`provision` is built with one of the helpers (GDPR Art. 13(2)(e)):
+`Statutory(consequences)`, `Contractual(consequences)`,
+`ContractPrerequisite(consequences)`, `Voluntary(consequences)`.
+
+## Jurisdiction ids (frozen at 1.0)
+
+Pick the codes that apply; the `us-${state}` tail not listed falls back to
+`us`. Posture and policy-text tier are read straight from the canonical table:
+
+- `br` — opt-in, equivalent policy text
+- `ca` — opt-in, equivalent policy text
+- `ch` — opt-in, equivalent policy text
+- `eea` — opt-in, specific policy text
+- `row` — opt-in, equivalent policy text
+- `uk` — opt-in, specific policy text
+- `us` — opt-out, equivalent policy text
+- `us-ca` — opt-out, specific policy text, inherits `us`, GPC legally binding
+- `us-co` — opt-out, equivalent policy text, inherits `us`, GPC legally binding
+- `us-ct` — opt-out, equivalent policy text, inherits `us`, GPC legally binding
+- `us-va` — opt-out, equivalent policy text, inherits `us`, GPC legally binding
+
+## Lawful bases
+
+Used by `data.context[*].lawfulBasis` and `cookies.context[*].lawfulBasis`.
+The consent gating is an explicit, exhaustive table (§4.1) — only `consent`
+is gated:
+
+- `consent` — consent-gated (toggleable in the banner)
+- `contract` — standing legal ground (category renders locked-on)
+- `legal_obligation` — standing legal ground (category renders locked-on)
+- `legitimate_interests` — standing legal ground (category renders locked-on)
+- `public_task` — standing legal ground (category renders locked-on)
+- `vital_interests` — standing legal ground (category renders locked-on)
+
+## Cookies & consent (the merged surface)
+
+`cookies.used` is a flat map; `essential` is always `true`. Every enabled key
+needs a `cookies.context[key].lawfulBasis`:
+
+```ts
+cookies: {
+  used: { essential: true, analytics: true, marketing: true },
+  context: {
+    essential:  { lawfulBasis: "legal_obligation" },
+    analytics:  { lawfulBasis: "consent" },
+    marketing:  { lawfulBasis: "consent" },
+  },
+}
+```
+
+The consent runtime is **derived**, never authored separately. Call
+`toOpenCookiesConfig(config)` from `@openpolicy/sdk/consent` to bridge:
+
+- each truthy `cookies.used` key → a consent `Category`
+- `lawfulBasis === "consent"` → toggleable; any other basis → `locked: true`
+  (a missing basis stays gated and `validate()` hard-errors it)
+- `cookieVersion` → `policyVersion`; a changed hash re-prompts automatically
+- `consentMechanism.canWithdraw` → the preferences-route affordance
+- `config.locale` → the consent UI locale (policy text and banner agree)
+
+## Helper exports (from `@openpolicy/sdk`)
+
+Static-analysis markers (return their value unchanged; scanned at build time):
+
+- `collecting(category, value, labels)` — declare data at the point of storage;
+  use `Ignore` as a label to exclude a field
+- `sharing(key, recipient, value)` — record a data-egress edge (the CCPA
+  sell/share signal), wrap the outbound payload
+- `thirdParty(name, purpose, policyUrl)` — declare a vendor exists
+- `defineCookie(category)` — declare a consent category at its use site
+
+Presets (optional convenience — plain objects/strings, spread or reference):
+
+- Data categories: `DataCategories.AccountInfo`, `DataCategories.Communications`, `DataCategories.DeviceInfo`, `DataCategories.LocationData`, `DataCategories.PaymentInfo`, `DataCategories.SessionData`, `DataCategories.UsageData`
+- Lawful bases: `LegalBases.Consent` (`"consent"`), `LegalBases.Contract` (`"contract"`), `LegalBases.LegalObligation` (`"legal_obligation"`), `LegalBases.LegitimateInterests` (`"legitimate_interests"`), `LegalBases.PublicTask` (`"public_task"`), `LegalBases.VitalInterests` (`"vital_interests"`)
+- Retention: `Retention.AsRequiredByLaw` (`"As required by applicable law"`), `Retention.NinetyDays` (`"90 days"`), `Retention.OneYear` (`"1 year"`), `Retention.ThirtyDays` (`"30 days"`), `Retention.ThreeYears` (`"3 years"`), `Retention.UntilAccountDeletion` (`"Until account deletion"`), `Retention.UntilSessionExpiry` (`"Until session expiry"`)
+- Providers: `Providers.AWS`, `Providers.Auth0`, `Providers.Clerk`, `Providers.Cloudflare`, `Providers.Datadog`, `Providers.GoogleAnalytics`, `Providers.LemonSqueezy`, `Providers.Loops`, `Providers.Mixpanel`, `Providers.Paddle`, `Providers.PayPal`, `Providers.Plausible`, `Providers.PostHog`, `Providers.Postmark`, `Providers.Resend`, `Providers.SendGrid`, `Providers.Sentry`, `Providers.Stripe`, `Providers.Vercel`
+- Compliance bundles: `Compliance.CCPA`, `Compliance.GDPR`, `Compliance.UK_GDPR`
+
+## Rules
+
+- Output a single `openpolicy.ts` calling `defineConfig()`. No prose.
+- Do not author `userRights`, `privacyVersion`, or `cookieVersion` — derived.
+- Every `data.collected` / `cookies.used` key needs a matching `context` entry.
+- OpenPolicy generates documents; it is not legal advice — a lawyer should
+  review the output before publication.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -13,6 +13,7 @@
 	},
 	"files": [
 		"dist",
+		"llms.txt",
 		"README.md",
 		"NOTICE.md",
 		"skills"
@@ -26,11 +27,13 @@
 		"./consent": {
 			"import": "./dist/consent.js",
 			"types": "./dist/consent.d.ts"
-		}
+		},
+		"./llms.txt": "./llms.txt"
 	},
 	"scripts": {
 		"dev": "vp pack --watch",
-		"build": "vp pack",
+		"build": "vp pack && vp run gen:llms",
+		"gen:llms": "node scripts/gen-llms.mjs",
 		"check-types": "tsc --noEmit",
 		"test": "vp test"
 	},

--- a/packages/sdk/scripts/gen-llms.mjs
+++ b/packages/sdk/scripts/gen-llms.mjs
@@ -1,0 +1,13 @@
+// Snapshots the canonical llms.txt that `@openpolicy/sdk` ships (PS-27).
+// Runs after `vp pack` so it reads the same built artifact consumers import.
+// The single source of truth is `renderLlmsTxt()` in src/llms.ts; this only
+// writes its output to disk. `llms.test.ts` guards the snapshot from drift.
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderLlmsTxt } from "../dist/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const out = join(here, "..", "llms.txt");
+writeFileSync(out, renderLlmsTxt());
+process.stdout.write(`Wrote ${out}\n`);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -49,6 +49,7 @@ export type {
 } from "./auto-collected";
 export { collecting, Ignore } from "./collecting";
 export { Compliance } from "./compliance";
+export { renderLlmsTxt } from "./llms";
 export { DataCategories, LegalBases, Retention } from "./data";
 export { defineCookie } from "./define-cookie";
 export { Providers } from "./providers";

--- a/packages/sdk/src/llms.test.ts
+++ b/packages/sdk/src/llms.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vite-plus/test";
+import { renderLlmsTxt } from "./llms";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const shipped = join(here, "..", "llms.txt");
+
+test("shipped llms.txt is in sync with renderLlmsTxt() — run `vp run gen:llms`", () => {
+	expect(readFileSync(shipped, "utf8")).toBe(renderLlmsTxt());
+});
+
+test("llms.txt enumerates the live jurisdiction and lawful-basis tables", () => {
+	const out = renderLlmsTxt();
+	// Drift canaries: these ride the same runtime tables the compiler uses,
+	// so a frozen-union change without a regen fails here too.
+	expect(out).toContain("`eea` — opt-in, specific policy text");
+	expect(out).toContain(
+		"`us-ca` — opt-out, specific policy text, inherits `us`, GPC legally binding",
+	);
+	expect(out).toContain("`consent` — consent-gated");
+	expect(out).toContain("`legitimate_interests` — standing legal ground");
+});

--- a/packages/sdk/src/llms.ts
+++ b/packages/sdk/src/llms.ts
@@ -1,0 +1,208 @@
+import {
+	isConsentGated,
+	JURISDICTION_TABLE,
+	LAWFUL_BASIS_CONSENT_GATED,
+	LOCALES,
+} from "@openpolicy/core";
+import { Compliance } from "./compliance";
+import { DataCategories, LegalBases, Retention } from "./data";
+import { Providers } from "./providers";
+
+/**
+ * The canonical `llms.txt` SDK reference, **generated from the live SDK and
+ * core constants** so it cannot drift from the real API surface (PS-27).
+ *
+ * One source of truth, shipped three ways:
+ *   1. `@openpolicy/sdk` ships `llms.txt` (this function, snapshotted by
+ *      `scripts/gen-llms.mjs`; guarded by `llms.test.ts`).
+ *   2. `apps/web` serves it at `/sdk.txt` by calling this function.
+ *   3. The CLI writes it into the user's project on `init` and points the
+ *      agent prompt at that local file.
+ *
+ * Every enumeration (jurisdictions, lawful bases, locales, the vendor /
+ * data-category / retention presets) is derived at call time from the same
+ * runtime tables the compiler and validator use — add a jurisdiction or a
+ * provider and this document updates with it.
+ */
+export function renderLlmsTxt(): string {
+	const jurisdictionRows = Object.entries(JURISDICTION_TABLE)
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([id, cap]) => {
+			const parent = cap.parent ? `, inherits \`${cap.parent}\`` : "";
+			const gpc = cap.gpcLegallyBinding ? ", GPC legally binding" : "";
+			return `- \`${id}\` — ${cap.consentModel}, ${cap.policyText} policy text${parent}${gpc}`;
+		});
+
+	const lawfulBasisRows = Object.entries(LAWFUL_BASIS_CONSENT_GATED)
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([basis]) => {
+			const gated = isConsentGated(basis as keyof typeof LAWFUL_BASIS_CONSENT_GATED);
+			return `- \`${basis}\` — ${gated ? "consent-gated (toggleable in the banner)" : "standing legal ground (category renders locked-on)"}`;
+		});
+
+	const localeList = [...LOCALES]
+		.sort()
+		.map((l) => `\`${l}\``)
+		.join(", ");
+
+	const dataCategoryKeys = Object.keys(DataCategories)
+		.sort()
+		.map((k) => `\`DataCategories.${k}\``)
+		.join(", ");
+
+	const legalBasesKeys = Object.entries(LegalBases)
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([k, v]) => `\`LegalBases.${k}\` (\`"${v}"\`)`)
+		.join(", ");
+
+	const retentionKeys = Object.entries(Retention)
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([k, v]) => `\`Retention.${k}\` (\`"${v}"\`)`)
+		.join(", ");
+
+	const providerKeys = Object.keys(Providers)
+		.sort()
+		.map((k) => `\`Providers.${k}\``)
+		.join(", ");
+
+	const complianceKeys = Object.keys(Compliance)
+		.sort()
+		.map((k) => `\`Compliance.${k}\``)
+		.join(", ");
+
+	return `# PolicyStack SDK reference (llms.txt)
+
+> Generated from \`@openpolicy/sdk\` types — do not edit by hand. Feed this file
+> to a coding agent so it can write a correct \`openpolicy.ts\`. One typed
+> \`defineConfig()\` call is the single source of truth: it produces the privacy
+> policy, the cookie policy, and — via the §4.1 bridge — the consent runtime.
+
+## Entry point
+
+\`\`\`ts
+import { defineConfig } from "@openpolicy/sdk";
+
+export default defineConfig({ /* OpenPolicyConfig */ });
+\`\`\`
+
+\`defineConfig(config)\` returns the config with \`privacyVersion\` and
+\`cookieVersion\` filled in (stable content hashes) unless you set them yourself.
+Output only a single \`openpolicy.ts\` — no explanations.
+
+## OpenPolicyConfig shape
+
+Required:
+
+- \`company\`: \`{ name, legalName, address, contact: { email, phone? }, dpo?, euRepresentative? }\`
+- \`effectiveDate\`: \`"YYYY-MM-DD"\`
+- \`jurisdictions\`: non-empty array of jurisdiction ids (see below)
+- \`data\`: \`{ collected, context }\` — the data posture (an empty \`collected\`
+  is valid for a brochure site but emits a \`data-collected-empty\` warning)
+
+Optional:
+
+- \`locale\`: one of ${localeList} (default \`"en"\`) — governs only
+  OpenPolicy-emitted boilerplate; your own strings pass through untouched
+- \`children\`: \`{ underAge: number, noticeUrl? }\`
+- \`thirdParties\`: \`{ name, purpose, policyUrl? }[]\`
+- \`automatedDecisionMaking\`: \`{ name, logic, significance }[]\` (GDPR Art. 22)
+- \`cookies\`: \`{ used, context }\` — see "Cookies & consent" below
+- \`trackingTechnologies\`: \`string[]\`
+- \`consentMechanism\`: \`{ hasBanner, hasPreferencePanel, canWithdraw }\`
+- \`policies\`: explicit \`("privacy" | "cookie")[]\` opt-out of auto-detection
+- \`privacyVersion\` / \`cookieVersion\`: override the auto-computed hash
+
+\`userRights\` is **not** authored — it is derived from \`jurisdictions\`.
+
+## data.collected & data.context (symmetric per-key)
+
+\`data.collected\` maps a human category label to the list of fields collected.
+Every category key must have a matching \`data.context\` entry:
+
+\`\`\`ts
+data: {
+  collected: { "Account Information": ["Name", "Email address"] },
+  context: {
+    "Account Information": {
+      purpose: "Operate your account",
+      lawfulBasis: "contract",          // a lawful basis (see below)
+      retention: "Until account deletion",
+      provision: Contractual("You cannot create an account without it."),
+    },
+  },
+}
+\`\`\`
+
+\`provision\` is built with one of the helpers (GDPR Art. 13(2)(e)):
+\`Statutory(consequences)\`, \`Contractual(consequences)\`,
+\`ContractPrerequisite(consequences)\`, \`Voluntary(consequences)\`.
+
+## Jurisdiction ids (frozen at 1.0)
+
+Pick the codes that apply; the \`us-\${state}\` tail not listed falls back to
+\`us\`. Posture and policy-text tier are read straight from the canonical table:
+
+${jurisdictionRows.join("\n")}
+
+## Lawful bases
+
+Used by \`data.context[*].lawfulBasis\` and \`cookies.context[*].lawfulBasis\`.
+The consent gating is an explicit, exhaustive table (§4.1) — only \`consent\`
+is gated:
+
+${lawfulBasisRows.join("\n")}
+
+## Cookies & consent (the merged surface)
+
+\`cookies.used\` is a flat map; \`essential\` is always \`true\`. Every enabled key
+needs a \`cookies.context[key].lawfulBasis\`:
+
+\`\`\`ts
+cookies: {
+  used: { essential: true, analytics: true, marketing: true },
+  context: {
+    essential:  { lawfulBasis: "legal_obligation" },
+    analytics:  { lawfulBasis: "consent" },
+    marketing:  { lawfulBasis: "consent" },
+  },
+}
+\`\`\`
+
+The consent runtime is **derived**, never authored separately. Call
+\`toOpenCookiesConfig(config)\` from \`@openpolicy/sdk/consent\` to bridge:
+
+- each truthy \`cookies.used\` key → a consent \`Category\`
+- \`lawfulBasis === "consent"\` → toggleable; any other basis → \`locked: true\`
+  (a missing basis stays gated and \`validate()\` hard-errors it)
+- \`cookieVersion\` → \`policyVersion\`; a changed hash re-prompts automatically
+- \`consentMechanism.canWithdraw\` → the preferences-route affordance
+- \`config.locale\` → the consent UI locale (policy text and banner agree)
+
+## Helper exports (from \`@openpolicy/sdk\`)
+
+Static-analysis markers (return their value unchanged; scanned at build time):
+
+- \`collecting(category, value, labels)\` — declare data at the point of storage;
+  use \`Ignore\` as a label to exclude a field
+- \`sharing(key, recipient, value)\` — record a data-egress edge (the CCPA
+  sell/share signal), wrap the outbound payload
+- \`thirdParty(name, purpose, policyUrl)\` — declare a vendor exists
+- \`defineCookie(category)\` — declare a consent category at its use site
+
+Presets (optional convenience — plain objects/strings, spread or reference):
+
+- Data categories: ${dataCategoryKeys}
+- Lawful bases: ${legalBasesKeys}
+- Retention: ${retentionKeys}
+- Providers: ${providerKeys}
+- Compliance bundles: ${complianceKeys}
+
+## Rules
+
+- Output a single \`openpolicy.ts\` calling \`defineConfig()\`. No prose.
+- Do not author \`userRights\`, \`privacyVersion\`, or \`cookieVersion\` — derived.
+- Every \`data.collected\` / \`cookies.used\` key needs a matching \`context\` entry.
+- OpenPolicy generates documents; it is not legal advice — a lawyer should
+  review the output before publication.
+`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
 
   packages/cli:
     devDependencies:
+      '@openpolicy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@openpolicy/tooling':
         specifier: workspace:*
         version: link:../../tooling/tsconfig


### PR DESCRIPTION
Closes PS-27.

One canonical SDK reference, **generated from the live SDK/core constants** so it cannot drift, shipped three ways.

## What

- **Single source of truth** — `renderLlmsTxt()` in `@openpolicy/sdk` (`packages/sdk/src/llms.ts`). Jurisdictions, lawful bases, locales, and the data-category / provider / retention presets are derived at call time from the same runtime tables the compiler and validator use (`JURISDICTION_TABLE`, `LAWFUL_BASIS_CONSENT_GATED`, `LOCALES`, the SDK preset objects). Documents the **merged** policy + consent surface — the §4.1 `toOpenCookiesConfig` bridge (gating, `policyVersion` re-prompt, `canWithdraw`, shared locale).
- **Shipped in-package** — `scripts/gen-llms.mjs` snapshots the function into `packages/sdk/llms.txt` on `build` (added to `files` + a `./llms.txt` export). `llms.test.ts` is a drift guard: it fails if the shipped file diverges from `renderLlmsTxt()`, plus canaries on the live jurisdiction/lawful-basis tables.
- **Served by the site** — new `/sdk.txt` route in `apps/web` calls the same function; linked from the existing `/llms.txt` sitemap under a new "SDK" section.
- **Written locally by the CLI** — `openpolicy init` writes `openpolicy.llms.txt` next to the stub; the agent prompt now points at that **local file** instead of a remote URL (works offline, matches the installed version). The prompt became `buildAgentPrompt({ stubRel, llmsRel })`; the stale `apps/www` sync comment is gone.
- Exposes `LOCALES` / `isLocale` from `@openpolicy/core` for drift-free locale enumeration.

## Verification

- `core` (452), `sdk` (46, incl. drift guard), `cli` (42, incl. new util test) tests green.
- Lint clean and `core`/`sdk`/`cli` type-check clean on all touched files.
- End-to-end: `openpolicy init` writes both files and the CLI-written `openpolicy.llms.txt` is **byte-identical** to the shipped `packages/sdk/llms.txt` and the site's output — one source, three ways, drift-free.

Notes: targets `v1` per the 1.0 process; no changeset (PS-* work). Pre-existing unrelated format drift in `apps/web/content/*` on `v1` is untouched. `apps/web` has no `check-types` script (its standalone `tsc` cannot resolve the build-time `content-collections` virtual module); the new route adds no new type errors and the TanStack generator regenerated `routeTree.gen.ts` cleanly with `/sdk.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)