### PR TITLE
ci: get v1 green and gate it so it stays green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, v1]
   pull_request:
     branches: [main, v1]
 concurrency:
@@ -20,9 +20,13 @@ jobs:
       - run: vp run -r build
       - run: vp check
       - run: vp run -r check-types
-      # TEMP: svelte tests pass per-package (`cd packages/svelte && vp test`)
-      # but the root aggregate run doesn't apply the package's `svelte()` Vite
-      # plugin, so .svelte SFC imports fail to transform. Excluded until the
-      # root test-aggregation config is sorted (PS-15 follow-up).
-      - run: vp test --run --exclude '**/packages/svelte/**'
-      # - run: vp run knip
+      # Per-package (dep order) so each package's own vite.config.ts applies —
+      # the root aggregate `vp test` drops per-package plugins (vite-plugin-solid,
+      # @sveltejs/vite-plugin-svelte) so solid renders SSR-only and svelte SFCs
+      # fail to transform. Recursive run fixes both; no exclusions needed.
+      - run: vp run -r test
+      # Non-blocking for now: knip surfaces dead deps/exports but still has
+      # per-workspace entry-config noise. Tracked as a follow-up to retune
+      # knip.json then drop continue-on-error.
+      - run: vp run knip
+        continue-on-error: true

--- a/.vite-hooks/pre-push
+++ b/.vite-hooks/pre-push
@@ -1,1 +1,5 @@
-vp run -r check-types
+# Build before type-checking: packages export from ./dist, so without a build
+# downstream check-types false-negatives after any core change (resolves
+# `@openpolicy/core/*` to stale/missing dist). Mirrors CI ordering.
+# Docs-only pushes can skip with `git push --no-verify`.
+vp run -r build && vp run -r check-types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,22 +31,29 @@ Run `vp help` for the full list and `vp <command> --help` for specifics.
 
 ## Project Structure
 
-- `apps/www` - A stub where the old OpenPolicy site was hosted. Now just redirects to the new site.
-- `packages/cli` - A CLI tool for installing and configuring PolicyStack.
-- `packages/core` - The core compilation engine for PolicyStack.
-- `packages/sdk` - The public API for defining privacy policies with PolicyStack.
-- `packages/vite` - A Vite plugin for integrating PolicyStack into your project.
-- `packages/react` - React components and hooks for PolicyStack.
-- `packages/svelte` - Svelte components and hooks for PolicyStack.
-- `packages/vue` - Vue components and hooks for PolicyStack.
-- `packages/astro` - Astro components and hooks for PolicyStack.
+Packages are still published under the `@openpolicy/*` scope (the `@policystack/*`
+rename is planned, not yet done).
 
-### Other Directories
+- `packages/core` — `@openpolicy/core`: compilation engine **and** the consent
+  runtime (exposed via the `./consent` subpath; OpenCookies was folded in here).
+- `packages/sdk` — `@openpolicy/sdk`: public API (`defineConfig()`), incl. the
+  `renderLlmsTxt()` generator.
+- `packages/cli` — `@openpolicy/cli`: install/configure CLI.
+- `packages/vite` — `@openpolicy/vite`: Vite plugin (`openPolicy()`); also hosts
+  the opt-in consent scanner.
+- `packages/react` / `vue` / `svelte` / `angular` / `solid` — per-framework
+  components & hooks; each splits `./policy` and `./consent` subpath exports
+  (React also has `./provider`). `solid` and `renderers` export from `./src`.
+- `packages/scripts` — `@openpolicy/scripts`: consent-gated third-party script
+  loaders.
+- `packages/renderers` — `@openpolicy/renderers`: shared policy render layer.
+- `tooling/tsconfig` — `@openpolicy/tooling`: shared TS base config (`./base`).
+- `apps/web` — the PolicyStack site (policystack.dev); dogfoods `@openpolicy/{react,sdk}`.
+- `apps/www` — stub redirecting the old OpenPolicy site.
+- `examples/tanstack` — example app (the sole SDK example).
 
-There are a few other directories that might be useful to know about when working on the project:
-
-- `opencookies` - The seperate project for consent management. As part of the 1.0.0 release, this will be merged into the main project.
-- `policystack` - The seperate project for the privacy policy website. As part of the 1.0.0 release, this will be merged into the main project.
+OpenCookies (consent) and the policystack site were separate projects; both are
+now merged in-repo (consent → `@openpolicy/core/consent`, site → `apps/web`).
 
 ## Important Notes
 
@@ -58,6 +65,11 @@ We're actively working on the 1.0.0 release.
 - **All PRs for 1.0 / PolicyStack work (any `PS-*` ticket) MUST target the `v1` branch, not `main`.** `v1` is well ahead of `main`; opening against `main` produces a wrong, bloated diff. Cut feature branches from `v1` and set the PR base to `v1` explicitly (the harness default of `main` is incorrect for this work).
 - **Name the feature branch with the Linear-provided branch name when one exists** — use the issue's `gitBranchName` (e.g. `ps-20`), available from the Linear MCP `get_issue`/`list_issues` `gitBranchName` field or "Copy git branch name" in Linear. Linear auto-links any PR whose head branch matches, so the ticket tracks the PR and its status with no manual linking. Still cut it from `v1` and target `v1`.
 - Breaking changes are allowed on the `v1` branch.
