### PR TITLE
PS-29: `openpolicy mcp` server — 6 frozen tools, no drift

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,8 +24,11 @@
 		"test": "vp test"
 	},
 	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.29.0",
+		"@openpolicy/vite": "workspace:*",
 		"bundle-require": "^5.1.0",
-		"esbuild": "^0.25.12"
+		"esbuild": "^0.25.12",
+		"zod": "^3.25.76"
 	},
 	"devDependencies": {
 		"@openpolicy/core": "workspace:*",

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,13 @@
+import { defineCommand } from "citty";
+import { runMcp } from "../mcp/server";
+
+export const mcpCommand = defineCommand({
+	meta: {
+		name: "mcp",
+		description:
+			"Run the PolicyStack MCP server over stdio. Exposes validate_config, scaffold_config, explain_jurisdiction, list_data_categories, explain_issue, and scan_ungated — all resolved against the frozen SDK surface (no drift).",
+	},
+	async run() {
+		await runMcp();
+	},
+});

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -79,17 +79,22 @@ function reportHuman(result: ValidateResult): void {
 	}
 }
 
-export async function runValidate(args: {
+/**
+ * The pure core of `openpolicy validate`: resolve the config path, load it, run
+ * the frozen {@link validate}, and return the {@link ValidateResult}. No I/O
+ * side effects (no stdout, no `process.exitCode`) — `runValidate` adds those,
+ * and the `policystack mcp` `validate_config` tool (PS-29) reuses *this*
+ * directly because its stdout is the MCP stdio transport and must stay clean.
+ */
+export async function resolveValidateResult(args: {
 	cwd: string;
 	config?: string;
-	json: boolean;
 }): Promise<ValidateResult> {
 	const cwd = resolve(args.cwd);
 	const file = resolveStubPath(cwd, args.config);
 
-	let result: ValidateResult;
 	if (!existsSync(file)) {
-		result = {
+		return {
 			ok: false,
 			config: file,
 			issues: [],
@@ -97,30 +102,36 @@ export async function runValidate(args: {
 			warningCount: 0,
 			loadError: `No config found at ${file} — pass a path or run \`openpolicy init\` first.`,
 		};
-	} else {
-		const { config, loadError } = await loadConfig(file);
-		if (loadError || !config) {
-			result = {
-				ok: false,
-				config: file,
-				issues: [],
-				errorCount: 0,
-				warningCount: 0,
-				loadError: (loadError ?? new Error(`${file} did not load`)).message,
-			};
-		} else {
-			const issues = validate(config);
-			const errorCount = issues.filter((i) => i.level === "error").length;
-			result = {
-				ok: errorCount === 0,
-				config: file,
-				issues,
-				errorCount,
-				warningCount: issues.length - errorCount,
-				loadError: null,
-			};
-		}
 	}
+	const { config, loadError } = await loadConfig(file);
+	if (loadError || !config) {
+		return {
+			ok: false,
+			config: file,
+			issues: [],
+			errorCount: 0,
+			warningCount: 0,
+			loadError: (loadError ?? new Error(`${file} did not load`)).message,
+		};
+	}
+	const issues = validate(config);
+	const errorCount = issues.filter((i) => i.level === "error").length;
+	return {
+		ok: errorCount === 0,
+		config: file,
+		issues,
+		errorCount,
+		warningCount: issues.length - errorCount,
+		loadError: null,
+	};
+}
+
+export async function runValidate(args: {
+	cwd: string;
+	config?: string;
+	json: boolean;
+}): Promise<ValidateResult> {
+	const result = await resolveValidateResult({ cwd: args.cwd, config: args.config });
 
 	if (args.json) {
 		// `--json` contract: exactly one JSON object on stdout, nothing else.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ export const mainCommand = defineCommand({
 	subCommands: {
 		init: () => import("./commands/init").then((m) => m.initCommand),
 		validate: () => import("./commands/validate").then((m) => m.validateCommand),
+		mcp: () => import("./commands/mcp").then((m) => m.mcpCommand),
 	},
 });
 

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -1,0 +1,135 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ISSUE_CATALOG, JURISDICTION_IDS } from "@openpolicy/core";
+import { expect, test } from "vite-plus/test";
+import { createMcpServer } from "./server";
+import { TOOL_NAMES } from "./tools";
+
+async function connect(): Promise<Client> {
+	const server = createMcpServer();
+	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+	const client = new Client({ name: "test", version: "0.0.0" });
+	await server.connect(serverTransport);
+	await client.connect(clientTransport);
+	return client;
+}
+
+/** Pull a property's JSON-schema `enum` off a listed tool's inputSchema. */
+function propEnum(inputSchema: unknown, prop: string): string[] {
+	const s = inputSchema as { properties?: Record<string, { enum?: string[] }> };
+	return s.properties?.[prop]?.enum ?? [];
+}
+
+type CallResult = Awaited<ReturnType<Client["callTool"]>>;
+
+function structured(res: CallResult): Record<string, unknown> {
+	return (res.structuredContent ?? {}) as Record<string, unknown>;
+}
+
+test("exposes exactly the six frozen tools", async () => {
+	const client = await connect();
+	const { tools } = await client.listTools();
+	expect(tools.map((t) => t.name).sort()).toEqual([...TOOL_NAMES].sort());
+});
+
+// Drift canaries: the accepted enums ride the same frozen runtime tables the
+// compiler/validator use, so a §6 union change without an MCP update fails
+// here (the guarantee PS-27 gave llms.txt, now extended to the tool surface).
+test("explain_jurisdiction enum === the frozen JURISDICTION_IDS", async () => {
+	const client = await connect();
+	const { tools } = await client.listTools();
+	const tool = tools.find((t) => t.name === "explain_jurisdiction");
+	expect(propEnum(tool?.inputSchema, "jurisdiction").sort()).toEqual([...JURISDICTION_IDS].sort());
+});
+
+test("explain_issue enum === the frozen ISSUE_CATALOG keys", async () => {
+	const client = await connect();
+	const { tools } = await client.listTools();
+	const tool = tools.find((t) => t.name === "explain_issue");
+	expect(propEnum(tool?.inputSchema, "code").sort()).toEqual(Object.keys(ISSUE_CATALOG).sort());
+});
+
+test("explain_jurisdiction returns the live table value", async () => {
+	const client = await connect();
+	const res = await client.callTool({
+		name: "explain_jurisdiction",
+		arguments: { jurisdiction: "us-ca" },
+	});
+	const sc = structured(res);
+	expect(sc.id).toBe("us-ca");
+	expect(sc.consentModel).toBe("opt-out");
+	expect(sc.policyText).toBe("specific");
+	expect(sc.parent).toBe("us");
+	expect(sc.gpcLegallyBinding).toBe(true);
+});
+
+test("explain_issue returns the live catalog entry", async () => {
+	const code = "data-context-missing";
+	const client = await connect();
+	const res = await client.callTool({ name: "explain_issue", arguments: { code } });
+	const sc = structured(res);
+	expect(sc.code).toBe(code);
+	expect(sc.level).toBe(ISSUE_CATALOG[code].level);
+	expect(sc.summary).toBe(ISSUE_CATALOG[code].summary);
+	expect(sc.fix).toBe(ISSUE_CATALOG[code].fix);
+});
+
+test("scaffold_config returns a defineConfig stub", async () => {
+	const client = await connect();
+	const res = await client.callTool({ name: "scaffold_config", arguments: {} });
+	const sc = structured(res);
+	expect(sc.filename).toBe("openpolicy.ts");
+	expect(String(sc.contents)).toContain("defineConfig");
+	expect(sc.llmsTxt).toBeUndefined();
+	const withLlms = structured(
+		await client.callTool({ name: "scaffold_config", arguments: { includeLlmsTxt: true } }),
+	);
+	expect(String(withLlms.llmsTxt)).toContain("PolicyStack SDK reference");
+});
+
+test("list_data_categories returns the SDK presets", async () => {
+	const client = await connect();
+	const sc = structured(await client.callTool({ name: "list_data_categories", arguments: {} }));
+	expect(sc.dataCategories).toMatchObject({ AccountInfo: {} });
+	expect(sc.legalBases).toMatchObject({ Consent: "consent" });
+	expect(sc.retention).toBeDefined();
+	expect(sc.providers).toBeDefined();
+	expect(sc.compliance).toBeDefined();
+});
+
+test("validate_config reports a missing config (ok:false)", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "ps29-"));
+	const client = await connect();
+	const sc = structured(
+		await client.callTool({ name: "validate_config", arguments: { cwd: dir } }),
+	);
+	expect(sc.ok).toBe(false);
+	expect(typeof sc.loadError).toBe("string");
+});
+
+test("scan_ungated returns a ScanResult shape on an empty dir", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "ps29-scan-"));
+	const client = await connect();
+	const sc = structured(await client.callTool({ name: "scan_ungated", arguments: { cwd: dir } }));
+	expect(Array.isArray(sc.cookies)).toBe(true);
+	expect(Array.isArray(sc.vendors)).toBe(true);
+	expect(Array.isArray(sc.ungated)).toBe(true);
+});
+
+test("rejects an unknown jurisdiction id", async () => {
+	const client = await connect();
+	let errored = false;
+	try {
+		const res = await client.callTool({
+			name: "explain_jurisdiction",
+			arguments: { jurisdiction: "zz" },
+		});
+		errored = res.isError === true;
+	} catch {
+		errored = true;
+	}
+	expect(errored).toBe(true);
+});

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -1,0 +1,27 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import pkgJson from "../../package.json";
+import { registerTools } from "./tools";
+
+/**
+ * Build the `openpolicy mcp` server with its six frozen tools registered, but
+ * NOT connected to a transport. Pure and side-effect-free so the drift test
+ * can drive it over an in-memory transport without a subprocess (PS-29).
+ */
+export function createMcpServer(): McpServer {
+	const server = new McpServer({ name: "openpolicy", version: pkgJson.version });
+	registerTools(server);
+	return server;
+}
+
+/**
+ * Run the server over stdio — the universal transport for an agent-launched
+ * server (Claude Code, the PS-32 skill pack). stdout is the protocol channel,
+ * so every tool path here is deliberately side-effect-free (no console/stdout
+ * writes; `validate_config` reuses the pure `resolveValidateResult`).
+ */
+export async function runMcp(): Promise<void> {
+	const server = createMcpServer();
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+}

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,0 +1,163 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+	ISSUE_CATALOG,
+	type IssueCode,
+	JURISDICTION_IDS,
+	type JurisdictionId,
+} from "@openpolicy/core";
+import {
+	Compliance,
+	DataCategories,
+	describeJurisdiction,
+	LegalBases,
+	Providers,
+	renderLlmsTxt,
+	Retention,
+} from "@openpolicy/sdk";
+import { scan } from "@openpolicy/vite/consent";
+import { z } from "zod";
+import { resolveValidateResult } from "../commands/validate";
+import { getStubContents } from "../utils/stub";
+
+/**
+ * The frozen tool surface of `openpolicy mcp` (PS-29). Exactly these six names;
+ * the drift test pins this list, and every enum below is built at *runtime*
+ * from the frozen core tables — never a hand-typed copy — so a §6 union change
+ * without a matching MCP update fails CI (the same guarantee PS-27 gave
+ * `llms.txt`).
+ */
+export const TOOL_NAMES = [
+	"validate_config",
+	"scaffold_config",
+	"explain_jurisdiction",
+	"list_data_categories",
+	"explain_issue",
+	"scan_ungated",
+] as const;
+
+export type ToolName = (typeof TOOL_NAMES)[number];
+
+// Runtime-derived enums — the no-drift seam. `JURISDICTION_IDS` and
+// `Object.keys(ISSUE_CATALOG)` ARE the frozen unions at runtime.
+const jurisdictionIds = [...JURISDICTION_IDS] as [JurisdictionId, ...JurisdictionId[]];
+const issueCodes = Object.keys(ISSUE_CATALOG) as IssueCode[] as [IssueCode, ...IssueCode[]];
+
+type JsonObject = Record<string, unknown>;
+
+/** Standard MCP tool result: structured payload + a JSON text rendering. */
+function result(structured: JsonObject) {
+	return {
+		content: [{ type: "text" as const, text: JSON.stringify(structured, null, 2) }],
+		structuredContent: structured,
+	};
+}
+
+export function registerTools(server: McpServer): void {
+	server.registerTool(
+		"validate_config",
+		{
+			title: "Validate an openpolicy config",
+			description:
+				"Run the frozen validate() over the project's openpolicy config and return the structured ValidateResult ({ ok, config, issues, errorCount, warningCount, loadError }). Same result the `openpolicy validate --json` command emits. Use explain_issue for any returned code.",
+			inputSchema: {
+				cwd: z
+					.string()
+					.optional()
+					.describe("Project directory (defaults to the server's working directory)"),
+				config: z
+					.string()
+					.optional()
+					.describe("Path to the config (defaults to src/openpolicy.ts, else openpolicy.ts)"),
+			},
+		},
+		async ({ cwd, config }) => {
+			const r = await resolveValidateResult({ cwd: cwd ?? process.cwd(), config });
+			return result(r);
+		},
+	);
+
+	server.registerTool(
+		"scaffold_config",
+		{
+			title: "Scaffold a starter openpolicy config",
+			description:
+				"Return the contents of a minimal `defineConfig()` starter (the same stub `openpolicy init` writes). Set includeLlmsTxt to also get the canonical SDK reference to fill it in. Does not write any files.",
+			inputSchema: {
+				includeLlmsTxt: z
+					.boolean()
+					.optional()
+					.describe("Also return the generated llms.txt SDK reference"),
+			},
+		},
+		async ({ includeLlmsTxt }) =>
+			result({
+				filename: "openpolicy.ts",
+				contents: getStubContents(),
+				...(includeLlmsTxt ? { llmsTxt: renderLlmsTxt() } : {}),
+			}),
+	);
+
+	server.registerTool(
+		"explain_jurisdiction",
+		{
+			title: "Explain a jurisdiction id",
+			description:
+				"Explain a frozen JurisdictionId: its consent posture, policy-text tier, parent jurisdiction, and whether GPC is legally binding. Same derivation as llms.txt.",
+			inputSchema: {
+				jurisdiction: z
+					.enum(jurisdictionIds)
+					.describe("A frozen jurisdiction id (e.g. eea, uk, us-ca)"),
+			},
+		},
+		async ({ jurisdiction }) => result(describeJurisdiction(jurisdiction)),
+	);
+
+	server.registerTool(
+		"list_data_categories",
+		{
+			title: "List the SDK presets",
+			description:
+				"List the @openpolicy/sdk preset objects an agent can reference when authoring a config: data categories, lawful bases, retention periods, third-party providers, and compliance bundles. Categories in a real config are user-defined; these are the canonical examples (same set enumerated in llms.txt).",
+		},
+		async () =>
+			result({
+				dataCategories: DataCategories,
+				legalBases: LegalBases,
+				retention: Retention,
+				providers: Providers,
+				compliance: Compliance,
+			}),
+	);
+
+	server.registerTool(
+		"explain_issue",
+		{
+			title: "Explain a validate() issue code",
+			description:
+				"Explain a frozen IssueCode emitted by validate()/validate_config: its level (error|warning), a config-independent summary, and the remediation. Pair with validate_config to close the audit loop.",
+			inputSchema: {
+				code: z.enum(issueCodes).describe("A frozen IssueCode (e.g. data-context-missing)"),
+			},
+		},
+		async ({ code }) => result({ code, ...ISSUE_CATALOG[code] }),
+	);
+
+	server.registerTool(
+		"scan_ungated",
+		{
+			title: "Scan for un-consented cookie/vendor usage",
+			description:
+				"Statically scan a project's source for cookie writes and tracking-vendor usage that is NOT behind a consent gate. Returns { cookies, vendors, ungated } — `ungated` is the actionable list. Uses the same scanner as the @openpolicy/vite consent island.",
+			inputSchema: {
+				cwd: z
+					.string()
+					.optional()
+					.describe("Project directory to scan (defaults to the server's working directory)"),
+			},
+		},
+		async ({ cwd }) => {
+			const r = await scan({ cwd: cwd ?? process.cwd() });
+			return result({ cwd: cwd ?? process.cwd(), ...r });
+		},
+	);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,8 @@ export { Contractual, ContractPrerequisite, Statutory, Voluntary } from "./provi
 export { computeCookieVersion, computePrivacyVersion } from "./policy-version";
 export { deriveUserRights } from "./user-rights";
 export { validate } from "./validate";
+export { ISSUE_CATALOG } from "./issue-catalog";
+export type { IssueExplanation } from "./issue-catalog";
 export { createT, isLocale, LOCALES } from "./i18n";
 export type { Dictionary, T } from "./i18n";
 

--- a/packages/core/src/issue-catalog.ts
+++ b/packages/core/src/issue-catalog.ts
@@ -1,0 +1,186 @@
+import type { IssueCode } from "./types";
+
+/**
+ * The static, agent-facing explanation for one {@link IssueCode}. `validate()`
+ * still emits its own *contextual* `message` (interpolated with the offending
+ * key) — this is the stable, config-independent summary + remediation an agent
+ * reads to act on a code, surfaced by the `explain_issue` MCP tool (PS-29).
+ *
+ * `level` mirrors exactly what `validate()` emits for the code; it is repeated
+ * here so the catalog is self-contained (the MCP tool never has to run a
+ * validation to know whether a code is fatal).
+ */
+export type IssueExplanation = {
+	level: "error" | "warning";
+	summary: string;
+	fix: string;
+};
+
+/**
+ * Frozen explanation table for every {@link IssueCode} (§6 freeze, PS-29).
+ *
+ * This is the **no-drift guard**: the `Record<IssueCode, …>` literal is
+ * compiler-exhaustive, so adding or removing an `IssueCode` without updating
+ * this table is a type error (the same mechanism the frozen `Visitor<R>` map
+ * uses). `Object.keys(ISSUE_CATALOG)` is therefore the canonical *runtime*
+ * enumeration of issue codes — the MCP `explain_issue` tool builds its accepted
+ * enum from it, and a drift test pins it to the live union.
+ *
+ * `validate()` is deliberately **not** rewired to source its messages from
+ * here: it stays the pure, frozen validator (PS-11/PS-13). `summary` mirrors
+ * the trailing `//` annotation on the `IssueCode` union; `fix` is the
+ * actionable remediation distilled from the validator's own message.
+ */
+export const ISSUE_CATALOG: Record<IssueCode, IssueExplanation> = {
+	"effective-date-required": {
+		level: "error",
+		summary: "effectiveDate is missing.",
+		fix: "Set `effectiveDate` to the policy's effective date as a `YYYY-MM-DD` string.",
+	},
+	"company-name-required": {
+		level: "error",
+		summary: "company.name is missing.",
+		fix: "Set `company.name` to the public-facing name of the entity.",
+	},
+	"company-legal-name-required": {
+		level: "error",
+		summary: "company.legalName is missing.",
+		fix: "Set `company.legalName` to the registered legal entity name.",
+	},
+	"company-address-required": {
+		level: "error",
+		summary: "company.address is missing.",
+		fix: "Set `company.address` to the company's registered postal address.",
+	},
+	"company-contact-required": {
+		level: "error",
+		summary: "company.contact.email is missing.",
+		fix: "Set `company.contact.email` to a monitored privacy contact address.",
+	},
+	"jurisdictions-required": {
+		level: "error",
+		summary: "jurisdictions is empty.",
+		fix: "Add at least one jurisdiction id to `jurisdictions` (see the `explain_jurisdiction` tool for valid codes).",
+	},
+	"jurisdiction-unknown": {
+		level: "error",
+		summary: "A jurisdictions entry is not a recognised JurisdictionId.",
+		fix: "Replace it with a valid jurisdiction id; an unlisted `us-<state>` code falls back to `us`.",
+	},
+	"locale-unknown": {
+		level: "error",
+		summary: "locale is not one of the supported LOCALES.",
+		fix: "Set `locale` to a supported locale, or omit it to default to `en`.",
+	},
+	"policy-empty": {
+		level: "error",
+		summary: "The config produces no policy at all.",
+		fix: "Provide data-handling fields (`data`, `children`) or `cookies` so at least one policy is emitted.",
+	},
+	"policy-cookie-empty": {
+		level: "error",
+		summary: 'policies includes "cookie" but cookies is unset.',
+		fix: 'Add a `cookies` block, or remove `"cookie"` from `policies`.',
+	},
+	"data-missing": {
+		level: "error",
+		summary: "data is required (a privacy policy is emitted) but omitted.",
+		fix: "Add a `data` block; use an empty `data.collected` for a site that collects nothing.",
+	},
+	"data-collected-empty": {
+		level: "warning",
+		summary: "data.collected has no entries.",
+		fix: "Add the collected categories if the site does collect personal data; otherwise the policy states none is collected.",
+	},
+	"data-context-missing": {
+		level: "error",
+		summary: "A collected category has no matching data.context entry.",
+		fix: "Add `data.context[category]` with purpose, lawful basis, retention, and provision.",
+	},
+	"data-context-orphan": {
+		level: "error",
+		summary: "A data.context entry has no matching data.collected category.",
+		fix: "Remove the orphan context entry, or declare its collected fields in `data.collected`.",
+	},
+	"data-purpose-missing": {
+		level: "error",
+		summary: "A data.context entry lacks a purpose (GDPR Art. 13(1)(c)).",
+		fix: "Set `data.context[category].purpose` to the processing purpose.",
+	},
+	"data-purpose-empty": {
+		level: "error",
+		summary: "A data.context purpose is blank.",
+		fix: "Set `data.context[category].purpose` to a non-empty string.",
+	},
+	"lawful-basis-incomplete": {
+		level: "error",
+		summary: "A collected category lacks an Article 6 lawful basis (GDPR Art. 13(1)(c)).",
+		fix: "Set `data.context[category].lawfulBasis` to an Article 6 lawful basis (see the `explain_jurisdiction`/lawful-basis reference).",
+	},
+	"statutory-contractual-obligation": {
+		level: "error",
+		summary: "GDPR Art. 13(2)(e) provision disclosure is missing or has empty consequences.",
+		fix: "Set `data.context[category].provision` with Statutory/Contractual/ContractPrerequisite/Voluntary and non-empty consequences.",
+	},
+	"retention-incomplete": {
+		level: "error",
+		summary: "A collected category has no retention period.",
+		fix: "Set `data.context[category].retention` to a non-empty retention period.",
+	},
+	"automated-decision-making": {
+		level: "warning",
+		summary: "GDPR Art. 13(2)(f) automated decision-making is not declared.",
+		fix: "Set `automatedDecisionMaking: []` to declare none, or list each activity with its logic and significance.",
+	},
+	"children-under-age-invalid": {
+		level: "error",
+		summary: "children.underAge is not a positive number.",
+		fix: "Set `children.underAge` to a positive integer.",
+	},
+	"company-dpo-undeclared": {
+		level: "warning",
+		summary: "GDPR Art. 13(1)(b) Data Protection Officer contact is undeclared.",
+		fix: "Set `company.dpo`, or `company.dpo = { required: false }` to declare none is needed.",
+	},
+	"company-contact-phone-recommended": {
+		level: "warning",
+		summary: "CCPA §1798.130(a)(1) toll-free phone is absent (us-ca declared).",
+		fix: "Set `company.contact.phone`, unless you operate exclusively online.",
+	},
+	"cookies-empty": {
+		level: "error",
+		summary: "No cookie category is enabled.",
+		fix: "Enable at least one cookie type in `cookies.used` (essential, analytics, functional, or marketing).",
+	},
+	"cookie-lawful-basis-missing": {
+		level: "error",
+		summary: "An enabled cookie category lacks a lawful basis.",
+		fix: "Set `cookies.context[key].lawfulBasis` for every enabled cookie category.",
+	},
+	"consent-mechanism-undeclared": {
+		level: "warning",
+		summary: "consentMechanism is absent.",
+		fix: "Add a `consentMechanism` describing how users manage cookie consent.",
+	},
+	"consent-withdrawal-required": {
+		level: "warning",
+		summary: "Consent withdrawal is not enabled under GDPR/UK scope.",
+		fix: "Set `consentMechanism.canWithdraw` to true.",
+	},
+	"consent-banner-required": {
+		level: "warning",
+		summary: "A consent-gated category exists but consentMechanism.hasBanner is false.",
+		fix: "Set `consentMechanism.hasBanner` to true so affirmative consent can be collected.",
+	},
+	"consent-preference-panel-required": {
+		level: "warning",
+		summary: "canWithdraw is true but hasPreferencePanel is false.",
+		fix: "Set `consentMechanism.hasPreferencePanel` to true so withdrawal has a panel.",
+	},
+	"jurisdiction-generic-policy-text": {
+		level: "warning",
+		summary:
+			"A declared jurisdiction ships only equivalent (parent) policy text, not hand-authored specific text.",
+		fix: "Acceptable if the equivalent tier suffices; otherwise pick a jurisdiction supported at the specific tier (see the `explain_jurisdiction` tool).",
+	},
+};

--- a/packages/sdk/src/describe.ts
+++ b/packages/sdk/src/describe.ts
@@ -1,0 +1,60 @@
+import {
+	type ConsentModel,
+	isConsentGated,
+	type JurisdictionId,
+	JURISDICTION_TABLE,
+	type LegalBasis,
+} from "@openpolicy/core";
+
+/**
+ * One source of truth for the human description of a frozen jurisdiction /
+ * lawful basis. Both `renderLlmsTxt()` and the `policystack mcp` tools
+ * (`explain_jurisdiction`, the lawful-basis reference) call these, so the
+ * agent-facing prose provably cannot drift between `llms.txt` and the MCP
+ * server (PS-29). `summary` is the exact line `llms.txt` already shipped — keep
+ * it byte-stable (the `llms.test.ts` drift guard pins it).
+ */
+export type JurisdictionDescription = {
+	id: JurisdictionId;
+	consentModel: ConsentModel;
+	policyText: "specific" | "equivalent";
+	parent: JurisdictionId | null;
+	gpcLegallyBinding: boolean;
+	/** One-line summary, without the leading `- ` list marker. */
+	summary: string;
+};
+
+export function describeJurisdiction(id: JurisdictionId): JurisdictionDescription {
+	const cap = JURISDICTION_TABLE[id];
+	const parent = cap.parent ?? null;
+	const parentText = parent ? `, inherits \`${parent}\`` : "";
+	const gpc = cap.gpcLegallyBinding ? ", GPC legally binding" : "";
+	return {
+		id,
+		consentModel: cap.consentModel,
+		policyText: cap.policyText,
+		parent,
+		gpcLegallyBinding: cap.gpcLegallyBinding,
+		summary: `\`${id}\` — ${cap.consentModel}, ${cap.policyText} policy text${parentText}${gpc}`,
+	};
+}
+
+export type LawfulBasisDescription = {
+	basis: LegalBasis;
+	consentGated: boolean;
+	/** One-line summary, without the leading `- ` list marker. */
+	summary: string;
+};
+
+export function describeLawfulBasis(basis: LegalBasis): LawfulBasisDescription {
+	const gated = isConsentGated(basis);
+	return {
+		basis,
+		consentGated: gated,
+		summary: `\`${basis}\` — ${
+			gated
+				? "consent-gated (toggleable in the banner)"
+				: "standing legal ground (category renders locked-on)"
+		}`,
+	};
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -38,9 +38,11 @@ export {
 	Contractual,
 	ContractPrerequisite,
 	createT,
+	ISSUE_CATALOG,
 	Statutory,
 	Voluntary,
 } from "@openpolicy/core";
+export type { IssueExplanation } from "@openpolicy/core";
 
 export type {
 	ScannedCollectionKeys,
@@ -49,6 +51,8 @@ export type {
 } from "./auto-collected";
 export { collecting, Ignore } from "./collecting";
 export { Compliance } from "./compliance";
+export { describeJurisdiction, describeLawfulBasis } from "./describe";
+export type { JurisdictionDescription, LawfulBasisDescription } from "./describe";
 export { renderLlmsTxt } from "./llms";
 export { DataCategories, LegalBases, Retention } from "./data";
 export { defineCookie } from "./define-cookie";

--- a/packages/sdk/src/llms.ts
+++ b/packages/sdk/src/llms.ts
@@ -1,11 +1,13 @@
 import {
-	isConsentGated,
+	type JurisdictionId,
 	JURISDICTION_TABLE,
 	LAWFUL_BASIS_CONSENT_GATED,
+	type LegalBasis,
 	LOCALES,
 } from "@openpolicy/core";
 import { Compliance } from "./compliance";
 import { DataCategories, LegalBases, Retention } from "./data";
+import { describeJurisdiction, describeLawfulBasis } from "./describe";
 import { Providers } from "./providers";
 
 /**
@@ -25,20 +27,15 @@ import { Providers } from "./providers";
  * provider and this document updates with it.
  */
 export function renderLlmsTxt(): string {
-	const jurisdictionRows = Object.entries(JURISDICTION_TABLE)
-		.sort(([a], [b]) => a.localeCompare(b))
-		.map(([id, cap]) => {
-			const parent = cap.parent ? `, inherits \`${cap.parent}\`` : "";
-			const gpc = cap.gpcLegallyBinding ? ", GPC legally binding" : "";
-			return `- \`${id}\` — ${cap.consentModel}, ${cap.policyText} policy text${parent}${gpc}`;
-		});
+	// Both row sets are derived from the shared `describe*` helpers — the same
+	// source the `policystack mcp` tools use, so the prose cannot drift (PS-29).
+	const jurisdictionRows = Object.keys(JURISDICTION_TABLE)
+		.sort((a, b) => a.localeCompare(b))
+		.map((id) => `- ${describeJurisdiction(id as JurisdictionId).summary}`);
 
-	const lawfulBasisRows = Object.entries(LAWFUL_BASIS_CONSENT_GATED)
-		.sort(([a], [b]) => a.localeCompare(b))
-		.map(([basis]) => {
-			const gated = isConsentGated(basis as keyof typeof LAWFUL_BASIS_CONSENT_GATED);
-			return `- \`${basis}\` — ${gated ? "consent-gated (toggleable in the banner)" : "standing legal ground (category renders locked-on)"}`;
-		});
+	const lawfulBasisRows = Object.keys(LAWFUL_BASIS_CONSENT_GATED)
+		.sort((a, b) => a.localeCompare(b))
+		.map((basis) => `- ${describeLawfulBasis(basis as LegalBasis).summary}`);
 
 	const localeList = [...LOCALES]
 		.sort()

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -23,6 +23,10 @@
 		".": {
 			"import": "./dist/index.js",
 			"types": "./dist/index.d.ts"
+		},
+		"./consent": {
+			"import": "./dist/consent.js",
+			"types": "./dist/consent.d.ts"
 		}
 	},
 	"scripts": {

--- a/packages/vite/vite.config.ts
+++ b/packages/vite/vite.config.ts
@@ -2,7 +2,15 @@ import { defineConfig } from "vite-plus";
 
 export default defineConfig({
 	pack: {
-		entry: "./src/index.ts",
+		// `./consent` is a second entry/chunk (the standalone scanner, PS-19):
+		// the `policystack mcp` server's `scan_ungated` tool imports it without
+		// pulling in the Vite plugin. `oxc-parser`/`tinyglobby` stay external
+		// (they are runtime `dependencies`), so the native binding is not
+		// bundled into either chunk.
+		entry: {
+			index: "./src/index.ts",
+			consent: "./src/consent/index.ts",
+		},
 		format: "esm",
 		dts: true,
 		platform: "node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,12 +282,21 @@ importers:
 
   packages/cli:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      '@openpolicy/vite':
+        specifier: workspace:*
+        version: link:../vite
       bundle-require:
         specifier: ^5.1.0
         version: 5.1.0(esbuild@0.25.12)
       esbuild:
         specifier: ^0.25.12
         version: 0.25.12
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@openpolicy/core':
         specifier: workspace:*


### PR DESCRIPTION
## Context

`PS-29` ([Linear](https://linear.app/open-policy/issue/PS-29/policystack-mcp-server)) — the highest-leverage DX bet of Phase 5, and the **blocker for PS-32** (AI skill pack). Its own blocker, PS-23 (§4.1 bridge), is Done.

Adds an `mcp` subcommand to `@openpolicy/cli` that runs a Model Context Protocol server over **stdio**, exposing six tools to coding agents — every one resolved against the frozen §6 surface so it **cannot drift** (the guarantee PS-27 gave `llms.txt`, now extended to the tool surface).

## The six tools

| Tool | Source of truth (reused) |
|---|---|
| `validate_config` | pure `resolveValidateResult()` extracted from the `validate` command (frozen PS-28 `ValidateResult`) |
| `scaffold_config` | `getStubContents()` (+ optional `renderLlmsTxt()`) |
| `explain_jurisdiction` | shared `describeJurisdiction()` — same derivation as `llms.txt` |
| `list_data_categories` | the `@openpolicy/sdk` preset objects |
| `explain_issue` | **new frozen `ISSUE_CATALOG`** in `@openpolicy/core` |
| `scan_ungated` | the standalone consent scanner via a new `@openpolicy/vite` `./consent` export |

## No-drift mechanism

- `ISSUE_CATALOG: Record<IssueCode, {level,summary,fix}>` — the `Record<IssueCode,…>` literal is **compiler-exhaustive**, so it doubles as the freeze guard *and* the runtime issue-code enumeration. `validate()` is left untouched/frozen (PS-11/PS-13).
- Tool enums are built at runtime from `JURISDICTION_IDS` / `Object.keys(ISSUE_CATALOG)` — never hand-typed.
- Shared `describeJurisdiction`/`describeLawfulBasis` helpers feed **both** `renderLlmsTxt()` and the MCP server (`llms.txt` byte-stable; its drift test still green).
- Drift test (`packages/cli/src/mcp/server.test.ts`) drives the real MCP `Client` over an in-memory transport: asserts exactly the six tools and pins the `explain_*` enums to the live frozen tables — a §6 change without an MCP update fails CI.

## Verification

- `vp run -r build` · `vp run -r test` (cli 9 files/61 tests incl. drift test) · `vp check` (fmt+lint) · `vp run -r check-types` — **all green** (v1 stays green).
- Built bin smoke-tested over stdio: `tools/list` returns the six tools; `explain_jurisdiction(eea)` returns the live value whose `summary` is byte-identical to the `llms.txt` line.

No changeset (PS-* / 1.0 work). Targets `v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)