-- Failing tests are acceptable on the `v1` branch.
+- **`v1` must stay green.** CI now runs on every push to `v1` (not just PRs), and
+  the pipeline is `vp run -r build` → `vp check` → `vp run -r check-types` →
+  `vp run -r test` (knip runs non-blocking). Do not merge red. Run tests
+  per-package via `vp run -r test` — the root aggregate `vp test` drops
+  per-package Vite plugins. (This supersedes the former "failing tests are
+  acceptable on v1" stance.)
 - **Do not add changesets for 1.0 / PolicyStack work (any `PS-*` ticket).** The 1.0 release is versioned as a single event; per-feature changesets going into `v1` are noise. Do not create `.changeset/*.md` files for this work.
 - Projects and tickets are in the `PolicyStack 1.0` team in Linear.

--- a/apps/web/content/blog/astro-cookie-banner.mdx
+++ b/apps/web/content/blog/astro-cookie-banner.mdx
@@ -36,22 +36,22 @@ The categories are referenced from two places — the SSR template (to render th
 import type { Category } from "@opencookies/core";
 
 export const categories: Category[] = [
-  {
-    key: "essential",
-    label: "Essential",
-    locked: true,
-    description: "Required for the site to work.",
-  },
-  {
-    key: "analytics",
-    label: "Analytics",
-    description: "Helps us understand how the site is used.",
-  },
-  {
-    key: "marketing",
-    label: "Marketing",
-    description: "Used to personalize ads and campaigns.",
-  },
+	{
+		key: "essential",
+		label: "Essential",
+		locked: true,
+		description: "Required for the site to work.",
+	},
+	{
+		key: "analytics",
+		label: "Analytics",
+		description: "Helps us understand how the site is used.",
+	},
+	{
+		key: "marketing",
+		label: "Marketing",
+		description: "Used to personalize ads and campaigns.",
+	},
 ];
 ```
 
@@ -235,19 +235,21 @@ import { localStorageAdapter } from "@opencookies/core/storage/local-storage";
 import { categories } from "./cookie-categories";
 
 const store = createConsentStore({
-  categories,
-  adapter: localStorageAdapter(),
+	categories,
+	adapter: localStorageAdapter(),
 });
 
 const ga4 = defineScript({
-  id: "ga4",
-  requires: "analytics",
-  src: "https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX",
-  queue: ["dataLayer.push"],
-  init: () => {
-    window.dataLayer = window.dataLayer || [];
-    window.gtag = function gtag() { window.dataLayer.push(arguments); };
-  },
+	id: "ga4",
+	requires: "analytics",
+	src: "https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX",
+	queue: ["dataLayer.push"],
+	init: () => {
+		window.dataLayer = window.dataLayer || [];
+		window.gtag = function gtag() {
+			window.dataLayer.push(arguments);
+		};
+	},
 });
 
 gateScript(store, ga4);
@@ -272,12 +274,9 @@ import { openCookies } from "@opencookies/vite";
 import { categories } from "./src/lib/cookie-categories";
 
 export default defineConfig({
-  vite: {
-    plugins: [
-      openCookies({ config: { categories } }),
-      tailwindcss(),
-    ],
-  },
+	vite: {
+		plugins: [openCookies({ config: { categories } }), tailwindcss()],
+	},
 });
 ```
 

--- a/apps/web/content/blog/expo-privacy-policy.mdx
+++ b/apps/web/content/blog/expo-privacy-policy.mdx
@@ -33,44 +33,44 @@ The whole policy is one file at the project root. Here's the example app's [`ope
 
 ```ts file="openpolicy.ts"
 import {
-  Compliance,
-  defineConfig,
-  LegalBases,
-  Providers,
-  Retention,
-  Voluntary,
+	Compliance,
+	defineConfig,
+	LegalBases,
+	Providers,
+	Retention,
+	Voluntary,
 } from "@openpolicy/sdk";
 
 export default defineConfig({
-  company: {
-    name: "Expo Example",
-    legalName: "Expo Example, Inc.",
-    address: "1 Example Way, San Francisco, CA 94107, USA",
-    contact: { email: "privacy@example.com" },
-  },
-  effectiveDate: "2026-05-07",
-  jurisdictions: Compliance.GDPR.jurisdictions,
-  data: {
-    collected: {
-      "Account Information": ["Name", "Email address"],
-      "Usage Data": ["Pages visited", "Features used"],
-    },
-    context: {
-      "Account Information": {
-        purpose: "Create and manage your account.",
-        lawfulBasis: LegalBases.Contract,
-        retention: Retention.UntilAccountDeletion,
-        provision: Voluntary("You can use the app without an account."),
-      },
-      "Usage Data": {
-        purpose: "Understand how the app is used and improve it.",
-        lawfulBasis: LegalBases.LegitimateInterests,
-        retention: Retention.NinetyDays,
-        provision: Voluntary("You can opt out of analytics in app settings."),
-      },
-    },
-  },
-  thirdParties: [Providers.Sentry],
+	company: {
+		name: "Expo Example",
+		legalName: "Expo Example, Inc.",
+		address: "1 Example Way, San Francisco, CA 94107, USA",
+		contact: { email: "privacy@example.com" },
+	},
+	effectiveDate: "2026-05-07",
+	jurisdictions: Compliance.GDPR.jurisdictions,
+	data: {
+		collected: {
+			"Account Information": ["Name", "Email address"],
+			"Usage Data": ["Pages visited", "Features used"],
+		},
+		context: {
+			"Account Information": {
+				purpose: "Create and manage your account.",
+				lawfulBasis: LegalBases.Contract,
+				retention: Retention.UntilAccountDeletion,
+				provision: Voluntary("You can use the app without an account."),
+			},
+			"Usage Data": {
+				purpose: "Understand how the app is used and improve it.",
+				lawfulBasis: LegalBases.LegitimateInterests,
+				retention: Retention.NinetyDays,
+				provision: Voluntary("You can opt out of analytics in app settings."),
+			},
+		},
+	},
+	thirdParties: [Providers.Sentry],
 });
 ```
 
@@ -93,37 +93,42 @@ import { Linking, StyleSheet, Text, View } from "react-native";
 import type { PolicyComponents } from "@openpolicy/react";
 
 const HEADING_SIZES: Record<1 | 2 | 3 | 4 | 5 | 6, number> = {
-  1: 28, 2: 22, 3: 18, 4: 16, 5: 15, 6: 14,
+	1: 28,
+	2: 22,
+	3: 18,
+	4: 16,
+	5: 15,
+	6: 14,
 };
 
 const policyComponents: PolicyComponents = {
-  Root: ({ children }) => <View>{children}</View>,
-  Section: ({ children }) => <View style={styles.section}>{children}</View>,
-  Heading: ({ node }) => {
-    const level = (node.level ?? 2) as 1 | 2 | 3 | 4 | 5 | 6;
-    return (
-      <Text
-        style={[
-          styles.heading,
-          { fontSize: HEADING_SIZES[level], marginTop: level <= 2 ? 20 : 14 },
-        ]}
-      >
-        {node.value}
-      </Text>
-    );
-  },
-  Paragraph: ({ children }) => <Text style={styles.paragraph}>{children}</Text>,
-  // ...List, ListItem, Table, TableRow, TableCell, Bold, Italic, Text...
-  Link: ({ node }) => (
-    <Text
-      style={styles.link}
-      onPress={() => {
-        Linking.openURL(node.href).catch(() => {});
-      }}
-    >
-      {node.value}
-    </Text>
-  ),
+	Root: ({ children }) => <View>{children}</View>,
+	Section: ({ children }) => <View style={styles.section}>{children}</View>,
+	Heading: ({ node }) => {
+		const level = (node.level ?? 2) as 1 | 2 | 3 | 4 | 5 | 6;
+		return (
+			<Text
+				style={[
+					styles.heading,
+					{ fontSize: HEADING_SIZES[level], marginTop: level <= 2 ? 20 : 14 },
+				]}
+			>
+				{node.value}
+			</Text>
+		);
+	},
+	Paragraph: ({ children }) => <Text style={styles.paragraph}>{children}</Text>,
+	// ...List, ListItem, Table, TableRow, TableCell, Bold, Italic, Text...
+	Link: ({ node }) => (
+		<Text
+			style={styles.link}
+			onPress={() => {
+				Linking.openURL(node.href).catch(() => {});
+			}}
+		>
+			{node.value}
+		</Text>
+	),
 };
 ```
 
@@ -148,16 +153,16 @@ import openpolicy from "../openpolicy";
 import policyComponents from "../components/PolicyComponents";
 
 export default function PrivacyPolicyScreen() {
-  return (
-    <SafeAreaView style={styles.safe}>
-      <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.title}>Privacy Policy</Text>
-        <OpenPolicy config={openpolicy}>
-          <PrivacyPolicy components={policyComponents} />
-        </OpenPolicy>
-      </ScrollView>
-    </SafeAreaView>
-  );
+	return (
+		<SafeAreaView style={styles.safe}>
+			<ScrollView contentContainerStyle={styles.content}>
+				<Text style={styles.title}>Privacy Policy</Text>
+				<OpenPolicy config={openpolicy}>
+					<PrivacyPolicy components={policyComponents} />
+				</OpenPolicy>
+			</ScrollView>
+		</SafeAreaView>
+	);
 }
 ```
 
@@ -170,12 +175,12 @@ import { StatusBar } from "expo-status-bar";
 import PrivacyPolicyScreen from "./screens/PrivacyPolicyScreen";
 
 export default function App() {
-  return (
-    <>
-      <PrivacyPolicyScreen />
-      <StatusBar style="auto" />
-    </>
-  );
+	return (
+		<>
+			<PrivacyPolicyScreen />
+			<StatusBar style="auto" />
+		</>
+	);
 }
 ```
 

--- a/apps/web/content/blog/openpolicy-v0-0-34-i18n.mdx
+++ b/apps/web/content/blog/openpolicy-v0-0-34-i18n.mdx
@@ -30,11 +30,13 @@ Either set `locale` once on the config and every render uses it:
 import { defineConfig } from "@openpolicy/sdk";
 
 export default defineConfig({
-  company: { name: "Acme, Inc." },
-  effectiveDate: "2026-01-01",
-  jurisdictions: ["eu", "fr"],
-  locale: "fr",
-  data: { /* ... */ },
+	company: { name: "Acme, Inc." },
+	effectiveDate: "2026-01-01",
+	jurisdictions: ["eu", "fr"],
+	locale: "fr",
+	data: {
+		/* ... */
+	},
 });
 ```
 
@@ -45,12 +47,12 @@ import { OpenPolicy, PrivacyPolicy } from "@openpolicy/react";
 import openpolicy from "@/openpolicy";
 
 export function PrivacyPolicyPage() {
-  return (
-    <OpenPolicy config={openpolicy}>
-      <PrivacyPolicy />              {/* uses config.locale */}
-      <PrivacyPolicy locale="fr" />  {/* override → French */}
-    </OpenPolicy>
-  );
+	return (
+		<OpenPolicy config={openpolicy}>
+			<PrivacyPolicy /> {/* uses config.locale */}
+			<PrivacyPolicy locale="fr" /> {/* override → French */}
+		</OpenPolicy>
+	);
 }
 ```
 

--- a/apps/web/content/blog/remix-day-one.mdx
+++ b/apps/web/content/blog/remix-day-one.mdx
@@ -34,52 +34,47 @@ pnpm add @opencookies/core @openpolicy/core @openpolicy/sdk
 The point of doing this once on day one is that the privacy policy, the cookie policy, and the banner's categories all come from the same source. Put it under `app/data/`:
 
 ```ts file="app/data/openpolicy.ts"
-import {
-  ContractPrerequisite,
-  LegalBases,
-  Voluntary,
-  defineConfig,
-} from '@openpolicy/sdk'
+import { ContractPrerequisite, LegalBases, Voluntary, defineConfig } from "@openpolicy/sdk";
 
 export const policy = defineConfig({
-  company: {
-    name: 'Acme',
-    legalName: 'Acme Ltd',
-    address: '1 Demo Lane, London, UK',
-    contact: { email: 'privacy@acme.com' },
-  },
-  effectiveDate: '2026-05-12',
-  jurisdictions: ['eu', 'uk'],
-  data: {
-    collected: {
-      'Account Information': ['Name', 'Email address'],
-      'Usage Data': ['Pages visited', 'IP address'],
-    },
-    context: {
-      'Account Information': {
-        purpose: 'To authenticate users and send service notifications.',
-        lawfulBasis: LegalBases.Contract,
-        retention: 'Until account deletion',
-        provision: ContractPrerequisite('We cannot operate your account.'),
-      },
-      'Usage Data': {
-        purpose: 'To understand product usage and improve the service.',
-        lawfulBasis: LegalBases.LegitimateInterests,
-        retention: '90 days',
-        provision: Voluntary('None — your service is unaffected.'),
-      },
-    },
-  },
-  thirdParties: [],
-  cookies: {
-    used: { essential: true, analytics: true, marketing: false },
-    context: {
-      essential: { lawfulBasis: LegalBases.LegalObligation },
-      analytics: { lawfulBasis: LegalBases.Consent },
-      marketing: { lawfulBasis: LegalBases.Consent },
-    },
-  },
-})
+	company: {
+		name: "Acme",
+		legalName: "Acme Ltd",
+		address: "1 Demo Lane, London, UK",
+		contact: { email: "privacy@acme.com" },
+	},
+	effectiveDate: "2026-05-12",
+	jurisdictions: ["eu", "uk"],
+	data: {
+		collected: {
+			"Account Information": ["Name", "Email address"],
+			"Usage Data": ["Pages visited", "IP address"],
+		},
+		context: {
+			"Account Information": {
+				purpose: "To authenticate users and send service notifications.",
+				lawfulBasis: LegalBases.Contract,
+				retention: "Until account deletion",
+				provision: ContractPrerequisite("We cannot operate your account."),
+			},
+			"Usage Data": {
+				purpose: "To understand product usage and improve the service.",
+				lawfulBasis: LegalBases.LegitimateInterests,
+				retention: "90 days",
+				provision: Voluntary("None — your service is unaffected."),
+			},
+		},
+	},
+	thirdParties: [],
+	cookies: {
+		used: { essential: true, analytics: true, marketing: false },
+		context: {
+			essential: { lawfulBasis: LegalBases.LegalObligation },
+			analytics: { lawfulBasis: LegalBases.Consent },
+			marketing: { lawfulBasis: LegalBases.Consent },
+		},
+	},
+});
 ```
 
 This is the only file you edit when something changes. Add an SDK that drops a third-party cookie? It goes in `thirdParties`. Change retention on usage data? You change one line. The banner's category list and both policy documents update from the same config.
@@ -89,28 +84,28 @@ This is the only file you edit when something changes. Add an SDK that drops a t
 `@openpolicy/core` exposes two compiler functions — `compilePrivacyPolicy` and `compileCookiePolicy` — that produce a Document AST. Compile once at module load, then hand the result to a server component that walks the tree:
 
 ```tsx file="app/controllers/privacy.tsx"
-import { compilePrivacyPolicy } from '@openpolicy/core'
-import type { BuildAction } from 'remix/fetch-router'
+import { compilePrivacyPolicy } from "@openpolicy/core";
+import type { BuildAction } from "remix/fetch-router";
 
-import { policy } from '../data/openpolicy.ts'
-import type { routes } from '../routes.ts'
-import { Layout } from '../ui/layout.tsx'
-import { PolicyDocument } from '../ui/policy-document.tsx'
-import { render } from '../utils/render.tsx'
+import { policy } from "../data/openpolicy.ts";
+import type { routes } from "../routes.ts";
+import { Layout } from "../ui/layout.tsx";
+import { PolicyDocument } from "../ui/policy-document.tsx";
+import { render } from "../utils/render.tsx";
 
-const privacyDoc = compilePrivacyPolicy(policy)
-if (!privacyDoc) throw new Error('No privacy policy configured')
+const privacyDoc = compilePrivacyPolicy(policy);
+if (!privacyDoc) throw new Error("No privacy policy configured");
 
-export const privacy: BuildAction<'GET', typeof routes.privacy> = {
-  handler({ request }) {
-    return render(
-      <Layout title="Privacy Policy">
-        <PolicyDocument doc={privacyDoc} />
-      </Layout>,
-      request,
-    )
-  },
-}
+export const privacy: BuildAction<"GET", typeof routes.privacy> = {
+	handler({ request }) {
+		return render(
+			<Layout title="Privacy Policy">
+				<PolicyDocument doc={privacyDoc} />
+			</Layout>,
+			request,
+		);
+	},
+};
 ```
 
 The cookie policy is the same controller with `compileCookiePolicy` instead. Both run server-only — no `clientEntry`, no hydration, no client JS for the document content.
@@ -118,47 +113,45 @@ The cookie policy is the same controller with `compileCookiePolicy` instead. Bot
 `PolicyDocument` is the framework-specific bit. Because the AST is plain data (`Document → DocumentSection → ContentNode → InlineNode`), the walker is short and reads like a stand-alone HTML transformer:
 
 ```tsx file="app/ui/policy-document.tsx"
-import type {
-  ContentNode,
-  Document,
-  InlineNode,
-  ListNode,
-  TableNode,
-} from '@openpolicy/core'
-import { css, type Handle, type RemixNode } from 'remix/ui'
+import type { ContentNode, Document, InlineNode, ListNode, TableNode } from "@openpolicy/core";
+import { css, type Handle, type RemixNode } from "remix/ui";
 
 export function PolicyDocument(handle: Handle<{ doc: Document }>) {
-  return () => (
-    <article mix={css({ maxWidth: '42rem', margin: '2rem auto', lineHeight: 1.6 })}>
-      {handle.props.doc.sections.map((section) => (
-        <section id={section.id}>{section.content.map(renderContent)}</section>
-      ))}
-    </article>
-  )
+	return () => (
+		<article mix={css({ maxWidth: "42rem", margin: "2rem auto", lineHeight: 1.6 })}>
+			{handle.props.doc.sections.map((section) => (
+				<section id={section.id}>{section.content.map(renderContent)}</section>
+			))}
+		</article>
+	);
 }
 
 function renderContent(node: ContentNode): RemixNode {
-  switch (node.type) {
-    case 'heading': {
-      const Tag = `h${node.level ?? 2}` as 'h1' | 'h2' | 'h3'
-      return <Tag>{node.value}</Tag>
-    }
-    case 'paragraph':
-      return <p>{node.children.map(renderInline)}</p>
-    case 'list':
-      return renderList(node)
-    case 'table':
-      return renderTable(node)
-  }
+	switch (node.type) {
+		case "heading": {
+			const Tag = `h${node.level ?? 2}` as "h1" | "h2" | "h3";
+			return <Tag>{node.value}</Tag>;
+		}
+		case "paragraph":
+			return <p>{node.children.map(renderInline)}</p>;
+		case "list":
+			return renderList(node);
+		case "table":
+			return renderTable(node);
+	}
 }
 
 function renderInline(node: InlineNode): RemixNode {
-  switch (node.type) {
-    case 'text':    return node.value
-    case 'bold':    return <strong>{node.value}</strong>
-    case 'italic':  return <em>{node.value}</em>
-    case 'link':    return <a href={node.href}>{node.value}</a>
-  }
+	switch (node.type) {
+		case "text":
+			return node.value;
+		case "bold":
+			return <strong>{node.value}</strong>;
+		case "italic":
+			return <em>{node.value}</em>;
+		case "link":
+			return <a href={node.href}>{node.value}</a>;
+	}
 }
 ```
 
@@ -171,50 +164,49 @@ What you get is a privacy policy and a cookie policy that render with zero clien
 The banner is the one piece that has to run on the client — visitor clicks "Accept all," the store updates, the banner re-renders, and on the next page load the analytics SDKs are allowed to load. In Remix 3 that's a single `clientEntry` module that wraps an `@opencookies/core` store:
 
 ```tsx file="app/ui/cookie-banner.tsx"
-import {
-  createConsentStore,
-  timezoneResolver,
-  type ConsentStore,
-} from '@opencookies/core'
-import { localStorageAdapter } from '@opencookies/core/storage/local-storage'
-import { toOpenCookiesConfig } from '@openpolicy/sdk/opencookies'
-import { clientEntry, css, on, type Handle } from 'remix/ui'
+import { createConsentStore, timezoneResolver, type ConsentStore } from "@opencookies/core";
+import { localStorageAdapter } from "@opencookies/core/storage/local-storage";
+import { toOpenCookiesConfig } from "@openpolicy/sdk/opencookies";
+import { clientEntry, css, on, type Handle } from "remix/ui";
 
-import { policy } from '../data/openpolicy.ts'
+import { policy } from "../data/openpolicy.ts";
 
 const consentConfig = toOpenCookiesConfig(policy, {
-  jurisdictionResolver: timezoneResolver(),
-})
+	jurisdictionResolver: timezoneResolver(),
+});
 
-export const CookieBanner = clientEntry(
-  import.meta.url,
-  function CookieBanner(handle: Handle) {
-    let store: ConsentStore | null = null
+export const CookieBanner = clientEntry(import.meta.url, function CookieBanner(handle: Handle) {
+	let store: ConsentStore | null = null;
 
-    if (typeof window !== 'undefined') {
-      store = createConsentStore({ ...consentConfig, adapter: localStorageAdapter() })
-      let unsubscribe = store.subscribe(() => handle.update())
-      handle.signal.addEventListener('abort', unsubscribe)
-    }
+	if (typeof window !== "undefined") {
+		store = createConsentStore({ ...consentConfig, adapter: localStorageAdapter() });
+		let unsubscribe = store.subscribe(() => handle.update());
+		handle.signal.addEventListener("abort", unsubscribe);
+	}
 
-    return () => {
-      let route = store?.getState().route
-      if (route !== 'cookie') return <div data-cookie-banner hidden />
-      return (
-        <div role="dialog" aria-label="Cookie consent" mix={css({ /* ... */ })}>
-          <p>We use cookies to improve your experience.</p>
-          <button mix={on('click', () => store?.acceptAll())}>Accept all</button>
-          <button mix={on('click', () => store?.acceptNecessary())}>Necessary only</button>
-        </div>
-      )
-    }
-  },
-)
+	return () => {
+		let route = store?.getState().route;
+		if (route !== "cookie") return <div data-cookie-banner hidden />;
+		return (
+			<div
+				role="dialog"
+				aria-label="Cookie consent"
+				mix={css({
+					/* ... */
+				})}
+			>
+				<p>We use cookies to improve your experience.</p>
+				<button mix={on("click", () => store?.acceptAll())}>Accept all</button>
+				<button mix={on("click", () => store?.acceptNecessary())}>Necessary only</button>
+			</div>
+		);
+	};
+});
 ```
 
 Three things worth pointing at:
 
-- **`toOpenCookiesConfig(policy)`** derives the consent categories — `essential`, `analytics`, `marketing` — directly from the OpenPolicy config. The cookie policy's category list and the banner's category list cannot drift apart, because they're computed from the same source. A `marketing: true` flip in `app/data/openpolicy.ts` adds the marketing checkbox to the banner *and* the marketing disclosure to the cookie policy on the same deploy.
+- **`toOpenCookiesConfig(policy)`** derives the consent categories — `essential`, `analytics`, `marketing` — directly from the OpenPolicy config. The cookie policy's category list and the banner's category list cannot drift apart, because they're computed from the same source. A `marketing: true` flip in `app/data/openpolicy.ts` adds the marketing checkbox to the banner _and_ the marketing disclosure to the cookie policy on the same deploy.
 - **`handle.update()`** is Remix 3's "tell the framework to re-render this entry." We pass it to the store's `subscribe` callback so the banner re-renders on every state change. `handle.signal` is an `AbortSignal` for the lifetime of the entry — we register the `unsubscribe` against it, so when the framework tears the banner down (navigation, replacement, server hand-off), the subscription goes with it. No leaks, no manual lifecycle.
 - **The `typeof window` guard** is the Remix 3-shaped equivalent of "only touch localStorage in the browser." `clientEntry` modules also run on the server during the initial render so the framework knows what to ship; the store gets constructed only when `window` exists.
 
@@ -223,19 +215,19 @@ Three things worth pointing at:
 The banner sits in the shared layout, so every page gets it:
 
 ```tsx file="app/ui/layout.tsx"
-import type { RemixNode } from 'remix/ui'
+import type { RemixNode } from "remix/ui";
 
-import { CookieBanner } from './cookie-banner.tsx'
-import { Document } from './document.tsx'
+import { CookieBanner } from "./cookie-banner.tsx";
+import { Document } from "./document.tsx";
 
 export function Layout() {
-  return ({ title, children }: { title?: string; children?: RemixNode }) => (
-    <Document title={title}>
-      <header>{/* nav */}</header>
-      <main>{children}</main>
-      <CookieBanner />
-    </Document>
-  )
+	return ({ title, children }: { title?: string; children?: RemixNode }) => (
+		<Document title={title}>
+			<header>{/* nav */}</header>
+			<main>{children}</main>
+			<CookieBanner />
+		</Document>
+	);
 }
 ```
 
@@ -246,18 +238,18 @@ That's it. The banner is one entry, hydrated independently. The policy pages sta
 Remix 3's asset server has a deliberate allow-list for what files the browser can load. In a consent-aware app, that's not just hygiene — it's a useful enforcement boundary:
 
 ```ts file="app/assets.ts"
-import { createAssetServer } from 'remix/assets'
+import { createAssetServer } from "remix/assets";
 
 export const assets = createAssetServer({
-  basePath: '/assets',
-  rootDir: process.cwd(),
-  fileMap: {
-    'app/*path': 'app/*path',
-    'node_modules/*path': 'node_modules/*path',
-  },
-  allow: ['app/assets/**', 'app/data/**', 'app/ui/cookie-banner.tsx', 'node_modules/**'],
-  deny: ['app/**/*.server.*'],
-})
+	basePath: "/assets",
+	rootDir: process.cwd(),
+	fileMap: {
+		"app/*path": "app/*path",
+		"node_modules/*path": "node_modules/*path",
+	},
+	allow: ["app/assets/**", "app/data/**", "app/ui/cookie-banner.tsx", "node_modules/**"],
+	deny: ["app/**/*.server.*"],
+});
 ```
 
 `app/ui/cookie-banner.tsx` is explicitly allow-listed because it's the only UI module a client needs to load. Add an analytics SDK wrapper? You add it to `allow` consciously, with a PR that reviews against the consent config. Forget? It 404s in dev. Compared to the React-meta-framework default of "the bundler ships whatever you import," this is a real constraint on what can fire without consent.

--- a/apps/web/content/blog/tanstack-cookie-banner.mdx
+++ b/apps/web/content/blog/tanstack-cookie-banner.mdx
@@ -63,21 +63,21 @@ import type { Category } from "@opencookies/core";
 import { Outlet, createRootRoute } from "@tanstack/react-router";
 
 const categories: Category[] = [
-  { key: "essential", label: "Essential", locked: true },
-  { key: "analytics", label: "Analytics" },
-  { key: "marketing", label: "Marketing" },
+	{ key: "essential", label: "Essential", locked: true },
+	{ key: "analytics", label: "Analytics" },
+	{ key: "marketing", label: "Marketing" },
 ];
 
 export const Route = createRootRoute({
-  component: RootComponent,
+	component: RootComponent,
 });
 
 function RootComponent() {
-  return (
-    <OpenCookiesProvider config={{ categories }}>
-      <Outlet />
-    </OpenCookiesProvider>
-  );
+	return (
+		<OpenCookiesProvider config={{ categories }}>
+			<Outlet />
+		</OpenCookiesProvider>
+	);
 }
 ```
 
@@ -92,13 +92,13 @@ import { createConsentStore, timezoneResolver } from "@opencookies/core";
 import { localStorageAdapter } from "@opencookies/core/storage/local-storage";
 
 export const store = createConsentStore({
-  categories: [
-    { key: "essential", label: "Essential", locked: true },
-    { key: "analytics", label: "Analytics" },
-    { key: "marketing", label: "Marketing" },
-  ],
-  adapter: localStorageAdapter(),
-  jurisdictionResolver: timezoneResolver(),
+	categories: [
+		{ key: "essential", label: "Essential", locked: true },
+		{ key: "analytics", label: "Analytics" },
+		{ key: "marketing", label: "Marketing" },
+	],
+	adapter: localStorageAdapter(),
+	jurisdictionResolver: timezoneResolver(),
 });
 ```
 
@@ -110,8 +110,8 @@ import { store } from "@/lib/consent-store";
 
 // ...
 <OpenCookiesProvider store={store}>
-  <Outlet />
-</OpenCookiesProvider>
+	<Outlet />
+</OpenCookiesProvider>;
 ```
 
 **Storage adapters** decide where the consent record gets written and how it survives a refresh. Three ship in the box:
@@ -139,28 +139,28 @@ Why this matters: GDPR demands opt-in (categories default to denied, banner show
 import { useConsent } from "@opencookies/react";
 
 export function CookieBanner() {
-  const { route, acceptAll, acceptNecessary, setRoute } = useConsent();
-  if (route !== "cookie") return null;
+	const { route, acceptAll, acceptNecessary, setRoute } = useConsent();
+	if (route !== "cookie") return null;
 
-  return (
-    <div className="fixed inset-x-4 bottom-4 rounded-2xl border border-line bg-bg p-5 shadow-lg sm:inset-x-auto sm:right-4 sm:max-w-sm">
-      <p className="text-sm text-mute">
-        We use cookies to keep the app running and, with your permission, to
-        understand how it's used. You can change this any time in settings.
-      </p>
-      <div className="mt-4 flex gap-2">
-        <button onClick={acceptNecessary} className="btn btn-ghost flex-1">
-          Necessary only
-        </button>
-        <button onClick={() => setRoute("preferences")} className="btn btn-ghost flex-1">
-          Customize
-        </button>
-        <button onClick={acceptAll} className="btn btn-primary flex-1">
-          Accept all
-        </button>
-      </div>
-    </div>
-  );
+	return (
+		<div className="fixed inset-x-4 bottom-4 rounded-2xl border border-line bg-bg p-5 shadow-lg sm:inset-x-auto sm:right-4 sm:max-w-sm">
+			<p className="text-sm text-mute">
+				We use cookies to keep the app running and, with your permission, to understand how it's
+				used. You can change this any time in settings.
+			</p>
+			<div className="mt-4 flex gap-2">
+				<button onClick={acceptNecessary} className="btn btn-ghost flex-1">
+					Necessary only
+				</button>
+				<button onClick={() => setRoute("preferences")} className="btn btn-ghost flex-1">
+					Customize
+				</button>
+				<button onClick={acceptAll} className="btn btn-primary flex-1">
+					Accept all
+				</button>
+			</div>
+		</div>
+	);
 }
 ```
 
@@ -172,32 +172,36 @@ The preferences panel is a second component reading `useCategory(key)` for each 
 import { useConsent, useCategory } from "@opencookies/react";
 
 function Toggle({ k, label }: { k: "analytics" | "marketing"; label: string }) {
-  const { granted, toggle } = useCategory(k);
-  return (
-    <label className="flex items-center justify-between py-3">
-      <span>{label}</span>
-      <input type="checkbox" checked={granted} onChange={toggle} />
-    </label>
-  );
+	const { granted, toggle } = useCategory(k);
+	return (
+		<label className="flex items-center justify-between py-3">
+			<span>{label}</span>
+			<input type="checkbox" checked={granted} onChange={toggle} />
+		</label>
+	);
 }
 
 export function CookiePreferences() {
-  const { route, save, setRoute } = useConsent();
-  if (route !== "preferences") return null;
+	const { route, save, setRoute } = useConsent();
+	if (route !== "preferences") return null;
 
-  return (
-    <div className="fixed inset-0 grid place-items-center bg-bg/70 p-4">
-      <div className="w-full max-w-md rounded-2xl border border-line bg-bg p-6">
-        <h2 className="text-lg font-medium">Cookie preferences</h2>
-        <Toggle k="analytics" label="Analytics" />
-        <Toggle k="marketing" label="Marketing" />
-        <div className="mt-4 flex justify-end gap-2">
-          <button onClick={() => setRoute("cookie")} className="btn btn-ghost">Back</button>
-          <button onClick={save} className="btn btn-primary">Save</button>
-        </div>
-      </div>
-    </div>
-  );
+	return (
+		<div className="fixed inset-0 grid place-items-center bg-bg/70 p-4">
+			<div className="w-full max-w-md rounded-2xl border border-line bg-bg p-6">
+				<h2 className="text-lg font-medium">Cookie preferences</h2>
+				<Toggle k="analytics" label="Analytics" />
+				<Toggle k="marketing" label="Marketing" />
+				<div className="mt-4 flex justify-end gap-2">
+					<button onClick={() => setRoute("cookie")} className="btn btn-ghost">
+						Back
+					</button>
+					<button onClick={save} className="btn btn-primary">
+						Save
+					</button>
+				</div>
+			</div>
+		</div>
+	);
 }
 ```
 
@@ -211,15 +215,15 @@ For inline UI that depends on consent — an analytics chart, a personalised pro
 import { ConsentGate } from "@opencookies/react";
 
 function EnableAnalyticsPrompt() {
-  return <p className="text-sm text-mute">Enable analytics to see this chart.</p>;
+	return <p className="text-sm text-mute">Enable analytics to see this chart.</p>;
 }
 
 export function Dashboard() {
-  return (
-    <ConsentGate requires="analytics" fallback={<EnableAnalyticsPrompt />}>
-      <UsageChart />
-    </ConsentGate>
-  );
+	return (
+		<ConsentGate requires="analytics" fallback={<EnableAnalyticsPrompt />}>
+			<UsageChart />
+		</ConsentGate>
+	);
 }
 ```
 
@@ -234,16 +238,16 @@ import { defineScript, gateScript } from "@opencookies/core";
 import { store } from "@/lib/consent-store";
 
 const ga4 = defineScript({
-  id: "ga4",
-  requires: "analytics",
-  src: "https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX",
-  queue: ["dataLayer.push"],
-  init: () => {
-    window.dataLayer = window.dataLayer || [];
-    window.gtag = function gtag() {
-      window.dataLayer.push(arguments);
-    };
-  },
+	id: "ga4",
+	requires: "analytics",
+	src: "https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX",
+	queue: ["dataLayer.push"],
+	init: () => {
+		window.dataLayer = window.dataLayer || [];
+		window.gtag = function gtag() {
+			window.dataLayer.push(arguments);
+		};
+	},
 });
 
 gateScript(store, ga4);
@@ -273,20 +277,20 @@ import { defineConfig } from "vite";
 import tsConfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [
-    tsConfigPaths(),
-    openCookies({
-      config: {
-        categories: [
-          { key: "essential", label: "Essential", locked: true },
-          { key: "analytics", label: "Analytics" },
-          { key: "marketing", label: "Marketing" },
-        ],
-      },
-    }),
-    tanstackStart(),
-    viteReact(),
-  ],
+	plugins: [
+		tsConfigPaths(),
+		openCookies({
+			config: {
+				categories: [
+					{ key: "essential", label: "Essential", locked: true },
+					{ key: "analytics", label: "Analytics" },
+					{ key: "marketing", label: "Marketing" },
+				],
+			},
+		}),
+		tanstackStart(),
+		viteReact(),
+	],
 });
 ```
 

--- a/apps/web/content/blog/tanstack-privacy-policy.mdx
+++ b/apps/web/content/blog/tanstack-privacy-policy.mdx
@@ -42,12 +42,12 @@ import { defineConfig } from "vite";
 import tsConfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [
-    tsConfigPaths(),
-    openPolicy({ srcDir: "./src", thirdParties: { usePackageJson: true } }),
-    tanstackStart(),
-    viteReact(),
-  ],
+	plugins: [
+		tsConfigPaths(),
+		openPolicy({ srcDir: "./src", thirdParties: { usePackageJson: true } }),
+		tanstackStart(),
+		viteReact(),
+	],
 });
 ```
 
@@ -59,60 +59,60 @@ The config is a single `defineConfig()` call. The latest format leans on a handf
 
 ```ts file="openpolicy.ts"
 import {
-  ContractPrerequisite,
-  cookies,
-  dataCollected,
-  defineConfig,
-  LegalBases,
-  thirdParties,
+	ContractPrerequisite,
+	cookies,
+	dataCollected,
+	defineConfig,
+	LegalBases,
+	thirdParties,
 } from "@openpolicy/sdk";
 
 export default defineConfig({
-  company: {
-    name: "Acme Inc.",
-    legalName: "Acme Corporation",
-    address: "123 Main St, Springfield, USA",
-    contact: { email: "privacy@acme.com" },
-  },
-  effectiveDate: "2026-05-04",
-  jurisdictions: ["eu", "us-ca"],
-  data: {
-    collected: {
-      ...dataCollected,
-      "Usage Data": ["Pages visited", "Browser type", "IP address"],
-    },
-    context: {
-      "Account Information": {
-        purpose: "To authenticate users and send service notifications",
-        lawfulBasis: LegalBases.Contract,
-        retention: "Until account deletion",
-        provision: ContractPrerequisite("We cannot create or operate your account."),
-      },
-      "Usage Data": {
-        purpose: "To understand product usage and improve the service",
-        lawfulBasis: LegalBases.LegitimateInterests,
-        retention: "90 days",
-        provision: ContractPrerequisite("We cannot deliver or secure the service."),
-      },
-    },
-  },
-  cookies: {
-    used: cookies,
-    context: {
-      essential: { lawfulBasis: LegalBases.LegalObligation },
-      analytics: { lawfulBasis: LegalBases.Consent },
-      marketing: { lawfulBasis: LegalBases.Consent },
-    },
-  },
-  thirdParties,
-  trackingTechnologies: ["web beacons", "local storage"],
-  consentMechanism: {
-    hasBanner: true,
-    hasPreferencePanel: true,
-    canWithdraw: true,
-  },
-  children: { underAge: 16, noticeUrl: "https://acme.com/parental-notice" },
-  automatedDecisionMaking: [],
+	company: {
+		name: "Acme Inc.",
+		legalName: "Acme Corporation",
+		address: "123 Main St, Springfield, USA",
+		contact: { email: "privacy@acme.com" },
+	},
+	effectiveDate: "2026-05-04",
+	jurisdictions: ["eu", "us-ca"],
+	data: {
+		collected: {
+			...dataCollected,
+			"Usage Data": ["Pages visited", "Browser type", "IP address"],
+		},
+		context: {
+			"Account Information": {
+				purpose: "To authenticate users and send service notifications",
+				lawfulBasis: LegalBases.Contract,
+				retention: "Until account deletion",
+				provision: ContractPrerequisite("We cannot create or operate your account."),
+			},
+			"Usage Data": {
+				purpose: "To understand product usage and improve the service",
+				lawfulBasis: LegalBases.LegitimateInterests,
+				retention: "90 days",
+				provision: ContractPrerequisite("We cannot deliver or secure the service."),
+			},
+		},
+	},
+	cookies: {
+		used: cookies,
+		context: {
+			essential: { lawfulBasis: LegalBases.LegalObligation },
+			analytics: { lawfulBasis: LegalBases.Consent },
+			marketing: { lawfulBasis: LegalBases.Consent },
+		},
+	},
+	thirdParties,
+	trackingTechnologies: ["web beacons", "local storage"],
+	consentMechanism: {
+		hasBanner: true,
+		hasPreferencePanel: true,
+		canWithdraw: true,
+	},
+	children: { underAge: 16, noticeUrl: "https://acme.com/parental-notice" },
+	automatedDecisionMaking: [],
 });
 ```
 
@@ -130,15 +130,15 @@ import { OpenPolicy, PrivacyPolicy } from "@openpolicy/react";
 import openpolicy from "@/openpolicy";
 
 export const Route = createFileRoute("/privacy")({
-  component: PrivacyPolicyPage,
+	component: PrivacyPolicyPage,
 });
 
 function PrivacyPolicyPage() {
-  return (
-    <OpenPolicy config={openpolicy}>
-      <PrivacyPolicy />
-    </OpenPolicy>
-  );
+	return (
+		<OpenPolicy config={openpolicy}>
+			<PrivacyPolicy />
+		</OpenPolicy>
+	);
 }
 ```
 
@@ -154,37 +154,31 @@ import { OpenPolicy, PrivacyPolicy, type PolicyComponents } from "@openpolicy/re
 import openpolicy from "@/openpolicy";
 
 const components: PolicyComponents = {
-  Heading: ({ node }) => {
-    const Tag = `h${node.level ?? 2}` as const;
-    return (
-      <Tag className="mt-12 text-2xl font-medium tracking-tight text-ink">
-        {node.value}
-      </Tag>
-    );
-  },
-  Paragraph: ({ children }) => (
-    <p className="mt-4 text-pretty text-mute">{children}</p>
-  ),
-  Link: ({ node }) => (
-    <a
-      href={node.href}
-      className="underline decoration-mute underline-offset-4 hover:decoration-ink"
-    >
-      {node.value}
-    </a>
-  ),
+	Heading: ({ node }) => {
+		const Tag = `h${node.level ?? 2}` as const;
+		return <Tag className="mt-12 text-2xl font-medium tracking-tight text-ink">{node.value}</Tag>;
+	},
+	Paragraph: ({ children }) => <p className="mt-4 text-pretty text-mute">{children}</p>,
+	Link: ({ node }) => (
+		<a
+			href={node.href}
+			className="underline decoration-mute underline-offset-4 hover:decoration-ink"
+		>
+			{node.value}
+		</a>
+	),
 };
 
 export const Route = createFileRoute("/privacy")({
-  component: PrivacyPolicyPage,
+	component: PrivacyPolicyPage,
 });
 
 function PrivacyPolicyPage() {
-  return (
-    <OpenPolicy config={openpolicy}>
-      <PrivacyPolicy components={components} />
-    </OpenPolicy>
-  );
+	return (
+		<OpenPolicy config={openpolicy}>
+			<PrivacyPolicy components={components} />
+		</OpenPolicy>
+	);
 }
 ```
 
@@ -200,13 +194,11 @@ The hardest part of a code-first policy isn't the initial setup — it's keeping
 import { collecting } from "@openpolicy/sdk";
 
 export async function createUser(name: string, email: string) {
-  return db.insert(users).values(
-    collecting(
-      "Account Information",
-      { name, email },
-      { name: "Name", email: "Email address" },
-    ),
-  );
+	return db
+		.insert(users)
+		.values(
+			collecting("Account Information", { name, email }, { name: "Name", email: "Email address" }),
+		);
 }
 ```
 

--- a/apps/web/content/docs/opencookies/angular.md
+++ b/apps/web/content/docs/opencookies/angular.md
@@ -25,18 +25,18 @@ import { localStorageAdapter } from "@opencookies/core/storage/local-storage";
 import { AppComponent } from "./app.component";
 
 bootstrapApplication(AppComponent, {
-  providers: [
-    provideOpenCookies({
-      config: {
-        categories: [
-          { key: "essential", label: "Essential", locked: true },
-          { key: "analytics", label: "Analytics" },
-          { key: "marketing", label: "Marketing" },
-        ],
-        adapter: localStorageAdapter(),
-      },
-    }),
-  ],
+	providers: [
+		provideOpenCookies({
+			config: {
+				categories: [
+					{ key: "essential", label: "Essential", locked: true },
+					{ key: "analytics", label: "Analytics" },
+					{ key: "marketing", label: "Marketing" },
+				],
+				adapter: localStorageAdapter(),
+			},
+		}),
+	],
 });
 ```
 
@@ -60,20 +60,20 @@ import { Component, inject } from "@angular/core";
 import { ConsentService } from "@opencookies/angular";
 
 @Component({
-  selector: "app-banner",
-  standalone: true,
-  template: `
-    @if (consent.route() === "cookie") {
-      <div>
-        <button (click)="consent.acceptNecessary()">Necessary only</button>
-        <button (click)="consent.acceptAll()">Accept all</button>
-        <button (click)="consent.setRoute('preferences')">Customize</button>
-      </div>
-    }
-  `,
+	selector: "app-banner",
+	standalone: true,
+	template: `
+		@if (consent.route() === "cookie") {
+			<div>
+				<button (click)="consent.acceptNecessary()">Necessary only</button>
+				<button (click)="consent.acceptAll()">Accept all</button>
+				<button (click)="consent.setRoute('preferences')">Customize</button>
+			</div>
+		}
+	`,
 })
 export class BannerComponent {
-  readonly consent = inject(ConsentService);
+	readonly consent = inject(ConsentService);
 }
 ```
 
@@ -90,17 +90,17 @@ import { Component } from "@angular/core";
 import { injectCategory } from "@opencookies/angular";
 
 @Component({
-  selector: "category-row",
-  standalone: true,
-  template: `
-    <label>
-      <input type="checkbox" [checked]="analytics.granted()" (change)="analytics.toggle()" />
-      Analytics
-    </label>
-  `,
+	selector: "category-row",
+	standalone: true,
+	template: `
+		<label>
+			<input type="checkbox" [checked]="analytics.granted()" (change)="analytics.toggle()" />
+			Analytics
+		</label>
+	`,
 })
 export class CategoryRowComponent {
-  readonly analytics = injectCategory("analytics");
+	readonly analytics = injectCategory("analytics");
 }
 ```
 
@@ -115,17 +115,17 @@ import { ChartComponent } from "./chart.component";
 import { EnablePromptComponent } from "./enable-prompt.component";
 
 @Component({
-  selector: "gated-chart",
-  standalone: true,
-  imports: [ConsentGate, ChartComponent, EnablePromptComponent],
-  template: `
-    <chart *ocConsent="'analytics'; else fallback"></chart>
-    <ng-template #fallback>
-      <enable-prompt></enable-prompt>
-    </ng-template>
+	selector: "gated-chart",
+	standalone: true,
+	imports: [ConsentGate, ChartComponent, EnablePromptComponent],
+	template: `
+		<chart *ocConsent="'analytics'; else fallback"></chart>
+		<ng-template #fallback>
+			<enable-prompt></enable-prompt>
+		</ng-template>
 
-    <personalized-promo *ocConsent="{ and: ['analytics', 'marketing'] }"></personalized-promo>
-  `,
+		<personalized-promo *ocConsent="{ and: ['analytics', 'marketing'] }"></personalized-promo>
+	`,
 })
 export class GatedChartComponent {}
 ```

--- a/apps/web/content/docs/opencookies/core.md
+++ b/apps/web/content/docs/opencookies/core.md
@@ -21,12 +21,12 @@ import { createConsentStore } from "@opencookies/core";
 import { localStorageAdapter } from "@opencookies/core/storage/local-storage";
 
 const store = createConsentStore({
-  categories: [
-    { key: "essential", label: "Essential", locked: true },
-    { key: "analytics", label: "Analytics" },
-    { key: "marketing", label: "Marketing" },
-  ],
-  adapter: localStorageAdapter(),
+	categories: [
+		{ key: "essential", label: "Essential", locked: true },
+		{ key: "analytics", label: "Analytics" },
+		{ key: "marketing", label: "Marketing" },
+	],
+	adapter: localStorageAdapter(),
 });
 
 store.subscribe((state) => render(state));
@@ -54,9 +54,9 @@ import { createConsentStore, headerResolver } from "@opencookies/core";
 
 // Edge runtime (Cloudflare, Vercel, Netlify): read country from request headers.
 const store = createConsentStore({
-  categories,
-  jurisdictionResolver: headerResolver(),
-  request, // standard Request, or anything with a Headers instance
+	categories,
+	jurisdictionResolver: headerResolver(),
+	request, // standard Request, or anything with a Headers instance
 });
 ```
 
@@ -79,13 +79,13 @@ Implement the `JurisdictionResolver` interface and reuse `countryToJurisdiction`
 import { type JurisdictionResolver, countryToJurisdiction } from "@opencookies/core";
 
 export function ipApiResolver(): JurisdictionResolver {
-  return {
-    async resolve() {
-      const res = await fetch("https://ipapi.co/json/");
-      const { country_code } = await res.json();
-      return countryToJurisdiction(country_code);
-    },
-  };
+	return {
+		async resolve() {
+			const res = await fetch("https://ipapi.co/json/");
+			const { country_code } = await res.json();
+			return countryToJurisdiction(country_code);
+		},
+	};
 }
 ```
 
@@ -112,8 +112,8 @@ To scope GPC to the legally-required US states only:
 import { GPC_LEGALLY_REQUIRED_JURISDICTIONS, createConsentStore } from "@opencookies/core";
 
 const store = createConsentStore({
-  categories,
-  gpc: { applicableJurisdictions: GPC_LEGALLY_REQUIRED_JURISDICTIONS },
+	categories,
+	gpc: { applicableJurisdictions: GPC_LEGALLY_REQUIRED_JURISDICTIONS },
 });
 ```
 
@@ -121,9 +121,9 @@ A category that should ignore GPC sets `respectGPC: false`:
 
 ```ts
 const categories = [
-  { key: "essential", label: "Essential", locked: true },
-  { key: "analytics", label: "Analytics", respectGPC: false },
-  { key: "marketing", label: "Marketing" },
+	{ key: "essential", label: "Essential", locked: true },
+	{ key: "analytics", label: "Analytics", respectGPC: false },
+	{ key: "marketing", label: "Marketing" },
 ];
 ```
 
@@ -141,13 +141,13 @@ When a decision is persisted via a `StorageAdapter`, the store serialises it as 
 
 ```ts
 type ConsentRecord = {
-  schemaVersion: 1;
-  decisions: Record<string, boolean>;
-  policyVersion: string;
-  decidedAt: string; // ISO-8601
-  jurisdiction: Jurisdiction | null;
-  locale: string;
-  source: "banner" | "preferences" | "api" | "import";
+	schemaVersion: 1;
+	decisions: Record<string, boolean>;
+	policyVersion: string;
+	decidedAt: string; // ISO-8601
+	jurisdiction: Jurisdiction | null;
+	locale: string;
+	source: "banner" | "preferences" | "api" | "import";
 };
 ```
 
@@ -164,9 +164,9 @@ Read the current record via `store.getConsentRecord()` (or the binding-level `us
 
 ```ts
 const store = createConsentStore({
-  categories,
-  locale: "en-GB", // optional; falls back to navigator.language, then "en"
-  adapter: cookieAdapter(),
+	categories,
+	locale: "en-GB", // optional; falls back to navigator.language, then "en"
+	adapter: cookieAdapter(),
 });
 
 store.acceptAll();
@@ -192,15 +192,15 @@ A stored `ConsentRecord` can become stale: the cookie policy is updated, a new c
 
 ```ts
 const store = createConsentStore({
-  categories,
-  policyVersion: "v2",
-  adapter: cookieAdapter(),
-  triggers: {
-    policyVersionChanged: true, // config.policyVersion !== record.policyVersion
-    categoriesAdded: true, // a category in config is missing from the record
-    expiresAfter: "13 months", // older than the duration → re-prompt
-    jurisdictionChanged: true, // current jurisdiction differs from the recorded one
-  },
+	categories,
+	policyVersion: "v2",
+	adapter: cookieAdapter(),
+	triggers: {
+		policyVersionChanged: true, // config.policyVersion !== record.policyVersion
+		categoriesAdded: true, // a category in config is missing from the record
+		expiresAfter: "13 months", // older than the duration → re-prompt
+		jurisdictionChanged: true, // current jurisdiction differs from the recorded one
+	},
 });
 ```
 
@@ -217,8 +217,8 @@ When any trigger fires, the store invalidates state — `route` returns to `"coo
 const { repromptReason, getPreviousRecord } = useConsent();
 
 if (repromptReason !== null) {
-  console.log(`Re-prompting because: ${repromptReason}`);
-  console.log("Previous decisions:", getPreviousRecord()?.decisions);
+	console.log(`Re-prompting because: ${repromptReason}`);
+	console.log("Previous decisions:", getPreviousRecord()?.decisions);
 }
 ```
 
@@ -228,7 +228,7 @@ For analytics, the store emits an `oncookies:reprompt` event on `globalThis` whe
 
 ```ts
 globalThis.addEventListener("oncookies:reprompt", (event) => {
-  analytics.track("consent_reprompt", { reason: event.detail.reason });
+	analytics.track("consent_reprompt", { reason: event.detail.reason });
 });
 ```
 
@@ -242,18 +242,18 @@ import { createConsentStore, defineScript, gateScript } from "@opencookies/core"
 const store = createConsentStore({ categories });
 
 const ga4 = defineScript({
-  id: "ga4",
-  requires: "analytics",
-  src: "https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX",
-  queue: ["dataLayer.push"],
-  init: () => {
-    window.dataLayer = window.dataLayer || [];
-    window.gtag = function gtag() {
-      window.dataLayer.push(arguments);
-    };
-    window.gtag("js", new Date());
-    window.gtag("config", "G-XXXXXXX");
-  },
+	id: "ga4",
+	requires: "analytics",
+	src: "https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX",
+	queue: ["dataLayer.push"],
+	init: () => {
+		window.dataLayer = window.dataLayer || [];
+		window.gtag = function gtag() {
+			window.dataLayer.push(arguments);
+		};
+		window.gtag("js", new Date());
+		window.gtag("config", "G-XXXXXXX");
+	},
 });
 
 gateScript(store, ga4);

--- a/apps/web/content/docs/opencookies/index.md
+++ b/apps/web/content/docs/opencookies/index.md
@@ -41,39 +41,39 @@ npm install @opencookies/core @opencookies/angular
 import { OpenCookiesProvider, useConsent, ConsentGate } from "@opencookies/react";
 
 const config = {
-  categories: [
-    { key: "essential", label: "Essential", locked: true },
-    { key: "analytics", label: "Analytics" },
-    { key: "marketing", label: "Marketing" },
-  ],
+	categories: [
+		{ key: "essential", label: "Essential", locked: true },
+		{ key: "analytics", label: "Analytics" },
+		{ key: "marketing", label: "Marketing" },
+	],
 };
 
 function App() {
-  return (
-    <OpenCookiesProvider config={config}>
-      <YourApp />
-      <CookieBanner />
-    </OpenCookiesProvider>
-  );
+	return (
+		<OpenCookiesProvider config={config}>
+			<YourApp />
+			<CookieBanner />
+		</OpenCookiesProvider>
+	);
 }
 
 function CookieBanner() {
-  const { route, acceptAll, acceptNecessary, setRoute } = useConsent();
-  if (route !== "cookie") return null;
+	const { route, acceptAll, acceptNecessary, setRoute } = useConsent();
+	if (route !== "cookie") return null;
 
-  return (
-    <div className="your-styles-here">
-      <p>We use cookies to improve your experience.</p>
-      <button onClick={acceptAll}>Accept all</button>
-      <button onClick={acceptNecessary}>Necessary only</button>
-      <button onClick={() => setRoute("preferences")}>Customise</button>
-    </div>
-  );
+	return (
+		<div className="your-styles-here">
+			<p>We use cookies to improve your experience.</p>
+			<button onClick={acceptAll}>Accept all</button>
+			<button onClick={acceptNecessary}>Necessary only</button>
+			<button onClick={() => setRoute("preferences")}>Customise</button>
+		</div>
+	);
 }
 
 // Gate third-party code on consent
 <ConsentGate requires="analytics">
-  <GoogleAnalytics />
+	<GoogleAnalytics />
 </ConsentGate>;
 ```
 
@@ -96,7 +96,7 @@ function CookieBanner() {
 import openCookies from "@opencookies/vite";
 
 export default {
-  plugins: [openCookies({ mode: "warn" })],
+	plugins: [openCookies({ mode: "warn" })],
 };
 ```
 
@@ -104,8 +104,8 @@ The plugin scans your code for cookie writes and known third-party vendors, and 
 
 ## Packages
 
-| Package                                       | Description                                                                                   |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Package                                             | Description                                                                                   |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | [`@opencookies/core`](/docs/opencookies/core)       | Headless consent store, GPC handling, jurisdiction resolvers, script gating, storage adapters |
 | [`@opencookies/react`](/docs/opencookies/react)     | React 18+ adapter — `useConsent`, `useCategory`, `<ConsentGate>`                              |
 | [`@opencookies/vue`](/docs/opencookies/vue)         | Vue 3 adapter — plugin or `<OpenCookiesProvider>`, composables, `<ConsentGate>`               |

--- a/apps/web/content/docs/opencookies/react.md
+++ b/apps/web/content/docs/opencookies/react.md
@@ -24,15 +24,15 @@ import type { Category } from "@opencookies/core";
 import { createRoot } from "react-dom/client";
 
 const categories: Category[] = [
-  { key: "essential", label: "Essential", locked: true },
-  { key: "analytics", label: "Analytics" },
-  { key: "marketing", label: "Marketing" },
+	{ key: "essential", label: "Essential", locked: true },
+	{ key: "analytics", label: "Analytics" },
+	{ key: "marketing", label: "Marketing" },
 ];
 
 createRoot(document.getElementById("root")!).render(
-  <OpenCookiesProvider config={{ categories }}>
-    <App />
-  </OpenCookiesProvider>,
+	<OpenCookiesProvider config={{ categories }}>
+		<App />
+	</OpenCookiesProvider>,
 );
 ```
 
@@ -50,16 +50,16 @@ Returns the current consent state plus action methods. Re-renders the consumer w
 import { useConsent } from "@opencookies/react";
 
 function Banner() {
-  const { route, acceptAll, acceptNecessary, setRoute } = useConsent();
-  if (route !== "cookie") return null;
+	const { route, acceptAll, acceptNecessary, setRoute } = useConsent();
+	if (route !== "cookie") return null;
 
-  return (
-    <div className="banner">
-      <button onClick={acceptNecessary}>Necessary only</button>
-      <button onClick={acceptAll}>Accept all</button>
-      <button onClick={() => setRoute("preferences")}>Customize</button>
-    </div>
-  );
+	return (
+		<div className="banner">
+			<button onClick={acceptNecessary}>Necessary only</button>
+			<button onClick={acceptAll}>Accept all</button>
+			<button onClick={() => setRoute("preferences")}>Customize</button>
+		</div>
+	);
 }
 ```
 
@@ -71,13 +71,13 @@ Granular per-category access. Returns `{ granted, toggle }`.
 import { useCategory } from "@opencookies/react";
 
 function AnalyticsToggle() {
-  const { granted, toggle } = useCategory("analytics");
-  return (
-    <label>
-      <input type="checkbox" checked={granted} onChange={toggle} />
-      Analytics
-    </label>
-  );
+	const { granted, toggle } = useCategory("analytics");
+	return (
+		<label>
+			<input type="checkbox" checked={granted} onChange={toggle} />
+			Analytics
+		</label>
+	);
 }
 ```
 
@@ -89,11 +89,11 @@ Renders `children` when the expression is satisfied; renders `fallback` otherwis
 import { ConsentGate } from "@opencookies/react";
 
 <ConsentGate requires="analytics" fallback={<EnablePrompt />}>
-  <Chart />
+	<Chart />
 </ConsentGate>;
 
 <ConsentGate requires={{ and: ["analytics", "marketing"] }}>
-  <PersonalizedPromo />
+	<PersonalizedPromo />
 </ConsentGate>;
 ```
 
@@ -110,12 +110,12 @@ import { OpenCookiesProvider } from "@opencookies/react";
 import type { Category } from "@opencookies/core";
 
 const categories: Category[] = [
-  { key: "essential", label: "Essential", locked: true },
-  { key: "analytics", label: "Analytics" },
+	{ key: "essential", label: "Essential", locked: true },
+	{ key: "analytics", label: "Analytics" },
 ];
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <OpenCookiesProvider config={{ categories }}>{children}</OpenCookiesProvider>;
+	return <OpenCookiesProvider config={{ categories }}>{children}</OpenCookiesProvider>;
 }
 ```
 
@@ -124,13 +124,13 @@ export function Providers({ children }: { children: React.ReactNode }) {
 import { Providers } from "./providers";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html>
-      <body>
-        <Providers>{children}</Providers>
-      </body>
-    </html>
-  );
+	return (
+		<html>
+			<body>
+				<Providers>{children}</Providers>
+			</body>
+		</html>
+	);
 }
 ```
 

--- a/apps/web/content/docs/opencookies/scanner.md
+++ b/apps/web/content/docs/opencookies/scanner.md
@@ -93,22 +93,22 @@ is what enforces consent. See [OpenCookies core] for the runtime story.
 import { defineRule, scan, defaultRules } from "@opencookies/scanner";
 
 const banPlausible = defineRule({
-  name: "plausible-import",
-  visit: (ctx) => {
-    if (ctx.node.type !== "ImportDeclaration") return;
-    const src = (ctx.node as { source?: { value?: string } }).source?.value;
-    if (src === "plausible-tracker") {
-      const { line, column } = ctx.position(ctx.node.start);
-      ctx.report({
-        file: ctx.file,
-        line,
-        column,
-        vendor: "plausible",
-        category: "analytics",
-        via: "import",
-      });
-    }
-  },
+	name: "plausible-import",
+	visit: (ctx) => {
+		if (ctx.node.type !== "ImportDeclaration") return;
+		const src = (ctx.node as { source?: { value?: string } }).source?.value;
+		if (src === "plausible-tracker") {
+			const { line, column } = ctx.position(ctx.node.start);
+			ctx.report({
+				file: ctx.file,
+				line,
+				column,
+				vendor: "plausible",
+				category: "analytics",
+				via: "import",
+			});
+		}
+	},
 });
 
 await scan({ cwd: process.cwd(), rules: [...defaultRules, banPlausible] });
@@ -121,11 +121,11 @@ entry has the shape:
 
 ```json
 {
-  "vendor": "stripe",
-  "category": "payments",
-  "imports": ["@stripe/stripe-js", "stripe"],
-  "globals": ["Stripe"],
-  "scriptUrls": ["https://js.stripe.com/v3/"]
+	"vendor": "stripe",
+	"category": "payments",
+	"imports": ["@stripe/stripe-js", "stripe"],
+	"globals": ["Stripe"],
+	"scriptUrls": ["https://js.stripe.com/v3/"]
 }
 ```
 

--- a/apps/web/content/docs/opencookies/solid.md
+++ b/apps/web/content/docs/opencookies/solid.md
@@ -24,18 +24,18 @@ import type { Category } from "@opencookies/core";
 import { render } from "solid-js/web";
 
 const categories: Category[] = [
-  { key: "essential", label: "Essential", locked: true },
-  { key: "analytics", label: "Analytics" },
-  { key: "marketing", label: "Marketing" },
+	{ key: "essential", label: "Essential", locked: true },
+	{ key: "analytics", label: "Analytics" },
+	{ key: "marketing", label: "Marketing" },
 ];
 
 render(
-  () => (
-    <OpenCookiesProvider config={{ categories }}>
-      <App />
-    </OpenCookiesProvider>
-  ),
-  document.getElementById("root")!,
+	() => (
+		<OpenCookiesProvider config={{ categories }}>
+			<App />
+		</OpenCookiesProvider>
+	),
+	document.getElementById("root")!,
 );
 ```
 
@@ -52,16 +52,16 @@ import { useConsent } from "@opencookies/solid";
 import { Show } from "solid-js";
 
 function Banner() {
-  const { route, acceptAll, acceptNecessary, setRoute } = useConsent();
-  return (
-    <Show when={route() === "cookie"}>
-      <div class="banner">
-        <button onClick={acceptNecessary}>Necessary only</button>
-        <button onClick={acceptAll}>Accept all</button>
-        <button onClick={() => setRoute("preferences")}>Customize</button>
-      </div>
-    </Show>
-  );
+	const { route, acceptAll, acceptNecessary, setRoute } = useConsent();
+	return (
+		<Show when={route() === "cookie"}>
+			<div class="banner">
+				<button onClick={acceptNecessary}>Necessary only</button>
+				<button onClick={acceptAll}>Accept all</button>
+				<button onClick={() => setRoute("preferences")}>Customize</button>
+			</div>
+		</Show>
+	);
 }
 ```
 
@@ -73,13 +73,13 @@ Granular per-category access.
 import { useCategory } from "@opencookies/solid";
 
 function AnalyticsToggle() {
-  const analytics = useCategory("analytics");
-  return (
-    <label>
-      <input type="checkbox" checked={analytics.granted()} onChange={analytics.toggle} />
-      Analytics
-    </label>
-  );
+	const analytics = useCategory("analytics");
+	return (
+		<label>
+			<input type="checkbox" checked={analytics.granted()} onChange={analytics.toggle} />
+			Analytics
+		</label>
+	);
 }
 ```
 
@@ -111,13 +111,13 @@ import { FileRoutes } from "@solidjs/start/router";
 import { categories } from "./cookies";
 
 export default function App() {
-  return (
-    <OpenCookiesProvider config={{ categories }}>
-      <Router>
-        <FileRoutes />
-      </Router>
-    </OpenCookiesProvider>
-  );
+	return (
+		<OpenCookiesProvider config={{ categories }}>
+			<Router>
+				<FileRoutes />
+			</Router>
+		</OpenCookiesProvider>
+	);
 }
 ```
 

--- a/apps/web/content/docs/opencookies/vite.md
+++ b/apps/web/content/docs/opencookies/vite.md
@@ -20,17 +20,17 @@ import { defineConfig } from "vite";
 import { openCookies } from "@opencookies/vite";
 
 export default defineConfig({
-  plugins: [
-    openCookies({
-      config: {
-        categories: [
-          { key: "necessary", label: "Necessary", locked: true },
-          { key: "analytics", label: "Analytics" },
-          { key: "marketing", label: "Marketing" },
-        ],
-      },
-    }),
-  ],
+	plugins: [
+		openCookies({
+			config: {
+				categories: [
+					{ key: "necessary", label: "Necessary", locked: true },
+					{ key: "analytics", label: "Analytics" },
+					{ key: "marketing", label: "Marketing" },
+				],
+			},
+		}),
+	],
 });
 ```
 

--- a/apps/web/content/docs/opencookies/vue.md
+++ b/apps/web/content/docs/opencookies/vue.md
@@ -24,16 +24,16 @@ import { OpenCookiesPlugin } from "@opencookies/vue";
 import App from "./App.vue";
 
 createApp(App)
-  .use(OpenCookiesPlugin, {
-    config: {
-      categories: [
-        { key: "essential", label: "Essential", locked: true },
-        { key: "analytics", label: "Analytics" },
-        { key: "marketing", label: "Marketing" },
-      ],
-    },
-  })
-  .mount("#app");
+	.use(OpenCookiesPlugin, {
+		config: {
+			categories: [
+				{ key: "essential", label: "Essential", locked: true },
+				{ key: "analytics", label: "Analytics" },
+				{ key: "marketing", label: "Marketing" },
+			],
+		},
+	})
+	.mount("#app");
 ```
 
 Or scope a store to a subtree with the `<OpenCookiesProvider>` component:
@@ -44,9 +44,9 @@ import { OpenCookiesProvider } from "@opencookies/vue";
 </script>
 
 <template>
-  <OpenCookiesProvider :config="{ categories }">
-    <App />
-  </OpenCookiesProvider>
+	<OpenCookiesProvider :config="{ categories }">
+		<App />
+	</OpenCookiesProvider>
 </template>
 ```
 
@@ -66,11 +66,11 @@ const { route, decisions, acceptAll, acceptNecessary, setRoute } = useConsent();
 </script>
 
 <template>
-  <div v-if="route === 'cookie'">
-    <button @click="acceptNecessary">Necessary only</button>
-    <button @click="acceptAll">Accept all</button>
-    <button @click="setRoute('preferences')">Customize</button>
-  </div>
+	<div v-if="route === 'cookie'">
+		<button @click="acceptNecessary">Necessary only</button>
+		<button @click="acceptAll">Accept all</button>
+		<button @click="setRoute('preferences')">Customize</button>
+	</div>
 </template>
 ```
 
@@ -86,10 +86,10 @@ const { granted, toggle } = useCategory("analytics");
 </script>
 
 <template>
-  <label>
-    <input type="checkbox" :checked="granted" @change="toggle" />
-    Analytics
-  </label>
+	<label>
+		<input type="checkbox" :checked="granted" @change="toggle" />
+		Analytics
+	</label>
 </template>
 ```
 
@@ -105,16 +105,16 @@ import EnablePrompt from "./EnablePrompt.vue";
 </script>
 
 <template>
-  <ConsentGate requires="analytics">
-    <Chart />
-    <template #fallback>
-      <EnablePrompt />
-    </template>
-  </ConsentGate>
+	<ConsentGate requires="analytics">
+		<Chart />
+		<template #fallback>
+			<EnablePrompt />
+		</template>
+	</ConsentGate>
 
-  <ConsentGate :requires="{ and: ['analytics', 'marketing'] }">
-    <PersonalizedPromo />
-  </ConsentGate>
+	<ConsentGate :requires="{ and: ['analytics', 'marketing'] }">
+		<PersonalizedPromo />
+	</ConsentGate>
 </template>
 ```
 
@@ -128,17 +128,17 @@ import { defineComponent } from "vue";
 import { useConsent, useCategory } from "@opencookies/vue";
 
 export default defineComponent({
-  setup() {
-    const consent = useConsent();
-    const analytics = useCategory("analytics");
-    return { consent, analytics };
-  },
+	setup() {
+		const consent = useConsent();
+		const analytics = useCategory("analytics");
+		return { consent, analytics };
+	},
 });
 </script>
 
 <template>
-  <button @click="consent.acceptAll()">Accept all</button>
-  <input type="checkbox" :checked="analytics.granted" @change="analytics.toggle()" />
+	<button @click="consent.acceptAll()">Accept all</button>
+	<input type="checkbox" :checked="analytics.granted" @change="analytics.toggle()" />
 </template>
 ```
 
@@ -152,12 +152,12 @@ import { OpenCookiesPlugin } from "@opencookies/vue";
 import type { Category } from "@opencookies/core";
 
 const categories: Category[] = [
-  { key: "essential", label: "Essential", locked: true },
-  { key: "analytics", label: "Analytics" },
+	{ key: "essential", label: "Essential", locked: true },
+	{ key: "analytics", label: "Analytics" },
 ];
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.use(OpenCookiesPlugin, { config: { categories } });
+	nuxtApp.vueApp.use(OpenCookiesPlugin, { config: { categories } });
 });
 ```
 

--- a/apps/web/content/docs/openpolicy/configuration.md
+++ b/apps/web/content/docs/openpolicy/configuration.md
@@ -146,7 +146,7 @@ The user rights you're legally required to disclose (access, erasure, portabilit
 import openpolicy from "./openpolicy";
 
 openpolicy.privacyVersion; // "a1b2c3d4"
-openpolicy.cookieVersion;  // "f5e6d7c8"
+openpolicy.cookieVersion; // "f5e6d7c8"
 ```
 
 When set, the version is rendered inline with the effective-date sentence in each policy's intro — `… Effective Date: 2026-01-01. Version: a1b2c3d4.` — so customers have a printed reference they can quote.
@@ -155,8 +155,8 @@ Pin a manual version (e.g. for a published v3 doc) by passing it on input:
 
 ```ts
 defineConfig({
-  // ...
-  privacyVersion: "v3",
+	// ...
+	privacyVersion: "v3",
 });
 ```
 

--- a/apps/web/content/docs/openpolicy/cookies/overview.md
+++ b/apps/web/content/docs/openpolicy/cookies/overview.md
@@ -30,11 +30,9 @@ import { toOpenCookiesConfig } from "@openpolicy/sdk/opencookies";
 import openpolicy from "./openpolicy";
 
 export function Root({ children }: { children: React.ReactNode }) {
-  return (
-    <OpenCookiesProvider config={toOpenCookiesConfig(openpolicy)}>
-      {children}
-    </OpenCookiesProvider>
-  );
+	return (
+		<OpenCookiesProvider config={toOpenCookiesConfig(openpolicy)}>{children}</OpenCookiesProvider>
+	);
 }
 ```
 

--- a/apps/web/content/docs/openpolicy/i18n.md
+++ b/apps/web/content/docs/openpolicy/i18n.md
@@ -8,12 +8,12 @@ OpenPolicy emits around 125 strings into every compiled policy — headings, tab
 
 ## Supported locales
 
-| Locale | Tag | Status |
-|---|---|---|
+| Locale  | Tag  | Status           |
+| ------- | ---- | ---------------- |
 | English | `en` | Ships in v0.0.34 |
-| French | `fr` | Ships in v0.0.34 |
-| German | `de` | Ships in v0.0.34 |
-| Dutch | `nl` | Ships in v0.0.34 |
+| French  | `fr` | Ships in v0.0.34 |
+| German  | `de` | Ships in v0.0.34 |
+| Dutch   | `nl` | Ships in v0.0.34 |
 | Spanish | `es` | Ships in v0.0.34 |
 
 English is the ground truth — every other dictionary is checked against it at compile time via the `Dictionary` type, so a missing key fails `tsc` rather than silently falling back to English at runtime.
@@ -27,11 +27,13 @@ Pass `locale` to `defineConfig` and every emitted string in both the privacy and
 import { defineConfig } from "@openpolicy/sdk";
 
 export default defineConfig({
-  company: { name: "Acme, Inc." },
-  effectiveDate: "2026-01-01",
-  jurisdictions: ["eu", "fr"],
-  locale: "fr",
-  data: { /* ... */ },
+	company: { name: "Acme, Inc." },
+	effectiveDate: "2026-01-01",
+	jurisdictions: ["eu", "fr"],
+	locale: "fr",
+	data: {
+		/* ... */
+	},
 });
 ```
 
@@ -46,12 +48,12 @@ import { OpenPolicy, PrivacyPolicy } from "@openpolicy/react";
 import openpolicy from "@/openpolicy";
 
 export function PrivacyPolicyPage() {
-  return (
-    <OpenPolicy config={openpolicy}>
-      <PrivacyPolicy />              {/* uses config.locale */}
-      <PrivacyPolicy locale="fr" />  {/* override → French */}
-    </OpenPolicy>
-  );
+	return (
+		<OpenPolicy config={openpolicy}>
+			<PrivacyPolicy /> {/* uses config.locale */}
+			<PrivacyPolicy locale="fr" /> {/* override → French */}
+		</OpenPolicy>
+	);
 }
 ```
 

--- a/apps/web/content/pages/index.md
+++ b/apps/web/content/pages/index.md
@@ -8,7 +8,7 @@ PolicyStack ships small, composable building blocks that let teams handle privac
 
 Today's privacy story is heavy SaaS banners glued to hand-written legal pages. Nothing composes with your stack. Nothing is testable. Nothing speaks to AI agents.
 
-PolicyStack is built on the opposite premise: consent and policy are *infrastructure*. They belong in your repo, behind types, in your tests, and out of the way.
+PolicyStack is built on the opposite premise: consent and policy are _infrastructure_. They belong in your repo, behind types, in your tests, and out of the way.
 
 ## Three building blocks
 

--- a/apps/web/content/pages/opencookies.md
+++ b/apps/web/content/pages/opencookies.md
@@ -5,28 +5,25 @@
 Tiny core. Adapters for every major framework. A Vite plugin that yells at you when a script sets a cookie behind a category the user hasn't accepted yet.
 
 ```tsx
-import {
-  OpenCookiesProvider,
-  ConsentGate,
-} from "@opencookies/react";
+import { OpenCookiesProvider, ConsentGate } from "@opencookies/react";
 
 const config = {
-  categories: [
-    { key: "essential", label: "Essential", locked: true },
-    { key: "analytics", label: "Analytics" },
-    { key: "marketing", label: "Marketing" },
-  ],
+	categories: [
+		{ key: "essential", label: "Essential", locked: true },
+		{ key: "analytics", label: "Analytics" },
+		{ key: "marketing", label: "Marketing" },
+	],
 };
 
 export function App() {
-  return (
-    <OpenCookiesProvider config={config}>
-      <YourApp />
-      <ConsentGate requires="analytics">
-        <GoogleAnalytics />
-      </ConsentGate>
-    </OpenCookiesProvider>
-  );
+	return (
+		<OpenCookiesProvider config={config}>
+			<YourApp />
+			<ConsentGate requires="analytics">
+				<GoogleAnalytics />
+			</ConsentGate>
+		</OpenCookiesProvider>
+	);
 }
 ```
 
@@ -61,13 +58,13 @@ pnpm add @opencookies/core @opencookies/react
 import { useConsent } from "@opencookies/react";
 
 export function CookieBanner() {
-  const { acceptAll, acceptNecessary } = useConsent();
-  return (
-    <div>
-      <button onClick={acceptAll}>Accept all</button>
-      <button onClick={acceptNecessary}>Necessary only</button>
-    </div>
-  );
+	const { acceptAll, acceptNecessary } = useConsent();
+	return (
+		<div>
+			<button onClick={acceptAll}>Accept all</button>
+			<button onClick={acceptNecessary}>Necessary only</button>
+		</div>
+	);
 }
 ```
 

--- a/apps/web/content/pages/openpolicy.md
+++ b/apps/web/content/pages/openpolicy.md
@@ -31,16 +31,16 @@ export function PrivacyPolicyPage() {
 
 Same legal coverage you'd get from a lawyer, a template, or one of the incumbent SaaS tools — without the invoice, the dashboard, or the drift.
 
-| Feature | OpenPolicy | Lawyers | Templates | Termly | iubenda |
-|---|---|---|---|---|---|
-| Developer workflow (Git, TypeScript, CI) | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Version controlled | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Renders as a React / Vue / Svelte component | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Always in sync with the codebase | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Markdown / HTML / PDF output | ✓ | PDF only | Word / PDF | Hosted page | Hosted widget |
-| GDPR + CCPA coverage | ✓ | ✓ | Varies | ✓ | ✓ |
-| No ongoing subscription | ✓ | ✗ | ✓ | ✗ | ✗ |
-| Self-hostable / open source | ✓ | — | — | ✗ | ✗ |
+| Feature                                     | OpenPolicy | Lawyers  | Templates  | Termly      | iubenda       |
+| ------------------------------------------- | ---------- | -------- | ---------- | ----------- | ------------- |
+| Developer workflow (Git, TypeScript, CI)    | ✓          | ✗        | ✗          | ✗           | ✗             |
+| Version controlled                          | ✓          | ✗        | ✗          | ✗           | ✗             |
+| Renders as a React / Vue / Svelte component | ✓          | ✗        | ✗          | ✗           | ✗             |
+| Always in sync with the codebase            | ✓          | ✗        | ✗          | ✗           | ✗             |
+| Markdown / HTML / PDF output                | ✓          | PDF only | Word / PDF | Hosted page | Hosted widget |
+| GDPR + CCPA coverage                        | ✓          | ✓        | Varies     | ✓           | ✓             |
+| No ongoing subscription                     | ✓          | ✗        | ✓          | ✗           | ✗             |
+| Self-hostable / open source                 | ✓          | —        | —          | ✗           | ✗             |
 
 GDPR and CCPA coverage is the floor — OpenPolicy is not legal advice and is not a replacement for counsel on high-stakes matters.
 
@@ -48,22 +48,24 @@ GDPR and CCPA coverage is the floor — OpenPolicy is not legal advice and is no
 
 Pass `locale` to `defineConfig` and the ~125 strings OpenPolicy emits — headings, table headers, GDPR/CCPA boilerplate, formatted dates — render in your chosen language. Your company name, processing purposes, retention text, and third-party descriptions pass through as you wrote them.
 
-| Locale | Tag |
-|---|---|
+| Locale  | Tag  |
+| ------- | ---- |
 | English | `en` |
-| French | `fr` |
-| German | `de` |
-| Dutch | `nl` |
+| French  | `fr` |
+| German  | `de` |
+| Dutch   | `nl` |
 | Spanish | `es` |
 
 ```ts
 import { defineConfig } from "@openpolicy/sdk";
 
 export default defineConfig({
-  company: { name: "Acme, Inc." },
-  jurisdictions: ["eu", "fr"],
-  locale: "fr",
-  data: { /* ... */ },
+	company: { name: "Acme, Inc." },
+	jurisdictions: ["eu", "fr"],
+	locale: "fr",
+	data: {
+		/* ... */
+	},
 });
 ```
 
@@ -81,13 +83,13 @@ pnpm dlx @openpolicy/cli init
 import { defineConfig } from "@openpolicy/sdk";
 
 export default defineConfig({
-  company: { name: "Acme, Inc." },
-  jurisdictions: ["eu", "us-ca"],
-  data: {
-    collected: {
-      "Account Information": ["Name", "Email"],
-    },
-  },
+	company: { name: "Acme, Inc." },
+	jurisdictions: ["eu", "us-ca"],
+	data: {
+		collected: {
+			"Account Information": ["Name", "Email"],
+		},
+	},
 });
 ```
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2,67 +2,67 @@
 @import "tailwindcss";
 
 @theme {
-  --font-sans: "Geist Mono", ui-monospace, "SFMono-Regular", monospace;
-  --font-mono: "Geist Mono", ui-monospace, "SFMono-Regular", monospace;
+	--font-sans: "Geist Mono", ui-monospace, "SFMono-Regular", monospace;
+	--font-mono: "Geist Mono", ui-monospace, "SFMono-Regular", monospace;
 
-  --color-canvas: #ffffff;
-  --color-ink: #000000;
-  --color-line: #000000;
-  --color-mute: #6b6b6b;
+	--color-canvas: #ffffff;
+	--color-ink: #000000;
+	--color-line: #000000;
+	--color-mute: #6b6b6b;
 
-  --docs-sidebar-width: 17rem;
+	--docs-sidebar-width: 17rem;
 }
 
 * {
-  box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 html,
 body,
 #app {
-  min-height: 100%;
+	min-height: 100%;
 }
 
 html {
-  background: var(--color-canvas);
-  color: var(--color-ink);
-  font-feature-settings: "ss02", "ss03", "zero", "calt";
+	background: var(--color-canvas);
+	color: var(--color-ink);
+	font-feature-settings: "ss02", "ss03", "zero", "calt";
 }
 
 body {
-  margin: 0;
+	margin: 0;
 }
 
 ::selection {
-  background: var(--color-ink);
-  color: var(--color-canvas);
+	background: var(--color-ink);
+	color: var(--color-canvas);
 }
 
 .shiki {
-  background: transparent !important;
-  margin: 0;
-  padding: 0;
-  font-family: var(--font-mono);
-  font-size: inherit;
-  line-height: 1.6;
+	background: transparent !important;
+	margin: 0;
+	padding: 0;
+	font-family: var(--font-mono);
+	font-size: inherit;
+	line-height: 1.6;
 }
 
 .shiki code {
-  display: block;
+	display: block;
 }
 
 @utility border-2 {
-  border-width: 3px;
+	border-width: 3px;
 }
 @utility border-t-2 {
-  border-top-width: 3px;
+	border-top-width: 3px;
 }
 @utility border-b-2 {
-  border-bottom-width: 3px;
+	border-bottom-width: 3px;
 }
 @utility border-l-2 {
-  border-left-width: 3px;
+	border-left-width: 3px;
 }
 @utility border-r-2 {
-  border-right-width: 3px;
+	border-right-width: 3px;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,12 @@ settings:
 catalogs:
   default:
     vite-plus:
-      specifier: latest
+      specifier: 0.1.21
       version: 0.1.21
 
 overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.21
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.21
 
 importers:
 
@@ -153,7 +153,7 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@latest
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)'
       vite-plus:
         specifier: 'catalog:'
@@ -234,7 +234,7 @@ importers:
         specifier: ^4.2.1
         version: 4.2.4
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@latest
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)'
       vite-plus:
         specifier: 'catalog:'
@@ -465,7 +465,7 @@ importers:
         specifier: ^0.2.0
         version: 0.2.16
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@latest
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)'
     devDependencies:
       '@openpolicy/sdk':
@@ -1295,42 +1295,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -1480,48 +1487,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.124.0':
     resolution: {integrity: sha512-uvG7v4Tz9S8/PVqY0SP0DLHxo4hZGe+Pv2tGVnwcsjKCCUPjplbrFVvDzXq+kOaEoUkiCY0Kt1hlZ6FDJ1LKNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.124.0':
     resolution: {integrity: sha512-t7KZaaUhfp2au0MRpoENEFqwLKYDdptEry6V7pTAVdPEcFG4P6ii8yeGU9m6p5vb+b8WEKmdpGMNXBEYy7iJdw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.124.0':
     resolution: {integrity: sha512-eurGGaxHZiIQ+fBSageS8TAkRqZgdOiBeqNrWAqAPup9hXBTmQ0WcBjwsLElf+3jvDL9NhnX0dOgOqPfsjSjdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.124.0':
     resolution: {integrity: sha512-d1V7/ll1i/LhqE/gZy6Wbz6evlk0egh2XKkwMI3epiojtbtUwQSLIER0Y3yDBBocPuWOjJdvmjtEmPTTLXje/w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.124.0':
     resolution: {integrity: sha512-w1+cBvriUteOpox6ATqCFVkpGL47PFdcfCPGmgUZbd78Fw44U0gQkc+kVGvAOTvGrptMYgwomD1c6OTVvkrpGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.124.0':
     resolution: {integrity: sha512-RRB1evQiXRtMCsQQiAh9U0H3HzguLpE0ytfStuhRgmOj7tqUCOVxkHsvM9geZjAax6NqVRj7VXx32qjjkZPsBw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.124.0':
     resolution: {integrity: sha512-asVYN0qmSHlCU8H9Q47SmeJ/Z5EG4IWCC+QGxkfFboI5qh15aLlJnHmnrV61MwQRPXGnVC/sC3qKhrUyqGxUqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.124.0':
     resolution: {integrity: sha512-nhwuxm6B8pn9lzAzMUfa571L5hCXYwQo8C8cx5aGOuHWCzruR8gPJnRRXGBci+uGaIIQEZDyU/U6HDgrSp/JlQ==}
@@ -1604,41 +1619,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -1712,48 +1735,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.48.0':
     resolution: {integrity: sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
     resolution: {integrity: sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
     resolution: {integrity: sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.48.0':
     resolution: {integrity: sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.48.0':
     resolution: {integrity: sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.48.0':
     resolution: {integrity: sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.48.0':
     resolution: {integrity: sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.48.0':
     resolution: {integrity: sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==}
@@ -1856,48 +1887,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.63.0':
     resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.63.0':
     resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.63.0':
     resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.63.0':
     resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.63.0':
     resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.63.0':
     resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.63.0':
     resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.63.0':
     resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
@@ -1987,36 +2026,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -2779,24 +2824,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -2885,72 +2934,84 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0':
     resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
@@ -3062,66 +3123,79 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -3316,24 +3390,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -3824,24 +3902,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.21':
     resolution: {integrity: sha512-Q5c6i1TyRuMELDcGozuI5Y0JhIZsSbAJ067Okty6XmoJ5tSmUnMzEO5HKRmgjfGryjJpn5dpUKXzj2eWsdx+6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.21':
     resolution: {integrity: sha512-DquiIAvGIUIJBfqOnqAtBPoyhNIGLM1DzswzDPddO5kjg6NCE4hPbFr5ncjhSKqyp88Kd1YWYD93yg3FAdr/EA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.21':
     resolution: {integrity: sha512-/nVT+eFySYwf3uEv+n9FrdJ0bg3SbfqUkAnIxH7XMQ/hhmU4lAE2dH4SiUqk6h70gESaFHfJmhWtp5Qzt/W7Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@voidzero-dev/vite-plus-test@0.1.21':
     resolution: {integrity: sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ==}
@@ -5307,24 +5389,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,10 +4,28 @@ packages:
   - "tooling/*"
   - "examples/*"
 
+# Pinned (not `latest`) so a new Vite+ release can't turn CI red with zero
+# repo changes — toolchain bumps land as deliberate, reviewable PRs.
 catalog:
-  vite: "npm:@voidzero-dev/vite-plus-core@latest"
-  vitest: "npm:@voidzero-dev/vite-plus-test@latest"
-  vite-plus: "latest"
+  vite: "npm:@voidzero-dev/vite-plus-core@0.1.21"
+  vitest: "npm:@voidzero-dev/vite-plus-test@0.1.21"
+  vite-plus: "0.1.21"
+
+# Supply-chain defense: a newly published version can't be installed until it
+# has been public for 7 days (value in minutes), blunting the npm
+# publish-malware-then-yank window. `--frozen-lockfile` installs from the
+# resolved lockfile and doesn't re-resolve, so this only gates new deps/bumps.
+minimumReleaseAge: 10080
+# Exempt the Vite+ toolchain: it's pinned exactly above and bumped on purpose,
+# so the grace period shouldn't stall a deliberate toolchain upgrade. Listed by
+# both the catalog alias (`vite`/`vitest` — always aliased to vite-plus via
+# `overrides`, the real packages are never installed) and the real names.
+minimumReleaseAgeExclude:
+  - "vite"
+  - "vitest"
+  - "vite-plus"
+  - "@voidzero-dev/vite-plus-core"
+  - "@voidzero-dev/vite-plus-test"
 
 onlyBuiltDependencies:
   - esbuild

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
 		exclude: ["**/node_modules/**", "**/dist/**"],
 	},
 	staged: {
-		"*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,json,jsonc}": "vp check --fix",
+		// Include md/mdx/css so prose + styles are auto-formatted on commit.
+		// `vp check` checks them in CI, so the staged set must match or content
+		// edits drift red (the gap that left 21 apps/web files unformatted).
+		"*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,json,jsonc,md,mdx,css}": "vp check --fix",
 	},
 });


### PR DESCRIPTION
## Why

CI on `v1` was **red** and nobody noticed: `ci.yml` only triggered on push to `main` + PRs (never on push to `v1`), and CLAUDE.md declared failing tests "acceptable on v1". Two reds had accumulated on `v1` HEAD:

- **Format**: 21 `apps/web` files (content `.md`/`.mdx` + `styles.css`) unformatted — the pre-commit staged glob only auto-fixed `.js/.ts/.json`, so prose edits bypassed the formatter locally but `vp check` checks them in CI.
- **Tests**: the root aggregate `vp test` drops per-package `vite.config.ts`, so `solid` rendered SSR-only (15 failing) and `svelte` was excluded entirely.

## Make it green

- Formatted the 21 files (`vp check --fix`) and widened the staged glob to `md,mdx,css` so content can't drift red again.
- CI test step → `vp run -r test` (per-package, dep order) so each package's own Vite plugins apply. Fixes `solid` + `svelte`; the svelte exclusion is gone (closes the PS-15 follow-up).

## Keep it green / hardening

- **Gate `v1`**: CI now runs on push to `v1`, not just PRs.
- **Pin the Vite+ catalog** (`latest` → `0.1.21`): a new upstream release can no longer turn CI red with zero repo changes; toolchain bumps become deliberate, reviewable PRs. Lockfile diff is purely the specifier string — zero version churn.
- **7-day dependency grace period** (`minimumReleaseAge: 10080`): newly published versions can't be installed until public for 7 days (npm publish-malware-then-yank defense). CI is unaffected — `--frozen-lockfile` never re-resolves; the gate only bites deliberate dep changes. The pinned Vite+ toolchain is excluded so intentional upgrades aren't stalled.
- **pre-push hook** builds before `check-types` (it false-negatived after any `@openpolicy/core` change because packages export from `./dist`).
- **knip** now runs in CI **non-blocking** (`continue-on-error: true`) — surfaces dead deps/exports without re-redding the pipeline.
- **Refreshed stale CLAUDE.md**: real package list, OpenCookies/site-merge reality, and "`v1` must stay green" replacing the old stance.

Verified locally end-to-end: `vp install --frozen-lockfile && vp run -r build && vp check && vp run -r check-types && vp run -r test` → all green.

## Follow-ups (not in this PR)

- **knip → blocking**: retune per-workspace `entry`/`project` in `knip.json` to real library entrypoints, drive findings to zero, drop `continue-on-error`.
- 4 non-fatal `state_referenced_locally` Svelte warnings in `packages/svelte/src/__tests__/Harness.svelte`.
- **Recommended repo setting** (maintainer action): add a GitHub branch ruleset requiring the `ci` check to pass before merge into `v1` and `main` — code-level CI gating only helps if merges are actually blocked on it.
- Note for future deliberate dep bumps that pull a <7-day-old version: regenerate the lockfile once with `pnpm install --config.minimumReleaseAge=0`, then commit the reviewed lockfile (CI's frozen install stays clean).

No changeset (1.0 work, per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)