### PR TITLE
core: simplify — drop projection layer, unify jurisdiction/locale, decouple

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,18 +60,19 @@ pnpm --filter @policystack/cli exec tsx src/cli.ts --help
 ### Core compilation pipeline
 
 ```
-PolicyInput → compilePolicy() → section builders → PolicySection[] → renderer → string
+PolicyStackConfig → compilePrivacyPolicy()/compileCookiePolicy() → section builders → DocumentSection[] → renderer → string
 ```
 
-- **Section builders** are functions `(config) => PolicySection | null`. Returning `null` omits the section.
-- **`PolicyInput`** is a discriminated union: `{ type: "privacy" } & PrivacyPolicyConfig | { type: "cookie" } & CookiePolicyConfig`.
-- **Renderers** in `packages/core/src/renderers/` produce Markdown or HTML output.
+- **`PolicyStackConfig`** is the single, flat public config. There is no intermediate per-document projection — the section builders read it directly and derive values (`userRights`, `consentMechanism`, the per-document `version`) at their point of use.
+- **Section builders** are functions `(config: PolicyStackConfig, t) => DocumentSection | null`. Returning `null` omits the section.
+- **`compilePrivacyPolicy` / `compileCookiePolicy`** gate emission via `shouldEmit()` and return `Document | null`.
+- **Renderers** (`@policystack/renderers`) turn the `Document` tree into Markdown, HTML, or PDF.
 
 ### Adding a new section
 
 1. Add a builder function in `packages/core/src/documents/privacy.ts` or `documents/cookie.ts`.
-2. Register it in the relevant `compile*Document()` function.
-3. Add fields to `PrivacyPolicyConfig` or `CookiePolicyConfig` in `types.ts`.
+2. Register it in the relevant `compile*Document()` `SECTION_BUILDERS` array.
+3. Add any new fields to `PolicyStackConfig` in `types.ts`.
 4. Write tests in `packages/core/src/*.test.ts`.
 
 ## Testing

--- a/apps/web/content/docs/consent/core.md
+++ b/apps/web/content/docs/consent/core.md
@@ -224,10 +224,10 @@ if (repromptReason !== null) {
 
 `repromptReason` is one of `"policyVersion" | "categoriesAdded" | "expired" | "jurisdiction"`, in priority order — the first trigger to fire wins. Once the visitor makes a new decision (`acceptAll`, `acceptNecessary`, `reject`, or `save`), `repromptReason` clears, `getPreviousRecord()` returns `null`, and a fresh record is written via the adapter.
 
-For analytics, the store emits an `oncookies:reprompt` event on `globalThis` whenever a trigger fires, with `event.detail.reason` containing the trigger name:
+For analytics, the store emits a `policystack:reprompt` event on `globalThis` whenever a trigger fires, with `event.detail.reason` containing the trigger name:
 
 ```ts
-globalThis.addEventListener("oncookies:reprompt", (event) => {
+globalThis.addEventListener("policystack:reprompt", (event) => {
 	analytics.track("consent_reprompt", { reason: event.detail.reason });
 });
 ```

--- a/packages/angular/src/consent.service.ts
+++ b/packages/angular/src/consent.service.ts
@@ -6,7 +6,7 @@ import type {
 	ConsentRecord,
 	ConsentState,
 	ConsentStore,
-	Jurisdiction,
+	JurisdictionId,
 	RepromptReason,
 	Route,
 } from "@policystack/core/consent";
@@ -21,7 +21,7 @@ export class ConsentService {
 	readonly route: Signal<Route> = computed(() => this._state().route);
 	readonly categories: Signal<Category[]> = computed(() => this._state().categories);
 	readonly decisions: Signal<Record<string, boolean>> = computed(() => this._state().decisions);
-	readonly jurisdiction: Signal<Jurisdiction | null> = computed(() => this._state().jurisdiction);
+	readonly jurisdiction: Signal<JurisdictionId | null> = computed(() => this._state().jurisdiction);
 	readonly policyVersion: Signal<string> = computed(() => this._state().policyVersion);
 	readonly decidedAt: Signal<string | null> = computed(() => this._state().decidedAt);
 	readonly repromptReason: Signal<RepromptReason | null> = computed(

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -11,7 +11,7 @@ export type {
 	ConsentRecordSource,
 	ConsentState,
 	ConsentStore,
-	Jurisdiction,
+	JurisdictionId,
 	PolicyStackConsentConfig,
 	RepromptReason,
 	Route,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,15 +13,34 @@ This is an internal package used by `@policystack/sdk`, `@policystack/vite`, and
 
 ## Direct usage
 
-If you're building a custom integration (e.g. a framework plugin not covered by the official packages), you can use `compilePolicy` directly. It returns the rendered output in memory — the caller decides what to do with it (inject into a page, send over the wire, write to disk, etc.).
+If you're building a custom integration (e.g. a framework plugin not covered by the official packages), compile the document tree from a `PolicyStackConfig` with `compilePrivacyPolicy` / `compileCookiePolicy` (each returns a `Document` tree, or `null` when that policy is not emitted):
 
 ```ts
-import { compilePolicy } from "@policystack/core";
+import { compilePrivacyPolicy } from "@policystack/core";
+
+const doc = compilePrivacyPolicy({
+	effectiveDate: "2026-01-01",
+	jurisdictions: ["eea"],
+	company: {
+		name: "Acme",
+		legalName: "Acme, Inc.",
+		address: "...",
+		contact: { email: "privacy@acme.com" },
+	},
+	// ... rest of config
+});
+// doc is a Document AST you can render however you like, or null.
+```
+
+To render straight to strings/PDF in memory, use `compilePolicy` from `@policystack/renderers` — it takes the same flat config plus the policy type, and the caller decides what to do with the output (inject into a page, send over the wire, write to disk, etc.):
+
+```ts
+import { compilePolicy } from "@policystack/renderers";
 
 const results = await compilePolicy(
 	{
-		type: "privacy",
 		effectiveDate: "2026-01-01",
+		jurisdictions: ["eea"],
 		company: {
 			name: "Acme",
 			legalName: "Acme, Inc.",
@@ -30,6 +49,7 @@ const results = await compilePolicy(
 		},
 		// ... rest of config
 	},
+	"privacy",
 	{ formats: ["markdown", "html", "pdf"] },
 );
 

--- a/packages/core/src/consent/gpc.test.ts
+++ b/packages/core/src/consent/gpc.test.ts
@@ -4,7 +4,7 @@ import type { Category, ConsentState, PolicyStackConsentConfig } from "./types";
 
 describe("GPC_LEGALLY_REQUIRED_JURISDICTIONS", () => {
 	it("contains exactly the four legally-required US states", () => {
-		expect(GPC_LEGALLY_REQUIRED_JURISDICTIONS).toEqual(["US-CA", "US-CO", "US-CT", "US-VA"]);
+		expect(GPC_LEGALLY_REQUIRED_JURISDICTIONS).toEqual(["us-ca", "us-co", "us-ct", "us-va"]);
 	});
 });
 
@@ -50,30 +50,30 @@ describe("readGPCSignal", () => {
 
 describe("gpcApplies", () => {
 	it("defaults to applying in all jurisdictions", () => {
-		expect(gpcApplies("EEA", undefined)).toBe(true);
-		expect(gpcApplies("US", undefined)).toBe(true);
-		expect(gpcApplies("ROW", undefined)).toBe(true);
+		expect(gpcApplies("eea", undefined)).toBe(true);
+		expect(gpcApplies("us", undefined)).toBe(true);
+		expect(gpcApplies("row", undefined)).toBe(true);
 		expect(gpcApplies(null, undefined)).toBe(true);
 	});
 
 	it("does not apply when explicitly disabled", () => {
-		expect(gpcApplies("US-CA", { enabled: false })).toBe(false);
+		expect(gpcApplies("us-ca", { enabled: false })).toBe(false);
 	});
 
 	it("matches an explicit jurisdiction list", () => {
 		const config = { applicableJurisdictions: GPC_LEGALLY_REQUIRED_JURISDICTIONS };
-		expect(gpcApplies("US-CA", config)).toBe(true);
-		expect(gpcApplies("US-VA", config)).toBe(true);
-		expect(gpcApplies("EEA", config)).toBe(false);
-		expect(gpcApplies("US", config)).toBe(false);
+		expect(gpcApplies("us-ca", config)).toBe(true);
+		expect(gpcApplies("us-va", config)).toBe(true);
+		expect(gpcApplies("eea", config)).toBe(false);
+		expect(gpcApplies("us", config)).toBe(false);
 	});
 
 	it("returns false for null jurisdiction when scope is an explicit list", () => {
-		expect(gpcApplies(null, { applicableJurisdictions: ["US-CA"] })).toBe(false);
+		expect(gpcApplies(null, { applicableJurisdictions: ["us-ca"] })).toBe(false);
 	});
 
 	it('treats explicit "all" the same as default', () => {
-		expect(gpcApplies("EEA", { applicableJurisdictions: "all" })).toBe(true);
+		expect(gpcApplies("eea", { applicableJurisdictions: "all" })).toBe(true);
 		expect(gpcApplies(null, { applicableJurisdictions: "all" })).toBe(true);
 	});
 });
@@ -90,7 +90,7 @@ describe("applyGPC", () => {
 			route: "cookie",
 			categories: baseCategories,
 			decisions: { essential: true, analytics: true, marketing: true },
-			jurisdiction: "US-CA",
+			jurisdiction: "us-ca",
 			policyVersion: "",
 			decidedAt: null,
 			source: "default",
@@ -158,7 +158,7 @@ describe("applyGPC", () => {
 	});
 
 	it("is a no-op when jurisdiction is not in the explicit applicable list", () => {
-		const state = makeState({ jurisdiction: "EEA" });
+		const state = makeState({ jurisdiction: "eea" });
 		const next = applyGPC(
 			state,
 			makeConfig({
@@ -169,7 +169,7 @@ describe("applyGPC", () => {
 	});
 
 	it("applies in EEA under the privacy-positive default scope", () => {
-		const state = makeState({ jurisdiction: "EEA" });
+		const state = makeState({ jurisdiction: "eea" });
 		const next = applyGPC(state, makeConfig());
 		expect(next.source).toBe("gpc");
 		expect(next.decisions.marketing).toBe(false);

--- a/packages/core/src/consent/gpc.ts
+++ b/packages/core/src/consent/gpc.ts
@@ -1,10 +1,11 @@
-import type { ConsentState, GPCConfig, Jurisdiction, PolicyStackConsentConfig } from "./types";
+import type { JurisdictionId } from "../jurisdiction-id";
+import type { ConsentState, GPCConfig, PolicyStackConsentConfig } from "./types";
 
-export const GPC_LEGALLY_REQUIRED_JURISDICTIONS: Jurisdiction[] = [
-	"US-CA",
-	"US-CO",
-	"US-CT",
-	"US-VA",
+export const GPC_LEGALLY_REQUIRED_JURISDICTIONS: JurisdictionId[] = [
+	"us-ca",
+	"us-co",
+	"us-ct",
+	"us-va",
 ];
 
 export function readGPCSignal(config: GPCConfig | undefined): boolean {
@@ -15,7 +16,7 @@ export function readGPCSignal(config: GPCConfig | undefined): boolean {
 }
 
 export function gpcApplies(
-	jurisdiction: Jurisdiction | null,
+	jurisdiction: JurisdictionId | null,
 	config: GPCConfig | undefined,
 ): boolean {
 	if (config?.enabled === false) return false;

--- a/packages/core/src/consent/index.ts
+++ b/packages/core/src/consent/index.ts
@@ -9,12 +9,8 @@ export {
 	manualResolver,
 	timezoneResolver,
 } from "./jurisdiction";
-export {
-	type ConsentModel,
-	jurisdictionPosture,
-	postureDecisions,
-	toJurisdictionId,
-} from "./posture";
+export type { JurisdictionId } from "../jurisdiction-id";
+export { type ConsentModel, jurisdictionPosture, postureDecisions } from "./posture";
 export { defineScript, gateScript, gateScripts } from "./scripts";
 export { createConsentStore } from "./store";
 export type {
@@ -29,7 +25,6 @@ export type {
 	EvaluateOptions,
 	GateOptions,
 	GPCConfig,
-	Jurisdiction,
 	JurisdictionResolver,
 	PolicyStackConsentConfig,
 	PolicyStackConsentOptions,

--- a/packages/core/src/consent/jurisdiction.test.ts
+++ b/packages/core/src/consent/jurisdiction.test.ts
@@ -8,27 +8,29 @@ import {
 } from "./jurisdiction";
 
 describe("countryToJurisdiction", () => {
-	it("maps EEA member states to EEA", () => {
+	it("maps EEA member states to eea", () => {
 		for (const code of ["DE", "FR", "IT", "ES", "SE", "IS", "LI", "NO"]) {
-			expect(countryToJurisdiction(code)).toBe("EEA");
+			expect(countryToJurisdiction(code)).toBe("eea");
 		}
 	});
 
-	it("maps GB to UK and CH to CH", () => {
-		expect(countryToJurisdiction("GB")).toBe("UK");
-		expect(countryToJurisdiction("CH")).toBe("CH");
+	it("maps GB to uk and CH to ch", () => {
+		expect(countryToJurisdiction("GB")).toBe("uk");
+		expect(countryToJurisdiction("CH")).toBe("ch");
 	});
 
-	it("maps named jurisdictions to themselves", () => {
-		expect(countryToJurisdiction("US")).toBe("US");
-		expect(countryToJurisdiction("BR")).toBe("BR");
-		expect(countryToJurisdiction("CA")).toBe("CA");
-		expect(countryToJurisdiction("AU")).toBe("AU");
+	it("maps US/BR/CA country codes to their canonical id; AU has no canonical id → row", () => {
+		expect(countryToJurisdiction("US")).toBe("us");
+		expect(countryToJurisdiction("BR")).toBe("br");
+		expect(countryToJurisdiction("CA")).toBe("ca");
+		// Australia has no canonical `au` member — folds to `row` (the same
+		// conservative opt-in posture the pre-canonical bridge gave "AU").
+		expect(countryToJurisdiction("AU")).toBe("row");
 	});
 
-	it("falls back to ROW for unknown countries", () => {
-		expect(countryToJurisdiction("ZZ")).toBe("ROW");
-		expect(countryToJurisdiction("JP")).toBe("ROW");
+	it("falls back to row for unknown countries", () => {
+		expect(countryToJurisdiction("ZZ")).toBe("row");
+		expect(countryToJurisdiction("JP")).toBe("row");
 	});
 
 	it("returns null for empty / nullish input", () => {
@@ -39,8 +41,8 @@ describe("countryToJurisdiction", () => {
 	});
 
 	it("normalises case and whitespace", () => {
-		expect(countryToJurisdiction("de")).toBe("EEA");
-		expect(countryToJurisdiction(" gb ")).toBe("UK");
+		expect(countryToJurisdiction("de")).toBe("eea");
+		expect(countryToJurisdiction(" gb ")).toBe("uk");
 	});
 });
 
@@ -51,17 +53,17 @@ describe("headerResolver", () => {
 
 	it("reads cf-ipcountry (Cloudflare)", () => {
 		const r = headerResolver();
-		expect(r.resolve(ctx({ "cf-ipcountry": "DE" }))).toBe("EEA");
+		expect(r.resolve(ctx({ "cf-ipcountry": "DE" }))).toBe("eea");
 	});
 
 	it("reads x-vercel-ip-country (Vercel)", () => {
 		const r = headerResolver();
-		expect(r.resolve(ctx({ "x-vercel-ip-country": "GB" }))).toBe("UK");
+		expect(r.resolve(ctx({ "x-vercel-ip-country": "GB" }))).toBe("uk");
 	});
 
 	it("reads x-country fallback (Netlify / custom)", () => {
 		const r = headerResolver();
-		expect(r.resolve(ctx({ "x-country": "BR" }))).toBe("BR");
+		expect(r.resolve(ctx({ "x-country": "BR" }))).toBe("br");
 	});
 
 	it("prefers cf-ipcountry over Vercel and x-country", () => {
@@ -73,7 +75,7 @@ describe("headerResolver", () => {
 				"x-country": "BR",
 			}),
 		);
-		expect(result).toBe("EEA");
+		expect(result).toBe("eea");
 	});
 
 	it("falls through to Vercel when Cloudflare header is absent", () => {
@@ -84,7 +86,7 @@ describe("headerResolver", () => {
 				"x-country": "BR",
 			}),
 		);
-		expect(result).toBe("US");
+		expect(result).toBe("us");
 	});
 
 	it("returns null when no recognised header present", () => {
@@ -103,28 +105,28 @@ describe("headerResolver", () => {
 		const req = new Request("https://example.com", {
 			headers: { "cf-ipcountry": "FR" },
 		});
-		expect(r.resolve(req)).toBe("EEA");
+		expect(r.resolve(req)).toBe("eea");
 	});
 
-	it("maps unknown country to ROW", () => {
+	it("maps unknown country to row", () => {
 		const r = headerResolver();
-		expect(r.resolve(ctx({ "cf-ipcountry": "ZZ" }))).toBe("ROW");
+		expect(r.resolve(ctx({ "cf-ipcountry": "ZZ" }))).toBe("row");
 	});
 });
 
 describe("manualResolver", () => {
 	it("returns the configured jurisdiction", () => {
-		expect(manualResolver("EEA").resolve()).toBe("EEA");
-		expect(manualResolver("US-CA").resolve()).toBe("US-CA");
+		expect(manualResolver("eea").resolve()).toBe("eea");
+		expect(manualResolver("us-ca").resolve()).toBe("us-ca");
 		expect(manualResolver(null).resolve()).toBeNull();
 	});
 
 	it("ignores the request argument", () => {
-		const r = manualResolver("UK");
+		const r = manualResolver("uk");
 		const req = new Request("https://example.com", {
 			headers: { "cf-ipcountry": "US" },
 		});
-		expect(r.resolve(req)).toBe("UK");
+		expect(r.resolve(req)).toBe("uk");
 	});
 });
 
@@ -143,31 +145,31 @@ describe("timezoneResolver", () => {
 		Intl.DateTimeFormat = realDateTimeFormat;
 	});
 
-	it("maps an EEA zone to EEA", () => {
+	it("maps an EEA zone to eea", () => {
 		stubZone("Europe/Berlin");
-		expect(timezoneResolver().resolve()).toBe("EEA");
+		expect(timezoneResolver().resolve()).toBe("eea");
 	});
 
-	it("maps Europe/London to UK", () => {
+	it("maps Europe/London to uk", () => {
 		stubZone("Europe/London");
-		expect(timezoneResolver().resolve()).toBe("UK");
+		expect(timezoneResolver().resolve()).toBe("uk");
 	});
 
-	it("maps Europe/Zurich to CH", () => {
+	it("maps Europe/Zurich to ch", () => {
 		stubZone("Europe/Zurich");
-		expect(timezoneResolver().resolve()).toBe("CH");
+		expect(timezoneResolver().resolve()).toBe("ch");
 	});
 
-	it("maps US zones to US (state-level not derivable from IANA zone)", () => {
+	it("maps US zones to us (state-level not derivable from IANA zone)", () => {
 		stubZone("America/Los_Angeles");
-		expect(timezoneResolver().resolve()).toBe("US");
+		expect(timezoneResolver().resolve()).toBe("us");
 		stubZone("America/New_York");
-		expect(timezoneResolver().resolve()).toBe("US");
+		expect(timezoneResolver().resolve()).toBe("us");
 	});
 
-	it("maps a non-special-cased country zone to ROW", () => {
+	it("maps a non-special-cased country zone to row", () => {
 		stubZone("Asia/Tokyo");
-		expect(timezoneResolver().resolve()).toBe("ROW");
+		expect(timezoneResolver().resolve()).toBe("row");
 	});
 
 	it("returns null for an unknown zone", () => {
@@ -192,7 +194,7 @@ describe("timezoneResolver", () => {
 		const req = new Request("https://example.com", {
 			headers: { "cf-ipcountry": "US" },
 		});
-		expect(timezoneResolver().resolve(req)).toBe("EEA");
+		expect(timezoneResolver().resolve(req)).toBe("eea");
 	});
 });
 
@@ -207,20 +209,26 @@ describe("clientGeoResolver", () => {
 	it("normalises country to jurisdiction", async () => {
 		const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ country: "DE" }));
 		const r = clientGeoResolver({ endpoint: "/geo", fetch: fetchImpl });
-		expect(await r.resolve()).toBe("EEA");
+		expect(await r.resolve()).toBe("eea");
 		expect(fetchImpl).toHaveBeenCalledWith("/geo");
 	});
 
-	it("combines US country with region into US-XX", async () => {
+	it("combines US country + a canonical state region into a us-XX id", async () => {
 		const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ country: "US", region: "CA" }));
 		const r = clientGeoResolver({ endpoint: "/geo", fetch: fetchImpl });
-		expect(await r.resolve()).toBe("US-CA");
+		expect(await r.resolve()).toBe("us-ca");
+	});
+
+	it("folds a US region with no canonical state id down to `us`", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ country: "US", region: "TX" }));
+		const r = clientGeoResolver({ endpoint: "/geo", fetch: fetchImpl });
+		expect(await r.resolve()).toBe("us");
 	});
 
 	it("ignores region for non-US countries", async () => {
 		const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ country: "DE", region: "BY" }));
 		const r = clientGeoResolver({ endpoint: "/geo", fetch: fetchImpl });
-		expect(await r.resolve()).toBe("EEA");
+		expect(await r.resolve()).toBe("eea");
 	});
 
 	it("returns null on non-OK response", async () => {

--- a/packages/core/src/consent/jurisdiction.ts
+++ b/packages/core/src/consent/jurisdiction.ts
@@ -1,5 +1,6 @@
+import { type JurisdictionId, resolveJurisdiction } from "../jurisdiction-id";
 import { TZ_COUNTRY } from "./tz-country";
-import type { Jurisdiction, JurisdictionResolver, ResolverContext } from "./types";
+import type { JurisdictionResolver, ResolverContext } from "./types";
 
 const EEA_COUNTRIES = new Set([
 	"AT",
@@ -34,18 +35,21 @@ const EEA_COUNTRIES = new Set([
 	"NO",
 ]);
 
-export function countryToJurisdiction(code: string | null | undefined): Jurisdiction | null {
+// Country (ISO-3166 alpha-2) → canonical JurisdictionId. Country granularity
+// only, so this never yields a US sub-state id (see clientGeoResolver for that).
+// Australia has no canonical id — it folds to `row` (conservative opt-in), the
+// same posture the pre-canonical bridge already gave "AU".
+export function countryToJurisdiction(code: string | null | undefined): JurisdictionId | null {
 	if (!code) return null;
 	const c = code.trim().toUpperCase();
 	if (c.length === 0) return null;
-	if (EEA_COUNTRIES.has(c)) return "EEA";
-	if (c === "GB") return "UK";
-	if (c === "CH") return "CH";
-	if (c === "US") return "US";
-	if (c === "BR") return "BR";
-	if (c === "CA") return "CA";
-	if (c === "AU") return "AU";
-	return "ROW";
+	if (EEA_COUNTRIES.has(c)) return "eea";
+	if (c === "GB") return "uk";
+	if (c === "CH") return "ch";
+	if (c === "US") return "us";
+	if (c === "BR") return "br";
+	if (c === "CA") return "ca";
+	return "row";
 }
 
 const HEADER_NAMES = ["cf-ipcountry", "x-vercel-ip-country", "x-country"] as const;
@@ -88,7 +92,7 @@ export function timezoneResolver(): JurisdictionResolver {
 	};
 }
 
-export function manualResolver(jurisdiction: Jurisdiction | null): JurisdictionResolver {
+export function manualResolver(jurisdiction: JurisdictionId | null): JurisdictionResolver {
 	return {
 		resolve() {
 			return jurisdiction;
@@ -110,8 +114,9 @@ export function clientGeoResolver(opts: {
 				if (!res.ok) return null;
 				const body = (await res.json()) as GeoResponse;
 				const base = countryToJurisdiction(body.country);
-				if (base === "US" && body.region) {
-					return `US-${body.region.trim().toUpperCase()}` as Jurisdiction;
+				if (base === "us" && body.region) {
+					// us-ca/co/ct/va stay; any other US state folds to `us`.
+					return resolveJurisdiction(`us-${body.region.trim().toLowerCase()}`) ?? "us";
 				}
 				return base;
 			} catch {

--- a/packages/core/src/consent/locale.test.ts
+++ b/packages/core/src/consent/locale.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { LOCALES } from "../i18n/locales";
+import { LOCALES } from "../locale";
 import { normalizeLocale, resolveLocale } from "./locale";
 
 afterEach(() => {

--- a/packages/core/src/consent/locale.ts
+++ b/packages/core/src/consent/locale.ts
@@ -1,24 +1,19 @@
+import { isLocale, LOCALES } from "../locale";
 import type { Locale } from "../types";
 import type { PolicyStackConsentConfig } from "./types";
 
-// Canonical locale codes, kept dependency-free on purpose: importing the i18n
-// locale registry would drag the policy dictionaries into the lean consent
-// runtime. `satisfies` ties this list to the frozen `Locale` union (../types)
-// — the single source of truth — so a stray code here is a compile error.
-const CANONICAL_LOCALES = ["en", "fr", "de", "nl", "es"] as const satisfies readonly Locale[];
-
-function isCanonicalLocale(value: string): value is Locale {
-	return (CANONICAL_LOCALES as readonly string[]).includes(value);
-}
+// `LOCALES`/`isLocale` come from ../locale — the single runtime mirror of the
+// frozen `Locale` union, kept dependency-free so importing it here does NOT
+// drag the i18n policy dictionaries into the lean consent runtime.
 
 // Silent best-effort mapping for environmental input (navigator.language).
 // That is not a deprecated *configuration* — it is the runtime default and is
 // almost always region-tagged (e.g. "en-US") — so it must not warn. Outlives
 // the freeze (navigator.language stays a free string after PS-36).
 function coerceLocale(input: string): Locale {
-	if (isCanonicalLocale(input)) return input;
+	if (isLocale(input)) return input;
 	const primary = input.toLowerCase().split(/[-_]/)[0] ?? "";
-	return isCanonicalLocale(primary) ? primary : "en";
+	return isLocale(primary) ? primary : "en";
 }
 
 // ─── PS-26 warn-and-map migration shim — remove pre-freeze, PS-36 ───
@@ -29,20 +24,20 @@ function coerceLocale(input: string): Locale {
 // integrators migrate. PS-36 deletes this shim and tightens the surface to
 // `Locale`; the silent `coerceLocale` (navigator fallback) survives.
 export function normalizeLocale(input: string): Locale {
-	if (isCanonicalLocale(input)) return input;
+	if (isLocale(input)) return input;
 	const primary = input.toLowerCase().split(/[-_]/)[0] ?? "";
-	if (isCanonicalLocale(primary)) {
+	if (isLocale(primary)) {
 		console.warn(
 			`[policystack] locale "${input}" is not a supported PolicyStack locale; ` +
 				`mapping to "${primary}". Free-string locales are deprecated and will ` +
-				`be rejected when Locale is frozen (PS-36). Use one of: ${CANONICAL_LOCALES.join(", ")}.`,
+				`be rejected when Locale is frozen (PS-36). Use one of: ${LOCALES.join(", ")}.`,
 		);
 		return primary;
 	}
 	console.warn(
 		`[policystack] locale "${input}" is not a supported PolicyStack locale; ` +
 			`falling back to "en". Free-string locales are deprecated and will be ` +
-			`rejected when Locale is frozen (PS-36). Use one of: ${CANONICAL_LOCALES.join(", ")}.`,
+			`rejected when Locale is frozen (PS-36). Use one of: ${LOCALES.join(", ")}.`,
 	);
 	return "en";
 }

--- a/packages/core/src/consent/posture.test.ts
+++ b/packages/core/src/consent/posture.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
-import { consentModelFor, JURISDICTION_IDS } from "../jurisdiction-id";
-import { jurisdictionPosture, postureDecisions, toJurisdictionId } from "./posture";
-import type { Category, Jurisdiction } from "./types";
+import { consentModelFor, type JurisdictionId, JURISDICTION_IDS } from "../jurisdiction-id";
+import { jurisdictionPosture, postureDecisions } from "./posture";
+import type { Category } from "./types";
 
 describe("consentModelFor — all 11 canonical jurisdictions", () => {
 	const OPT_OUT = ["us", "us-ca", "us-co", "us-ct", "us-va"];
@@ -17,40 +17,15 @@ describe("consentModelFor — all 11 canonical jurisdictions", () => {
 	});
 });
 
-describe("toJurisdictionId — runtime Jurisdiction → canonical id", () => {
-	it("maps the recognised uppercase runtime codes", () => {
-		expect(toJurisdictionId("EEA")).toBe("eea");
-		expect(toJurisdictionId("UK")).toBe("uk");
-		expect(toJurisdictionId("CH")).toBe("ch");
-		expect(toJurisdictionId("BR")).toBe("br");
-		expect(toJurisdictionId("CA")).toBe("ca");
-		expect(toJurisdictionId("US")).toBe("us");
-		expect(toJurisdictionId("US-CA")).toBe("us-ca");
-		expect(toJurisdictionId("ROW")).toBe("row");
-	});
-
-	it("folds the unlisted US-state tail to `us`", () => {
-		expect(toJurisdictionId("US-FL")).toBe("us");
-		expect(toJurisdictionId("US-TX")).toBe("us");
-	});
-
-	it("falls back to `row` for null, AU, and anything unrecognised", () => {
-		expect(toJurisdictionId(null)).toBe("row");
-		// "AU" exists in the runtime union but has no canonical `au` member.
-		expect(toJurisdictionId("AU")).toBe("row");
-		expect(toJurisdictionId("XX" as Jurisdiction)).toBe("row");
-	});
-});
-
 describe("jurisdictionPosture — resolved visitor → posture", () => {
-	it("opt-in for EEA/UK/CH/BR/CA/AU/null/ROW (conservative)", () => {
-		for (const j of ["EEA", "UK", "CH", "BR", "CA", "AU", "ROW", null] as (Jurisdiction | null)[]) {
+	it("opt-in for eea/uk/ch/br/ca/row and a null resolve (conservative)", () => {
+		for (const j of ["eea", "uk", "ch", "br", "ca", "row", null] as (JurisdictionId | null)[]) {
 			expect(jurisdictionPosture(j)).toBe("opt-in");
 		}
 	});
 
-	it("opt-out for US and US states (listed + unlisted tail)", () => {
-		for (const j of ["US", "US-CA", "US-CO", "US-CT", "US-VA", "US-FL"] as Jurisdiction[]) {
+	it("opt-out for us and the canonical US states", () => {
+		for (const j of ["us", "us-ca", "us-co", "us-ct", "us-va"] as JurisdictionId[]) {
 			expect(jurisdictionPosture(j)).toBe("opt-out");
 		}
 	});

--- a/packages/core/src/consent/posture.ts
+++ b/packages/core/src/consent/posture.ts
@@ -1,31 +1,16 @@
-import {
-	type ConsentModel,
-	consentModelFor,
-	type JurisdictionId,
-	resolveJurisdiction,
-} from "../jurisdiction-id";
-import type { Category, Jurisdiction } from "./types";
+import { type ConsentModel, consentModelFor, type JurisdictionId } from "../jurisdiction-id";
+import type { Category } from "./types";
 
 export type { ConsentModel };
 
 /**
- * Bridge the runtime uppercase `Jurisdiction` onto a canonical `JurisdictionId`.
- * Lowercasing maps `"US-CA"`→`us-ca`, `"EEA"`→`eea`, `"ROW"`→`row`;
- * `resolveJurisdiction` folds the long US-state tail (`"US-FL"`) → `us`. A
- * `null` resolve, `"AU"` (runtime-only — no canonical `au`), or anything
- * unrecognised falls back to `row` (conservative opt-in, per §4.2).
- */
-export function toJurisdictionId(j: Jurisdiction | null): JurisdictionId {
-	if (j === null) return "row";
-	return resolveJurisdiction(j.toLowerCase()) ?? "row";
-}
-
-/**
  * The §4.2 flagship: the resolved visitor's jurisdiction → its default consent
- * posture, read from the same `JURISDICTION_TABLE` as the policy text.
+ * posture, read from the same `JURISDICTION_TABLE` as the policy text. A `null`
+ * resolve (no resolver configured, or the resolver returned null) defaults to
+ * `row` — conservative opt-in.
  */
-export function jurisdictionPosture(j: Jurisdiction | null): ConsentModel {
-	return consentModelFor(toJurisdictionId(j));
+export function jurisdictionPosture(j: JurisdictionId | null): ConsentModel {
+	return consentModelFor(j ?? "row");
 }
 
 /**

--- a/packages/core/src/consent/storage/cookie.test.ts
+++ b/packages/core/src/consent/storage/cookie.test.ts
@@ -6,7 +6,7 @@ import { cookieAdapter } from "./cookie";
 const sample: ConsentRecord = {
 	schemaVersion: 1,
 	decisions: { essential: true, analytics: false },
-	jurisdiction: "EEA",
+	jurisdiction: "eea",
 	policyVersion: "v1",
 	decidedAt: "2026-04-29T00:00:00.000Z",
 	locale: "en-GB",

--- a/packages/core/src/consent/storage/local-storage.test.ts
+++ b/packages/core/src/consent/storage/local-storage.test.ts
@@ -6,7 +6,7 @@ import { localStorageAdapter } from "./local-storage";
 const sample: ConsentRecord = {
 	schemaVersion: 1,
 	decisions: { essential: true, analytics: false },
-	jurisdiction: "EEA",
+	jurisdiction: "eea",
 	policyVersion: "v1",
 	decidedAt: "2026-04-29T00:00:00.000Z",
 	locale: "en-GB",

--- a/packages/core/src/consent/storage/record.test.ts
+++ b/packages/core/src/consent/storage/record.test.ts
@@ -9,7 +9,7 @@ const baseState: ConsentState = {
 		{ key: "analytics", label: "Analytics" },
 	],
 	decisions: { essential: true, analytics: true },
-	jurisdiction: "EEA",
+	jurisdiction: "eea",
 	policyVersion: "v2",
 	decidedAt: "2026-04-29T00:00:00.000Z",
 	source: "user",
@@ -26,7 +26,7 @@ const v1: ConsentRecord = {
 	decisions: { essential: true, analytics: true },
 	policyVersion: "v2",
 	decidedAt: "2026-04-29T00:00:00.000Z",
-	jurisdiction: "EEA",
+	jurisdiction: "eea",
 	locale: "en-GB",
 	source: "banner",
 };
@@ -59,7 +59,7 @@ describe("recordEquals", () => {
 		expect(recordEquals(v1, { ...v1, source: "preferences" })).toBe(false);
 		expect(recordEquals(v1, { ...v1, policyVersion: "v3" })).toBe(false);
 		expect(recordEquals(v1, { ...v1, decidedAt: "2026-05-01T00:00:00.000Z" })).toBe(false);
-		expect(recordEquals(v1, { ...v1, jurisdiction: "UK" })).toBe(false);
+		expect(recordEquals(v1, { ...v1, jurisdiction: "uk" })).toBe(false);
 		expect(recordEquals(v1, { ...v1, decisions: { essential: true, analytics: false } })).toBe(
 			false,
 		);
@@ -92,7 +92,7 @@ describe("fromUnknown", () => {
 	it("migrates a legacy OP-297 record (source 'user' -> 'banner')", () => {
 		const legacy = {
 			decisions: { essential: true, analytics: false },
-			jurisdiction: "EEA",
+			jurisdiction: "eea",
 			policyVersion: "v1",
 			decidedAt: "2026-04-01T00:00:00.000Z",
 			source: "user",
@@ -102,10 +102,23 @@ describe("fromUnknown", () => {
 			decisions: { essential: true, analytics: false },
 			policyVersion: "v1",
 			decidedAt: "2026-04-01T00:00:00.000Z",
-			jurisdiction: "EEA",
+			jurisdiction: "eea",
 			locale: "en-GB",
 			source: "banner",
 		});
+	});
+
+	it("reads a pre-canonical uppercase jurisdiction back as null (format break, decisions kept)", () => {
+		const legacy = {
+			decisions: { essential: true, analytics: false },
+			jurisdiction: "US-CA",
+			policyVersion: "v1",
+			decidedAt: "2026-04-01T00:00:00.000Z",
+			source: "banner",
+		};
+		const out = fromUnknown(legacy, "en");
+		expect(out?.jurisdiction).toBeNull();
+		expect(out?.decisions).toEqual({ essential: true, analytics: false });
 	});
 
 	it("maps unknown legacy sources to 'import'", () => {

--- a/packages/core/src/consent/storage/record.ts
+++ b/packages/core/src/consent/storage/record.ts
@@ -1,4 +1,4 @@
-import { isJurisdictionId, type JurisdictionId } from "../../jurisdiction-id";
+import { isJurisdictionId } from "../../jurisdiction-id";
 import type { Locale } from "../../types";
 import type { ConsentRecord, ConsentRecordSource, ConsentState } from "../types";
 
@@ -61,7 +61,12 @@ export function fromUnknown(raw: unknown, fallbackLocale: string): ConsentRecord
 
 	const decisions = isDecisions(obj.decisions) ? obj.decisions : {};
 	const policyVersion = typeof obj.policyVersion === "string" ? obj.policyVersion : "";
-	const jurisdiction = isJurisdiction(obj.jurisdiction) ? obj.jurisdiction : null;
+	// Validate against the canonical closed union. A legacy record written in
+	// the pre-canonical uppercase form ("EEA", "US-CA") no longer matches, so
+	// its jurisdiction reads back as null — informational only; the
+	// `jurisdictionChanged` reprompt needs both sides non-null, so an upgrading
+	// visitor is not spuriously re-prompted (decisions are preserved).
+	const jurisdiction = isJurisdictionId(obj.jurisdiction) ? obj.jurisdiction : null;
 	const locale =
 		typeof obj.locale === "string" && obj.locale.length > 0 ? obj.locale : fallbackLocale;
 	const source = isRecordSource(obj.source) ? obj.source : mapLegacySource(obj.source);
@@ -83,15 +88,6 @@ function isDecisions(value: unknown): value is Record<string, boolean> {
 		if (typeof v !== "boolean") return false;
 	}
 	return true;
-}
-
-// Validate against the canonical closed union. A legacy stored record written
-// in the pre-canonical uppercase form ("EEA", "US-CA") no longer matches, so
-// its jurisdiction reads back as null — informational only; the
-// `jurisdictionChanged` reprompt trigger needs both sides non-null, so this
-// does not spuriously re-prompt an upgrading visitor (decisions are preserved).
-function isJurisdiction(value: unknown): value is JurisdictionId {
-	return typeof value === "string" && isJurisdictionId(value);
 }
 
 function isRecordSource(value: unknown): value is ConsentRecordSource {

--- a/packages/core/src/consent/storage/record.ts
+++ b/packages/core/src/consent/storage/record.ts
@@ -1,5 +1,6 @@
+import { isJurisdictionId, type JurisdictionId } from "../../jurisdiction-id";
 import type { Locale } from "../../types";
-import type { ConsentRecord, ConsentRecordSource, ConsentState, Jurisdiction } from "../types";
+import type { ConsentRecord, ConsentRecordSource, ConsentState } from "../types";
 
 const RECORD_SOURCES: ReadonlySet<ConsentRecordSource> = new Set([
 	"banner",
@@ -84,8 +85,13 @@ function isDecisions(value: unknown): value is Record<string, boolean> {
 	return true;
 }
 
-function isJurisdiction(value: unknown): value is Jurisdiction {
-	return typeof value === "string" && value.length > 0;
+// Validate against the canonical closed union. A legacy stored record written
+// in the pre-canonical uppercase form ("EEA", "US-CA") no longer matches, so
+// its jurisdiction reads back as null — informational only; the
+// `jurisdictionChanged` reprompt trigger needs both sides non-null, so this
+// does not spuriously re-prompt an upgrading visitor (decisions are preserved).
+function isJurisdiction(value: unknown): value is JurisdictionId {
+	return typeof value === "string" && isJurisdictionId(value);
 }
 
 function isRecordSource(value: unknown): value is ConsentRecordSource {

--- a/packages/core/src/consent/storage/server.test.ts
+++ b/packages/core/src/consent/storage/server.test.ts
@@ -5,7 +5,7 @@ import { serverAdapter } from "./server";
 const sample: ConsentRecord = {
 	schemaVersion: 1,
 	decisions: { essential: true, analytics: false },
-	jurisdiction: "US",
+	jurisdiction: "us",
 	policyVersion: "v1",
 	decidedAt: "2026-04-29T00:00:00.000Z",
 	locale: "en-GB",

--- a/packages/core/src/consent/store.test.ts
+++ b/packages/core/src/consent/store.test.ts
@@ -116,7 +116,7 @@ describe("createConsentStore", () => {
 
 		it("opt-out jurisdiction: non-essential defaults ON, consentModel opt-out", () => {
 			const s = createConsentStore(
-				makeConfig({ jurisdictionResolver: manualResolver("US") }),
+				makeConfig({ jurisdictionResolver: manualResolver("us") }),
 			).getState();
 			expect(s.decisions).toEqual({ essential: true, analytics: true, marketing: true });
 			expect(s.consentModel).toBe("opt-out");
@@ -124,7 +124,7 @@ describe("createConsentStore", () => {
 
 		it("opt-in jurisdiction: non-essential defaults OFF, consentModel opt-in", () => {
 			const s = createConsentStore(
-				makeConfig({ jurisdictionResolver: manualResolver("EEA") }),
+				makeConfig({ jurisdictionResolver: manualResolver("eea") }),
 			).getState();
 			expect(s.decisions).toEqual({ essential: true, analytics: false, marketing: false });
 			expect(s.consentModel).toBe("opt-in");
@@ -138,7 +138,7 @@ describe("createConsentStore", () => {
 
 		it("async resolver: opt-in until resolved, opt-out after (footgun gone for async)", async () => {
 			const store = createConsentStore(
-				makeConfig({ jurisdictionResolver: { resolve: () => Promise.resolve("US") } }),
+				makeConfig({ jurisdictionResolver: { resolve: () => Promise.resolve("us") } }),
 			);
 			expect(store.getState().decisions).toEqual({
 				essential: true,
@@ -157,7 +157,7 @@ describe("createConsentStore", () => {
 
 		it("GPC is the opt-out: opt-out posture set ON, GPC flips it back OFF", () => {
 			const s = createConsentStore(
-				makeConfig({ jurisdictionResolver: manualResolver("US"), gpc: { signal: true } }),
+				makeConfig({ jurisdictionResolver: manualResolver("us"), gpc: { signal: true } }),
 			).getState();
 			expect(s.decisions).toEqual({ essential: true, analytics: false, marketing: false });
 			expect(s.source).toBe("gpc");
@@ -165,7 +165,7 @@ describe("createConsentStore", () => {
 		});
 
 		it("a prior user decision is never overridden by a later jurisdiction change", async () => {
-			let where: "EEA" | "US" = "EEA";
+			let where: "eea" | "us" = "eea";
 			const store = createConsentStore(
 				makeConfig({ jurisdictionResolver: { resolve: () => where } }),
 			);
@@ -175,9 +175,9 @@ describe("createConsentStore", () => {
 				analytics: false,
 				marketing: false,
 			});
-			where = "US";
+			where = "us";
 			await store.refreshJurisdiction();
-			expect(store.getState().jurisdiction).toBe("US");
+			expect(store.getState().jurisdiction).toBe("us");
 			// decisions stay the user's; only the UI hint tracks the new jurisdiction.
 			expect(store.getState().decisions).toEqual({
 				essential: true,
@@ -194,7 +194,7 @@ describe("createConsentStore", () => {
 					decisions: { essential: true, analytics: false, marketing: false },
 					policyVersion: "",
 					decidedAt: "2026-01-01T00:00:00.000Z",
-					jurisdiction: "EEA",
+					jurisdiction: "eea",
 					locale: "en",
 					source: "banner",
 				}),
@@ -203,7 +203,7 @@ describe("createConsentStore", () => {
 			};
 			const store = createConsentStore(
 				makeConfig({
-					jurisdictionResolver: { resolve: () => Promise.resolve("US") },
+					jurisdictionResolver: { resolve: () => Promise.resolve("us") },
 					triggers: { jurisdictionChanged: true },
 					adapter,
 				}),
@@ -225,25 +225,25 @@ describe("createConsentStore", () => {
 		});
 
 		it("populates jurisdiction synchronously when resolver is sync", () => {
-			const store = createConsentStore(makeConfig({ jurisdictionResolver: manualResolver("EEA") }));
-			expect(store.getState().jurisdiction).toBe("EEA");
+			const store = createConsentStore(makeConfig({ jurisdictionResolver: manualResolver("eea") }));
+			expect(store.getState().jurisdiction).toBe("eea");
 		});
 
 		it("starts null and notifies subscribers when resolver is async", async () => {
 			const resolver: JurisdictionResolver = {
-				resolve: () => Promise.resolve("UK"),
+				resolve: () => Promise.resolve("uk"),
 			};
 			const store = createConsentStore(makeConfig({ jurisdictionResolver: resolver }));
 			expect(store.getState().jurisdiction).toBeNull();
 			const listener = vi.fn();
 			store.subscribe(listener);
 			await flushMicrotasks();
-			expect(store.getState().jurisdiction).toBe("UK");
+			expect(store.getState().jurisdiction).toBe("uk");
 			expect(listener).toHaveBeenCalledWith(store.getState());
 		});
 
 		it("forwards config.request to the resolver", () => {
-			const resolve = vi.fn().mockReturnValue("US");
+			const resolve = vi.fn().mockReturnValue("us");
 			const req = { headers: new Headers({ "cf-ipcountry": "US" }) };
 			createConsentStore(makeConfig({ jurisdictionResolver: { resolve }, request: req }));
 			expect(resolve).toHaveBeenCalledWith(req);
@@ -273,17 +273,17 @@ describe("createConsentStore", () => {
 		});
 
 		it("preserves jurisdiction across decision mutations", () => {
-			const store = createConsentStore(makeConfig({ jurisdictionResolver: manualResolver("EEA") }));
+			const store = createConsentStore(makeConfig({ jurisdictionResolver: manualResolver("eea") }));
 			store.acceptAll();
-			expect(store.getState().jurisdiction).toBe("EEA");
+			expect(store.getState().jurisdiction).toBe("eea");
 			store.acceptNecessary();
-			expect(store.getState().jurisdiction).toBe("EEA");
+			expect(store.getState().jurisdiction).toBe("eea");
 			store.reject();
-			expect(store.getState().jurisdiction).toBe("EEA");
+			expect(store.getState().jurisdiction).toBe("eea");
 			store.toggle("analytics");
-			expect(store.getState().jurisdiction).toBe("EEA");
+			expect(store.getState().jurisdiction).toBe("eea");
 			store.save();
-			expect(store.getState().jurisdiction).toBe("EEA");
+			expect(store.getState().jurisdiction).toBe("eea");
 		});
 	});
 
@@ -293,29 +293,29 @@ describe("createConsentStore", () => {
 		});
 
 		it("re-invokes the resolver and commits the new value", async () => {
-			let next: "EEA" | "US" = "EEA";
+			let next: "eea" | "us" = "eea";
 			const resolver: JurisdictionResolver = {
 				resolve: () => next,
 			};
 			const store = createConsentStore(makeConfig({ jurisdictionResolver: resolver }));
-			expect(store.getState().jurisdiction).toBe("EEA");
-			next = "US";
+			expect(store.getState().jurisdiction).toBe("eea");
+			next = "us";
 			const result = await store.refreshJurisdiction();
-			expect(result).toBe("US");
-			expect(store.getState().jurisdiction).toBe("US");
+			expect(result).toBe("us");
+			expect(store.getState().jurisdiction).toBe("us");
 		});
 
 		it("notifies subscribers on refresh", async () => {
-			let next: "EEA" | "UK" = "EEA";
+			let next: "eea" | "uk" = "eea";
 			const store = createConsentStore(
 				makeConfig({ jurisdictionResolver: { resolve: () => next } }),
 			);
 			const listener = vi.fn();
 			store.subscribe(listener);
-			next = "UK";
+			next = "uk";
 			await store.refreshJurisdiction();
 			expect(listener).toHaveBeenCalledTimes(1);
-			expect(listener.mock.calls[0]?.[0].jurisdiction).toBe("UK");
+			expect(listener.mock.calls[0]?.[0].jurisdiction).toBe("uk");
 		});
 
 		it("returns the current jurisdiction when no resolver is configured", async () => {
@@ -325,7 +325,7 @@ describe("createConsentStore", () => {
 		});
 
 		it("forwards an explicit request override to the resolver", async () => {
-			const resolve = vi.fn().mockReturnValue("EEA");
+			const resolve = vi.fn().mockReturnValue("eea");
 			const store = createConsentStore(makeConfig({ jurisdictionResolver: { resolve } }));
 			resolve.mockClear();
 			const req = { headers: new Headers({ "cf-ipcountry": "DE" }) };
@@ -339,14 +339,14 @@ describe("createConsentStore", () => {
 			const resolver: JurisdictionResolver = {
 				resolve: () => {
 					if (mode === "boom") throw new Error("nope");
-					return "EEA";
+					return "eea";
 				},
 			};
 			const store = createConsentStore(makeConfig({ jurisdictionResolver: resolver }));
 			mode = "boom";
 			const result = await store.refreshJurisdiction();
-			expect(result).toBe("EEA");
-			expect(store.getState().jurisdiction).toBe("EEA");
+			expect(result).toBe("eea");
+			expect(store.getState().jurisdiction).toBe("eea");
 		});
 
 		it("leaves jurisdiction unchanged when the resolver rejects", async () => {
@@ -354,15 +354,15 @@ describe("createConsentStore", () => {
 			let mode: "ok" | "boom" = "ok";
 			const resolver: JurisdictionResolver = {
 				resolve: () =>
-					mode === "boom" ? Promise.reject(new Error("nope")) : Promise.resolve("UK"),
+					mode === "boom" ? Promise.reject(new Error("nope")) : Promise.resolve("uk"),
 			};
 			const store = createConsentStore(makeConfig({ jurisdictionResolver: resolver }));
 			await flushMicrotasks();
-			expect(store.getState().jurisdiction).toBe("UK");
+			expect(store.getState().jurisdiction).toBe("uk");
 			mode = "boom";
 			const result = await store.refreshJurisdiction();
-			expect(result).toBe("UK");
-			expect(store.getState().jurisdiction).toBe("UK");
+			expect(result).toBe("uk");
+			expect(store.getState().jurisdiction).toBe("uk");
 		});
 	});
 
@@ -579,7 +579,7 @@ describe("createConsentStore", () => {
 		it("applies on init when signal is true (privacy-positive default scope)", () => {
 			const store = createConsentStore(
 				makeConfig({
-					jurisdictionResolver: manualResolver("EEA"),
+					jurisdictionResolver: manualResolver("eea"),
 					gpc: { signal: true },
 				}),
 			);
@@ -592,7 +592,7 @@ describe("createConsentStore", () => {
 		it("does not apply when signal is false", () => {
 			const store = createConsentStore(
 				makeConfig({
-					jurisdictionResolver: manualResolver("US-CA"),
+					jurisdictionResolver: manualResolver("us-ca"),
 					gpc: { signal: false },
 				}),
 			);
@@ -603,7 +603,7 @@ describe("createConsentStore", () => {
 		it("applies in a legally-required US state", () => {
 			const store = createConsentStore(
 				makeConfig({
-					jurisdictionResolver: manualResolver("US-CA"),
+					jurisdictionResolver: manualResolver("us-ca"),
 					gpc: {
 						signal: true,
 						applicableJurisdictions: GPC_LEGALLY_REQUIRED_JURISDICTIONS,
@@ -616,7 +616,7 @@ describe("createConsentStore", () => {
 		it("does not apply in EEA when scope is restricted to the four US states", () => {
 			const store = createConsentStore(
 				makeConfig({
-					jurisdictionResolver: manualResolver("EEA"),
+					jurisdictionResolver: manualResolver("eea"),
 					gpc: {
 						signal: true,
 						applicableJurisdictions: GPC_LEGALLY_REQUIRED_JURISDICTIONS,
@@ -629,7 +629,7 @@ describe("createConsentStore", () => {
 
 		it("re-evaluates after async jurisdiction resolves", async () => {
 			const resolver: JurisdictionResolver = {
-				resolve: () => Promise.resolve("US-CA"),
+				resolve: () => Promise.resolve("us-ca"),
 			};
 			const store = createConsentStore(
 				makeConfig({
@@ -643,7 +643,7 @@ describe("createConsentStore", () => {
 			expect(store.getState().source).toBe("default");
 			await flushMicrotasks();
 			expect(store.getState().source).toBe("gpc");
-			expect(store.getState().jurisdiction).toBe("US-CA");
+			expect(store.getState().jurisdiction).toBe("us-ca");
 		});
 
 		it("respects per-category respectGPC: false", () => {
@@ -654,7 +654,7 @@ describe("createConsentStore", () => {
 			];
 			const store = createConsentStore({
 				categories,
-				jurisdictionResolver: manualResolver("US-CA"),
+				jurisdictionResolver: manualResolver("us-ca"),
 				gpc: { signal: true },
 			});
 			const decisions = { ...store.getState().decisions };
@@ -665,7 +665,7 @@ describe("createConsentStore", () => {
 		it("user mutation after GPC flips source back to 'user'", () => {
 			const store = createConsentStore(
 				makeConfig({
-					jurisdictionResolver: manualResolver("US-CA"),
+					jurisdictionResolver: manualResolver("us-ca"),
 					gpc: { signal: true },
 				}),
 			);
@@ -678,7 +678,7 @@ describe("createConsentStore", () => {
 		it("is fully bypassed when gpc.enabled is false (even with signal: true)", () => {
 			const store = createConsentStore(
 				makeConfig({
-					jurisdictionResolver: manualResolver("US-CA"),
+					jurisdictionResolver: manualResolver("us-ca"),
 					gpc: { enabled: false, signal: true },
 				}),
 			);
@@ -689,7 +689,7 @@ describe("createConsentStore", () => {
 		it("reads navigator.globalPrivacyControl when no signal override (Brave parity)", () => {
 			vi.stubGlobal("navigator", { globalPrivacyControl: true });
 			const store = createConsentStore(
-				makeConfig({ jurisdictionResolver: manualResolver("US-CA") }),
+				makeConfig({ jurisdictionResolver: manualResolver("us-ca") }),
 			);
 			expect(store.getState().source).toBe("gpc");
 		});
@@ -697,7 +697,7 @@ describe("createConsentStore", () => {
 		it("does not apply when navigator omits globalPrivacyControl (Chrome parity)", () => {
 			vi.stubGlobal("navigator", {});
 			const store = createConsentStore(
-				makeConfig({ jurisdictionResolver: manualResolver("US-CA") }),
+				makeConfig({ jurisdictionResolver: manualResolver("us-ca") }),
 			);
 			expect(store.getState().source).toBe("default");
 			expect(store.getState().route).toBe("cookie");
@@ -737,7 +737,7 @@ describe("createConsentStore", () => {
 			return {
 				schemaVersion: 1,
 				decisions: { essential: true, analytics: true, marketing: false },
-				jurisdiction: "EEA",
+				jurisdiction: "eea",
 				policyVersion: "v2",
 				decidedAt: "2026-04-01T00:00:00.000Z",
 				locale: "en-GB",
@@ -751,7 +751,7 @@ describe("createConsentStore", () => {
 			const store = createConsentStore(makeConfig({ adapter }));
 			const s = store.getState();
 			expect(s.decisions).toEqual({ essential: true, analytics: true, marketing: false });
-			expect(s.jurisdiction).toBe("EEA");
+			expect(s.jurisdiction).toBe("eea");
 			expect(s.decidedAt).toBe("2026-04-01T00:00:00.000Z");
 			expect(s.source).toBe("user");
 		});
@@ -782,7 +782,7 @@ describe("createConsentStore", () => {
 
 		it("hydrates state from an async adapter and notifies subscribers", async () => {
 			const adapter: StorageAdapter = {
-				read: () => Promise.resolve(v1Record({ jurisdiction: "UK", policyVersion: "" })),
+				read: () => Promise.resolve(v1Record({ jurisdiction: "uk", policyVersion: "" })),
 				write: () => {},
 				clear: () => {},
 			};
@@ -792,7 +792,7 @@ describe("createConsentStore", () => {
 			store.subscribe(listener);
 			await flushMicrotasks();
 			expect(store.getState().decisions.analytics).toBe(true);
-			expect(store.getState().jurisdiction).toBe("UK");
+			expect(store.getState().jurisdiction).toBe("uk");
 			expect(listener).toHaveBeenCalled();
 		});
 
@@ -907,7 +907,7 @@ describe("createConsentStore", () => {
 		it("migrates a legacy record on hydration ('user' source -> banner-shaped record)", () => {
 			const legacyRaw = {
 				decisions: { essential: true, analytics: true, marketing: false },
-				jurisdiction: "EEA",
+				jurisdiction: "eea",
 				policyVersion: "v1",
 				decidedAt: "2026-04-01T00:00:00.000Z",
 				source: "user",
@@ -976,7 +976,7 @@ describe("createConsentStore", () => {
 		it("does not surface a record for GPC-only state (no decision)", () => {
 			const store = createConsentStore(
 				makeConfig({
-					jurisdictionResolver: manualResolver("US-CA"),
+					jurisdictionResolver: manualResolver("us-ca"),
 					gpc: { signal: true },
 				}),
 			);
@@ -995,7 +995,7 @@ describe("createConsentStore", () => {
 			};
 			createConsentStore(
 				makeConfig({
-					jurisdictionResolver: manualResolver("US-CA"),
+					jurisdictionResolver: manualResolver("us-ca"),
 					gpc: { signal: true },
 					adapter,
 				}),
@@ -1006,7 +1006,7 @@ describe("createConsentStore", () => {
 		it("falls back to 'banner' source after GPC + a user decision", () => {
 			const store = createConsentStore(
 				makeConfig({
-					jurisdictionResolver: manualResolver("US-CA"),
+					jurisdictionResolver: manualResolver("us-ca"),
 					gpc: { signal: true },
 				}),
 			);
@@ -1068,7 +1068,7 @@ describe("createConsentStore", () => {
 			return {
 				schemaVersion: 1,
 				decisions: { essential: true, analytics: true, marketing: true },
-				jurisdiction: "EEA",
+				jurisdiction: "eea",
 				policyVersion: "v1",
 				decidedAt: "2026-04-01T00:00:00.000Z",
 				locale: "en-GB",
@@ -1097,7 +1097,7 @@ describe("createConsentStore", () => {
 		function listenForReprompt(): { events: { reason: string }[]; off: () => void } {
 			const events: { reason: string }[] = [];
 			const dispatchEvent = vi.fn((event: Event) => {
-				if (event.type === "oncookies:reprompt") {
+				if (event.type === "policystack:reprompt") {
 					const detail = (event as CustomEvent).detail as { reason: string };
 					events.push(detail);
 				}
@@ -1217,23 +1217,23 @@ describe("createConsentStore", () => {
 
 		describe("jurisdictionChanged", () => {
 			it("invalidates when the visitor crosses a jurisdiction boundary (sync resolver)", () => {
-				const { adapter } = adapterFor(v1Record({ jurisdiction: "EEA", policyVersion: "v1" }));
+				const { adapter } = adapterFor(v1Record({ jurisdiction: "eea", policyVersion: "v1" }));
 				const store = createConsentStore(
 					makeConfig({
 						adapter,
 						policyVersion: "v1",
-						jurisdictionResolver: manualResolver("US"),
+						jurisdictionResolver: manualResolver("us"),
 						triggers: { jurisdictionChanged: true },
 					}),
 				);
 				expect(store.getState().repromptReason).toBe("jurisdiction");
-				expect(store.getState().jurisdiction).toBe("US");
+				expect(store.getState().jurisdiction).toBe("us");
 			});
 
 			it("invalidates after async jurisdiction resolution", async () => {
-				const { adapter } = adapterFor(v1Record({ jurisdiction: "EEA", policyVersion: "v1" }));
+				const { adapter } = adapterFor(v1Record({ jurisdiction: "eea", policyVersion: "v1" }));
 				const resolver: JurisdictionResolver = {
-					resolve: () => Promise.resolve("US"),
+					resolve: () => Promise.resolve("us"),
 				};
 				const store = createConsentStore(
 					makeConfig({
@@ -1246,12 +1246,12 @@ describe("createConsentStore", () => {
 				expect(store.getState().repromptReason).toBeNull();
 				await flushMicrotasks();
 				expect(store.getState().repromptReason).toBe("jurisdiction");
-				expect(store.getPreviousRecord()?.jurisdiction).toBe("EEA");
+				expect(store.getPreviousRecord()?.jurisdiction).toBe("eea");
 			});
 		});
 
 		describe("event dispatch", () => {
-			it("emits oncookies:reprompt on globalThis when a trigger fires", async () => {
+			it("emits policystack:reprompt on globalThis when a trigger fires", async () => {
 				const { events, off } = listenForReprompt();
 				try {
 					const { adapter } = adapterFor(v1Record({ policyVersion: "v1" }));

--- a/packages/core/src/consent/store.ts
+++ b/packages/core/src/consent/store.ts
@@ -4,6 +4,7 @@ import { resolveLocale } from "./locale";
 import { jurisdictionPosture, postureDecisions } from "./posture";
 import { fromUnknown, recordEquals, toRecord } from "./storage/record";
 import { evaluateTriggers } from "./triggers";
+import type { JurisdictionId } from "../jurisdiction-id";
 import type {
 	ActionOptions,
 	ConsentExpr,
@@ -11,7 +12,6 @@ import type {
 	ConsentRecordSource,
 	ConsentState,
 	ConsentStore,
-	Jurisdiction,
 	PolicyStackConsentConfig,
 	RepromptReason,
 	ResolverContext,
@@ -102,7 +102,7 @@ export function createConsentStore(config: PolicyStackConsentConfig): ConsentSto
 		suspendWrite = false;
 	}
 
-	function handleJurisdictionChange(value: Jurisdiction | null): void {
+	function handleJurisdictionChange(value: JurisdictionId | null): void {
 		const model = jurisdictionPosture(value);
 		let next: ConsentState = { ...state, jurisdiction: value, consentModel: model };
 		// While pristine (no user decision, no stored record, no pending
@@ -133,7 +133,7 @@ export function createConsentStore(config: PolicyStackConsentConfig): ConsentSto
 
 	function checkTriggers(
 		record: ConsentRecord,
-		jurisdiction: Jurisdiction | null,
+		jurisdiction: JurisdictionId | null,
 	): RepromptReason | null {
 		return evaluateTriggers({
 			record,
@@ -297,7 +297,7 @@ export function createConsentStore(config: PolicyStackConsentConfig): ConsentSto
 		async refreshJurisdiction(req?: ResolverContext) {
 			const resolver = config.jurisdictionResolver;
 			if (!resolver) return state.jurisdiction;
-			let raw: Promise<Jurisdiction | null> | Jurisdiction | null;
+			let raw: Promise<JurisdictionId | null> | JurisdictionId | null;
 			try {
 				raw = resolver.resolve(req ?? config.request);
 			} catch (err) {
@@ -316,7 +316,7 @@ function dispatchRepromptEvent(reason: RepromptReason): void {
 		try {
 			const target = globalThis as { dispatchEvent?: (e: Event) => boolean };
 			if (typeof CustomEvent !== "undefined" && typeof target.dispatchEvent === "function") {
-				target.dispatchEvent(new CustomEvent("oncookies:reprompt", { detail: { reason } }));
+				target.dispatchEvent(new CustomEvent("policystack:reprompt", { detail: { reason } }));
 			}
 		} catch {
 			// Best-effort: ignore environments without CustomEvent/dispatchEvent.
@@ -325,8 +325,8 @@ function dispatchRepromptEvent(reason: RepromptReason): void {
 }
 
 type InitialJurisdiction = {
-	value: Jurisdiction | null;
-	pending: Promise<Jurisdiction | null> | null;
+	value: JurisdictionId | null;
+	pending: Promise<JurisdictionId | null> | null;
 };
 
 function resolveSync(
@@ -336,7 +336,7 @@ function resolveSync(
 	const resolver = config.jurisdictionResolver;
 	if (!resolver) return { value: null, pending: null };
 
-	let result: Promise<Jurisdiction | null> | Jurisdiction | null;
+	let result: Promise<JurisdictionId | null> | JurisdictionId | null;
 	try {
 		result = resolver.resolve(req);
 	} catch (err) {
@@ -351,10 +351,10 @@ function resolveSync(
 	return { value: result, pending: null };
 }
 
-type ResolveOutcome = { ok: true; value: Jurisdiction | null } | { ok: false };
+type ResolveOutcome = { ok: true; value: JurisdictionId | null } | { ok: false };
 
 async function safeResolve(
-	result: Promise<Jurisdiction | null> | Jurisdiction | null,
+	result: Promise<JurisdictionId | null> | JurisdictionId | null,
 ): Promise<ResolveOutcome> {
 	try {
 		const value = await result;

--- a/packages/core/src/consent/triggers.test.ts
+++ b/packages/core/src/consent/triggers.test.ts
@@ -12,7 +12,7 @@ const baseRecord: ConsentRecord = {
 	decisions: { essential: true, analytics: true },
 	policyVersion: "v1",
 	decidedAt: "2026-04-01T00:00:00.000Z",
-	jurisdiction: "EEA",
+	jurisdiction: "eea",
 	locale: "en-GB",
 	source: "banner",
 };
@@ -25,7 +25,7 @@ function input(overrides: Partial<TriggerInput> = {}): TriggerInput {
 		triggers: undefined,
 		policyVersion: "v1",
 		categories: baseCategories,
-		jurisdiction: "EEA",
+		jurisdiction: "eea",
 		now: NOW,
 		...overrides,
 	};
@@ -104,7 +104,7 @@ describe("evaluateTriggers", () => {
 	describe("jurisdictionChanged", () => {
 		it("fires when the visitor crosses a jurisdiction boundary", () => {
 			expect(
-				evaluateTriggers(input({ triggers: { jurisdictionChanged: true }, jurisdiction: "US" })),
+				evaluateTriggers(input({ triggers: { jurisdictionChanged: true }, jurisdiction: "us" })),
 			).toBe("jurisdiction");
 		});
 
@@ -122,7 +122,7 @@ describe("evaluateTriggers", () => {
 			const r = { ...baseRecord, jurisdiction: null };
 			expect(
 				evaluateTriggers(
-					input({ triggers: { jurisdictionChanged: true }, record: r, jurisdiction: "EEA" }),
+					input({ triggers: { jurisdictionChanged: true }, record: r, jurisdiction: "eea" }),
 				),
 			).toBeNull();
 		});
@@ -142,7 +142,7 @@ describe("evaluateTriggers", () => {
 						},
 						policyVersion: "v2",
 						categories: cats,
-						jurisdiction: "US",
+						jurisdiction: "us",
 					}),
 				),
 			).toBe("policyVersion");
@@ -159,7 +159,7 @@ describe("evaluateTriggers", () => {
 							jurisdictionChanged: true,
 						},
 						categories: cats,
-						jurisdiction: "US",
+						jurisdiction: "us",
 					}),
 				),
 			).toBe("categoriesAdded");
@@ -170,7 +170,7 @@ describe("evaluateTriggers", () => {
 				evaluateTriggers(
 					input({
 						triggers: { expiresAfter: 1, jurisdictionChanged: true },
-						jurisdiction: "US",
+						jurisdiction: "us",
 					}),
 				),
 			).toBe("expired");

--- a/packages/core/src/consent/triggers.ts
+++ b/packages/core/src/consent/triggers.ts
@@ -1,18 +1,13 @@
+import type { JurisdictionId } from "../jurisdiction-id";
 import { parseDuration } from "./duration";
-import type {
-	Category,
-	ConsentRecord,
-	Jurisdiction,
-	RepromptReason,
-	RepromptTriggers,
-} from "./types";
+import type { Category, ConsentRecord, RepromptReason, RepromptTriggers } from "./types";
 
 export type TriggerInput = {
 	record: ConsentRecord;
 	triggers: RepromptTriggers | undefined;
 	policyVersion: string;
 	categories: Category[];
-	jurisdiction: Jurisdiction | null;
+	jurisdiction: JurisdictionId | null;
 	now: number;
 };
 

--- a/packages/core/src/consent/types.ts
+++ b/packages/core/src/consent/types.ts
@@ -1,4 +1,4 @@
-import type { ConsentModel } from "../jurisdiction-id";
+import type { ConsentModel, JurisdictionId } from "../jurisdiction-id";
 import type { LegalBasis } from "../types";
 
 export type Route = "cookie" | "preferences" | "closed";
@@ -18,16 +18,14 @@ export type ConsentSource = "default" | "user" | "gpc";
 
 export type GPCConfig = {
 	enabled?: boolean;
-	applicableJurisdictions?: Jurisdiction[] | "all";
+	applicableJurisdictions?: JurisdictionId[] | "all";
 	signal?: boolean;
 };
-
-export type Jurisdiction = "EEA" | "UK" | "CH" | "US" | `US-${string}` | "BR" | "CA" | "AU" | "ROW";
 
 export type ResolverContext = Request | { headers: Headers };
 
 export type JurisdictionResolver = {
-	resolve(req?: ResolverContext): Promise<Jurisdiction | null> | Jurisdiction | null;
+	resolve(req?: ResolverContext): Promise<JurisdictionId | null> | JurisdictionId | null;
 };
 
 export type ConsentExpr =
@@ -46,7 +44,7 @@ export type ConsentState = {
 	route: Route;
 	categories: Category[];
 	decisions: Record<string, boolean>;
-	jurisdiction: Jurisdiction | null;
+	jurisdiction: JurisdictionId | null;
 	policyVersion: string;
 	decidedAt: string | null;
 	source: ConsentSource;
@@ -81,7 +79,7 @@ export type ConsentRecord = {
 	decisions: Record<string, boolean>;
 	policyVersion: string;
 	decidedAt: string;
-	jurisdiction: Jurisdiction | null;
+	jurisdiction: JurisdictionId | null;
 	locale: string;
 	source: ConsentRecordSource;
 };
@@ -140,7 +138,7 @@ export type ConsentStore = {
 	save(opts?: ActionOptions): void;
 	setRoute(route: Route): void;
 	has(expr: ConsentExpr): boolean;
-	refreshJurisdiction(req?: ResolverContext): Promise<Jurisdiction | null>;
+	refreshJurisdiction(req?: ResolverContext): Promise<JurisdictionId | null>;
 };
 
 export type ScriptDefinition = {

--- a/packages/core/src/document.test.ts
+++ b/packages/core/src/document.test.ts
@@ -1,9 +1,18 @@
 import { expect, test } from "vite-plus/test";
-import type { ParagraphNode, TableNode } from "./documents";
-import { compile } from "./documents";
-import type { PrivacyPolicyConfig } from "./types";
+import type { Document, ParagraphNode, TableNode } from "./documents";
+import { compilePrivacyPolicy } from "./index";
+import type { PolicyStackConfig } from "./types";
 
-const minimalPrivacyConfig: PrivacyPolicyConfig = {
+// compilePrivacyPolicy returns Document | null (null = privacy not emitted).
+// Every fixture below has data.collected populated, so a Document is expected;
+// unwrap once here rather than asserting non-null at 40 call sites.
+function privacy(config: PolicyStackConfig): Document {
+	const doc = compilePrivacyPolicy(config);
+	if (!doc) throw new Error("expected a privacy document");
+	return doc;
+}
+
+const minimalPrivacyConfig: PolicyStackConfig = {
 	effectiveDate: "2026-01-01",
 	locale: "en",
 	company: {
@@ -35,40 +44,52 @@ const minimalPrivacyConfig: PrivacyPolicyConfig = {
 		},
 	},
 	thirdParties: [],
-	userRights: ["access"],
 	jurisdictions: ["ca"],
 };
 
 test("compile returns a Document with correct type", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig });
+	const doc = privacy({ ...minimalPrivacyConfig });
 	expect(doc.policyType).toBe("privacy");
 	expect(Array.isArray(doc.sections)).toBe(true);
 });
 
 test("privacy compile returns non-empty sections", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig });
+	const doc = privacy({ ...minimalPrivacyConfig });
 	expect(doc.sections.length).toBeGreaterThan(0);
 });
 
 test("Reserved-region config has expected section IDs (no EU/UK/CA-only sections)", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig });
+	const doc = privacy({ ...minimalPrivacyConfig });
 	const ids = doc.sections.map((s) => s.id);
 	expect(ids).toContain("introduction");
 	expect(ids).toContain("data-collected");
 	expect(ids).toContain("data-retention");
 	expect(ids).toContain("cookies");
 	expect(ids).toContain("third-parties");
-	expect(ids).toContain("user-rights");
 	expect(ids).toContain("contact");
 	expect(ids).not.toContain("legal-basis");
 	expect(ids).not.toContain("gdpr-supplement");
 	expect(ids).not.toContain("uk-gdpr-supplement");
 	expect(ids).not.toContain("ccpa-supplement");
+	// user-rights is jurisdiction-derived now (deriveUserRights). Canada-only
+	// declares no statutory rights, so the section is correctly absent here.
+	expect(ids).not.toContain("user-rights");
+});
+
+test("user-rights section is derived from jurisdiction (present under EEA, absent for Canada-only)", () => {
+	const caOnly = privacy({ ...minimalPrivacyConfig });
+	expect(caOnly.sections.map((s) => s.id)).not.toContain("user-rights");
+
+	const eea = privacy({ ...minimalPrivacyConfig, jurisdictions: ["eea"] });
+	const ur = eea.sections.find((s) => s.id === "user-rights");
+	expect(ur).toBeDefined();
+	const blob = JSON.stringify(ur);
+	expect(blob).toContain("Your Rights");
+	expect(blob).toContain("Right to access your personal data");
 });
 
 test("EU config includes lawful-basis column in data-collected and gdpr-supplement", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 	});
@@ -81,8 +102,7 @@ test("EU config includes lawful-basis column in data-collected and gdpr-suppleme
 });
 
 test("UK config includes lawful-basis column in data-collected and uk-gdpr-supplement (not gdpr-supplement)", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["uk"],
 	});
@@ -99,8 +119,7 @@ test("UK config includes lawful-basis column in data-collected and uk-gdpr-suppl
 });
 
 test("US-CA config includes ccpa-supplement", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["us-ca"],
 	});
@@ -109,8 +128,7 @@ test("US-CA config includes ccpa-supplement", () => {
 });
 
 test("CA (Canada) alone does not include ccpa-supplement or gdpr-supplement", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["ca"],
 	});
@@ -121,14 +139,13 @@ test("CA (Canada) alone does not include ccpa-supplement or gdpr-supplement", ()
 });
 
 test("children-privacy section absent when children not set", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig });
+	const doc = privacy({ ...minimalPrivacyConfig });
 	const ids = doc.sections.map((s) => s.id);
 	expect(ids).not.toContain("children-privacy");
 });
 
 test("children-privacy section present when children is set", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		children: { underAge: 13 },
 	});
@@ -137,8 +154,7 @@ test("children-privacy section present when children is set", () => {
 });
 
 test("children-privacy has noticeUrl link when provided", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		children: { underAge: 13, noticeUrl: "https://acme.com/children" },
 	});
@@ -153,8 +169,7 @@ test("children-privacy has noticeUrl link when provided", () => {
 
 test("compile throws when data.collected is empty", () => {
 	expect(() =>
-		compile({
-			type: "privacy",
+		privacy({
 			...minimalPrivacyConfig,
 			data: {
 				collected: {},
@@ -165,7 +180,7 @@ test("compile throws when data.collected is empty", () => {
 });
 
 test("data-collected section has a table with at least one row", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig });
+	const doc = privacy({ ...minimalPrivacyConfig });
 	const s = doc.sections.find((x) => x.id === "data-collected")!;
 	const tbl = s.content.find((n) => n.type === "table") as TableNode;
 	expect(tbl.rows.length).toBeGreaterThan(0);
@@ -173,8 +188,7 @@ test("data-collected section has a table with at least one row", () => {
 });
 
 test("data-collected table includes the purpose for each category", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		data: {
 			collected: {
@@ -211,8 +225,7 @@ test("data-collected table includes the purpose for each category", () => {
 });
 
 test("gdpr-supplement mentions DPO when one is configured", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		company: {
@@ -229,8 +242,7 @@ test("gdpr-supplement mentions DPO when one is configured", () => {
 });
 
 test("gdpr-supplement states no DPO when company.dpo.required === false", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		company: {
@@ -246,8 +258,7 @@ test("gdpr-supplement states no DPO when company.dpo.required === false", () => 
 });
 
 test("gdpr-supplement falls back to no-DPO disclosure when unset", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 	});
@@ -258,8 +269,7 @@ test("gdpr-supplement falls back to no-DPO disclosure when unset", () => {
 });
 
 test("uk-gdpr-supplement includes DPO contact when configured", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["uk"],
 		company: {
@@ -274,8 +284,7 @@ test("uk-gdpr-supplement includes DPO contact when configured", () => {
 });
 
 test("contact section lists DPO when configured", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		company: {
 			...minimalPrivacyConfig.company,
@@ -289,7 +298,7 @@ test("contact section lists DPO when configured", () => {
 });
 
 test("introduction section has ParagraphNode children", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig });
+	const doc = privacy({ ...minimalPrivacyConfig });
 	const intro = doc.sections.find((s) => s.id === "introduction")!;
 	expect(intro.content.length).toBeGreaterThan(0);
 	const firstNode = intro.content[0];
@@ -300,20 +309,19 @@ test("introduction section has ParagraphNode children", () => {
 });
 
 test("privacy introduction renders version when set", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig, version: "abc12345" });
+	const doc = privacy({ ...minimalPrivacyConfig, privacyVersion: "abc12345" });
 	const intro = doc.sections.find((s) => s.id === "introduction")!;
 	expect(JSON.stringify(intro)).toContain("Version: abc12345");
 });
 
 test("privacy introduction omits version line when version is unset", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig });
+	const doc = privacy({ ...minimalPrivacyConfig });
 	const intro = doc.sections.find((s) => s.id === "introduction")!;
 	expect(JSON.stringify(intro)).not.toContain("Version:");
 });
 
 test("data-collected table includes lawful-basis labels with Article 6 sub-clause under EU jurisdiction", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		data: {
@@ -352,8 +360,7 @@ test("data-collected table includes lawful-basis labels with Article 6 sub-claus
 });
 
 test("consent-withdrawal section is rendered when any data category uses consent (EU)", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		data: {
@@ -393,8 +400,7 @@ test("consent-withdrawal section is rendered when any data category uses consent
 });
 
 test("consent-withdrawal section is rendered when only cookies use consent (EU)", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		cookies: {
@@ -412,8 +418,7 @@ test("consent-withdrawal section is rendered when only cookies use consent (EU)"
 });
 
 test("consent-withdrawal section is omitted when no data or cookie basis is consent (EU)", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		data: {
@@ -451,8 +456,7 @@ test("consent-withdrawal section is omitted when no data or cookie basis is cons
 });
 
 test("consent-withdrawal section is omitted under non-EU/UK jurisdictions even when consent is used", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["us-ca"],
 		cookies: {
@@ -467,8 +471,7 @@ test("consent-withdrawal section is omitted under non-EU/UK jurisdictions even w
 });
 
 test("data-collected section does not carry the consent-withdrawal paragraph (it's its own section now)", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		data: {
@@ -492,8 +495,7 @@ test("data-collected section does not carry the consent-withdrawal paragraph (it
 });
 
 test("data-collected table omits the lawful-basis column under non-GDPR jurisdictions", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["ca"],
 	});
@@ -504,8 +506,7 @@ test("data-collected table omits the lawful-basis column under non-GDPR jurisdic
 });
 
 test("automated-decision-making section is omitted under non-EU/UK jurisdictions even when set", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["us-ca"],
 		automatedDecisionMaking: [],
@@ -514,8 +515,7 @@ test("automated-decision-making section is omitted under non-EU/UK jurisdictions
 });
 
 test("automated-decision-making section is omitted when field is undefined under EU", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 	});
@@ -523,8 +523,7 @@ test("automated-decision-making section is omitted when field is undefined under
 });
 
 test("automated-decision-making section emits explicit-none paragraph when [] under EU", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		automatedDecisionMaking: [],
@@ -538,8 +537,7 @@ test("automated-decision-making section emits explicit-none paragraph when [] un
 });
 
 test("gdpr-supplement complaint paragraph links to EDPB members directory", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 	});
@@ -551,8 +549,7 @@ test("gdpr-supplement complaint paragraph links to EDPB members directory", () =
 });
 
 test("gdpr-supplement does not mention Article 27 representative when unset", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 	});
@@ -563,8 +560,7 @@ test("gdpr-supplement does not mention Article 27 representative when unset", ()
 });
 
 test("gdpr-supplement renders Article 27 representative paragraph when configured", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		company: {
@@ -585,8 +581,7 @@ test("gdpr-supplement renders Article 27 representative paragraph when configure
 });
 
 test("gdpr-supplement names specific Article 46 transfer safeguards and links the adequacy registry", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 	});
@@ -604,8 +599,7 @@ test("gdpr-supplement names specific Article 46 transfer safeguards and links th
 });
 
 test("uk-gdpr-supplement still names the ICO with its complaint URL", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["uk"],
 	});
@@ -616,8 +610,7 @@ test("uk-gdpr-supplement still names the ICO with its complaint URL", () => {
 });
 
 test("provision-requirement section renders one paragraph per category covering each basis (EU)", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		data: {
@@ -682,8 +675,7 @@ test("provision-requirement section renders one paragraph per category covering 
 });
 
 test("provision-requirement section is omitted under non-EU/UK jurisdictions", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["us-ca"],
 	});
@@ -691,8 +683,7 @@ test("provision-requirement section is omitted under non-EU/UK jurisdictions", (
 });
 
 test("provision-requirement section is rendered under UK jurisdiction", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["uk"],
 	});
@@ -700,8 +691,7 @@ test("provision-requirement section is rendered under UK jurisdiction", () => {
 });
 
 test("automated-decision-making section enumerates each activity and appends Art. 22 right-to-human-review", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["eea"],
 		automatedDecisionMaking: [
@@ -725,8 +715,7 @@ test("automated-decision-making section enumerates each activity and appends Art
 });
 
 test("Contact section renders phone when company.contact.phone is set", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		company: {
 			...minimalPrivacyConfig.company,
@@ -741,15 +730,14 @@ test("Contact section renders phone when company.contact.phone is set", () => {
 });
 
 test("Contact section omits phone when company.contact.phone is unset", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig });
+	const doc = privacy({ ...minimalPrivacyConfig });
 	const contact = doc.sections.find((s) => s.id === "contact")!;
 	const blob = JSON.stringify(contact);
 	expect(blob).not.toContain("Phone:");
 });
 
 test("CCPA supplement renders Submitting Requests with email and phone when us-ca", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["us-ca"],
 		company: {
@@ -766,8 +754,7 @@ test("CCPA supplement renders Submitting Requests with email and phone when us-c
 });
 
 test("CCPA supplement Submitting Requests lists email even when phone is unset", () => {
-	const doc = compile({
-		type: "privacy",
+	const doc = privacy({
 		...minimalPrivacyConfig,
 		jurisdictions: ["us-ca"],
 	});
@@ -778,6 +765,6 @@ test("CCPA supplement Submitting Requests lists email even when phone is unset",
 });
 
 test("CCPA supplement is omitted when us-ca is not in jurisdictions", () => {
-	const doc = compile({ type: "privacy", ...minimalPrivacyConfig });
+	const doc = privacy({ ...minimalPrivacyConfig });
 	expect(doc.sections.find((s) => s.id === "ccpa-supplement")).toBeUndefined();
 });

--- a/packages/core/src/documents/cookie.ts
+++ b/packages/core/src/documents/cookie.ts
@@ -1,20 +1,21 @@
 import type { T } from "../i18n";
 import { formatDate } from "../i18n";
-import type { CookiePolicyConfig } from "../types";
+import { deriveConsentMechanism } from "../normalize";
+import { ESSENTIAL_ONLY_COOKIES, type PolicyStackConfig } from "../types";
 import { bold, cell, heading, li, link, p, row, section, table, ul } from "./helpers";
 import type { ComplianceReason, DocumentSection, TableRowNode } from "./types";
 
-function versionSuffix(config: CookiePolicyConfig, t: T): string {
-	return config.version ? t.shared.versionSuffix({ version: config.version }) : "";
+function versionSuffix(config: PolicyStackConfig, t: T): string {
+	return config.cookieVersion ? t.shared.versionSuffix({ version: config.cookieVersion }) : "";
 }
 
-function buildIntroduction(config: CookiePolicyConfig, t: T): DocumentSection {
+function buildIntroduction(config: PolicyStackConfig, t: T): DocumentSection {
 	return section("cookie-introduction", [
 		heading(t.cookie.introduction.heading()),
 		p([
 			t.cookie.introduction.body({
 				companyName: config.company.name,
-				effectiveDate: formatDate(config.effectiveDate, config.locale),
+				effectiveDate: formatDate(config.effectiveDate, config.locale ?? "en"),
 				versionSuffix: versionSuffix(config, t),
 			}),
 		]),
@@ -39,9 +40,10 @@ function cookieTypeMeta(key: string, t: T): { label: string; description: string
 	return t.cookie.types.fallback({ key });
 }
 
-function buildTypes(config: CookiePolicyConfig, t: T): DocumentSection {
+function buildTypes(config: PolicyStackConfig, t: T): DocumentSection {
+	const cookies = config.cookies ?? ESSENTIAL_ONLY_COOKIES;
 	const types: { label: string; description: string }[] = [];
-	for (const [key, enabled] of Object.entries(config.cookies.used)) {
+	for (const [key, enabled] of Object.entries(cookies.used)) {
 		if (!enabled) continue;
 		types.push(cookieTypeMeta(key, t));
 	}
@@ -62,7 +64,7 @@ function buildTypes(config: CookiePolicyConfig, t: T): DocumentSection {
 	]);
 }
 
-function buildTrackingTechnologies(config: CookiePolicyConfig, t: T): DocumentSection | null {
+function buildTrackingTechnologies(config: PolicyStackConfig, t: T): DocumentSection | null {
 	if (!config.trackingTechnologies || config.trackingTechnologies.length === 0) return null;
 	return section("cookie-tracking-technologies", [
 		heading(t.cookie.trackingTechnologies.heading()),
@@ -71,7 +73,7 @@ function buildTrackingTechnologies(config: CookiePolicyConfig, t: T): DocumentSe
 	]);
 }
 
-function buildThirdParties(config: CookiePolicyConfig, t: T): DocumentSection | null {
+function buildThirdParties(config: PolicyStackConfig, t: T): DocumentSection | null {
 	if (!config.thirdParties || config.thirdParties.length === 0) return null;
 	const rows: TableRowNode[] = config.thirdParties.map((tp) =>
 		row([
@@ -87,9 +89,10 @@ function buildThirdParties(config: CookiePolicyConfig, t: T): DocumentSection | 
 	]);
 }
 
-function buildConsent(config: CookiePolicyConfig, t: T): DocumentSection | null {
-	if (!config.consentMechanism) return null;
-	const { hasBanner, hasPreferencePanel, canWithdraw } = config.consentMechanism;
+function buildConsent(config: PolicyStackConfig, t: T): DocumentSection | null {
+	const mechanism = deriveConsentMechanism(config);
+	if (!mechanism) return null;
+	const { hasBanner, hasPreferencePanel, canWithdraw } = mechanism;
 	const items: string[] = [];
 	if (hasBanner) items.push(t.cookie.consent.banner());
 	if (hasPreferencePanel) items.push(t.cookie.consent.panel());
@@ -114,7 +117,7 @@ function buildManaging(t: T): DocumentSection {
 	]);
 }
 
-function buildJurisdictionEuUk(config: CookiePolicyConfig, t: T): DocumentSection | null {
+function buildJurisdictionEuUk(config: PolicyStackConfig, t: T): DocumentSection | null {
 	const hasEu = config.jurisdictions.includes("eea");
 	const hasUk = config.jurisdictions.includes("uk");
 	if (!hasEu && !hasUk) return null;
@@ -137,7 +140,7 @@ function buildJurisdictionEuUk(config: CookiePolicyConfig, t: T): DocumentSectio
 	]);
 }
 
-function buildContact(config: CookiePolicyConfig, t: T): DocumentSection {
+function buildContact(config: PolicyStackConfig, t: T): DocumentSection {
 	const items = [
 		li([bold(`${t.shared.contactLabels.legalName()} `), config.company.legalName]),
 		li([bold(`${t.shared.contactLabels.address()} `), config.company.address]),
@@ -156,7 +159,7 @@ function buildContact(config: CookiePolicyConfig, t: T): DocumentSection {
 	]);
 }
 
-const SECTION_BUILDERS: ((config: CookiePolicyConfig, t: T) => DocumentSection | null)[] = [
+const SECTION_BUILDERS: ((config: PolicyStackConfig, t: T) => DocumentSection | null)[] = [
 	buildIntroduction,
 	(_, t) => buildWhatAreCookies(t),
 	buildTypes,
@@ -168,7 +171,7 @@ const SECTION_BUILDERS: ((config: CookiePolicyConfig, t: T) => DocumentSection |
 	buildContact,
 ];
 
-export function compileCookieDocument(config: CookiePolicyConfig, t: T): DocumentSection[] {
+export function compileCookieDocument(config: PolicyStackConfig, t: T): DocumentSection[] {
 	return SECTION_BUILDERS.map((builder) => builder(config, t)).filter(
 		(s): s is DocumentSection => s !== null,
 	);

--- a/packages/core/src/documents/index.ts
+++ b/packages/core/src/documents/index.ts
@@ -1,30 +1,5 @@
-import { createT } from "../i18n";
-import type { Dictionary } from "../i18n";
-import type { PolicyInput } from "../types";
-import { compileCookieDocument } from "./cookie";
-import { compilePrivacyDocument } from "./privacy";
-import { AST_VERSION, type Document } from "./types";
-
-export function compile(input: PolicyInput, dictionary?: Dictionary): Document {
-	const t = createT(input.locale, dictionary);
-	if (input.type === "privacy") {
-		const { type: _, ...config } = input;
-		return {
-			type: "document",
-			astVersion: AST_VERSION,
-			policyType: "privacy",
-			sections: compilePrivacyDocument(config, t),
-		};
-	}
-	const { type: _, ...config } = input;
-	return {
-		type: "document",
-		astVersion: AST_VERSION,
-		policyType: "cookie",
-		sections: compileCookieDocument(config, t),
-	};
-}
-
+export { compileCookieDocument } from "./cookie";
+export { compilePrivacyDocument } from "./privacy";
 export {
 	bold,
 	cell,
@@ -42,7 +17,7 @@ export {
 	text,
 	ul,
 } from "./helpers";
-export { AST_VERSION } from "./types";
+export { AST_VERSION, PROVENANCE_CODES } from "./types";
 export type {
 	BoldNode,
 	ComplianceReason,
@@ -51,7 +26,6 @@ export type {
 	DocumentSection,
 	HeadingNode,
 	InlineNode,
-	IssueCode,
 	ItalicNode,
 	LinkNode,
 	ListItemNode,
@@ -60,6 +34,7 @@ export type {
 	NodeContext,
 	ParagraphNode,
 	PolicyType,
+	ProvenanceCode,
 	TableCellNode,
 	TableHeaderCellNode,
 	TableHeaderRowNode,

--- a/packages/core/src/documents/index.ts
+++ b/packages/core/src/documents/index.ts
@@ -17,7 +17,7 @@ export {
 	text,
 	ul,
 } from "./helpers";
-export { AST_VERSION, PROVENANCE_CODES } from "./types";
+export { AST_VERSION } from "./types";
 export type {
 	BoldNode,
 	ComplianceReason,
@@ -34,7 +34,6 @@ export type {
 	NodeContext,
 	ParagraphNode,
 	PolicyType,
-	ProvenanceCode,
 	TableCellNode,
 	TableHeaderCellNode,
 	TableHeaderRowNode,

--- a/packages/core/src/documents/privacy.ts
+++ b/packages/core/src/documents/privacy.ts
@@ -1,6 +1,7 @@
 import type { T } from "../i18n";
 import { formatDate } from "../i18n";
-import type { PrivacyPolicyConfig } from "../types";
+import { ESSENTIAL_ONLY_COOKIES, type PolicyStackConfig } from "../types";
+import { deriveUserRights } from "../user-rights";
 import { bold, cell, heading, li, link, p, row, section, table, ul } from "./helpers";
 import type {
 	ComplianceReason,
@@ -11,17 +12,17 @@ import type {
 	TableRowNode,
 } from "./types";
 
-function versionSuffix(config: PrivacyPolicyConfig, t: T): string {
-	return config.version ? t.shared.versionSuffix({ version: config.version }) : "";
+function versionSuffix(config: PolicyStackConfig, t: T): string {
+	return config.privacyVersion ? t.shared.versionSuffix({ version: config.privacyVersion }) : "";
 }
 
-function buildIntroduction(config: PrivacyPolicyConfig, t: T): DocumentSection {
+function buildIntroduction(config: PolicyStackConfig, t: T): DocumentSection {
 	return section("introduction", [
 		heading(t.privacy.introduction.heading()),
 		p([
 			t.privacy.introduction.body({
 				companyName: config.company.name,
-				effectiveDate: formatDate(config.effectiveDate, config.locale),
+				effectiveDate: formatDate(config.effectiveDate, config.locale ?? "en"),
 				versionSuffix: versionSuffix(config, t),
 			}),
 		]),
@@ -29,7 +30,7 @@ function buildIntroduction(config: PrivacyPolicyConfig, t: T): DocumentSection {
 	]);
 }
 
-function buildChildrenPrivacy(config: PrivacyPolicyConfig, t: T): DocumentSection | null {
+function buildChildrenPrivacy(config: PolicyStackConfig, t: T): DocumentSection | null {
 	if (!config.children) return null;
 	const { underAge, noticeUrl } = config.children;
 	return section("children-privacy", [
@@ -53,7 +54,7 @@ function buildChildrenPrivacy(config: PrivacyPolicyConfig, t: T): DocumentSectio
 	]);
 }
 
-function buildDataCollected(config: PrivacyPolicyConfig, t: T): DocumentSection {
+function buildDataCollected(config: PolicyStackConfig, t: T): DocumentSection {
 	const { collected, context } = config.data;
 	const includeLegalBasis =
 		config.jurisdictions.includes("eea") || config.jurisdictions.includes("uk");
@@ -96,13 +97,14 @@ function buildDataCollected(config: PrivacyPolicyConfig, t: T): DocumentSection 
 	]);
 }
 
-function usesConsent(config: PrivacyPolicyConfig): boolean {
+function usesConsent(config: PolicyStackConfig): boolean {
 	if (Object.values(config.data.context).some((e) => e.lawfulBasis === "consent")) return true;
-	if (Object.values(config.cookies.context).some((e) => e.lawfulBasis === "consent")) return true;
+	if (Object.values(config.cookies?.context ?? {}).some((e) => e.lawfulBasis === "consent"))
+		return true;
 	return false;
 }
 
-function buildConsentWithdrawal(config: PrivacyPolicyConfig, t: T): DocumentSection | null {
+function buildConsentWithdrawal(config: PolicyStackConfig, t: T): DocumentSection | null {
 	if (!config.jurisdictions.includes("eea") && !config.jurisdictions.includes("uk")) return null;
 	if (!usesConsent(config)) return null;
 	return section("consent-withdrawal", [
@@ -118,7 +120,7 @@ function buildConsentWithdrawal(config: PrivacyPolicyConfig, t: T): DocumentSect
 	]);
 }
 
-function buildAutomatedDecisionMaking(config: PrivacyPolicyConfig, t: T): DocumentSection | null {
+function buildAutomatedDecisionMaking(config: PolicyStackConfig, t: T): DocumentSection | null {
 	if (!config.jurisdictions.includes("eea") && !config.jurisdictions.includes("uk")) return null;
 	const decisions = config.automatedDecisionMaking;
 	if (decisions === undefined) return null;
@@ -163,7 +165,7 @@ function buildAutomatedDecisionMaking(config: PrivacyPolicyConfig, t: T): Docume
 	return section("automated-decision-making", content);
 }
 
-function buildDataRetention(config: PrivacyPolicyConfig, t: T): DocumentSection {
+function buildDataRetention(config: PolicyStackConfig, t: T): DocumentSection {
 	const rows: TableRowNode[] = Object.entries(config.data.context).map(([category, entry]) =>
 		row([cell([bold(category)]), cell([entry.retention])]),
 	);
@@ -174,7 +176,7 @@ function buildDataRetention(config: PrivacyPolicyConfig, t: T): DocumentSection 
 	]);
 }
 
-function buildProvisionRequirement(config: PrivacyPolicyConfig, t: T): DocumentSection | null {
+function buildProvisionRequirement(config: PolicyStackConfig, t: T): DocumentSection | null {
 	if (!config.jurisdictions.includes("eea") && !config.jurisdictions.includes("uk")) return null;
 	const entries = Object.entries(config.data.context);
 	if (entries.length === 0) return null;
@@ -202,12 +204,13 @@ function cookieCategoryLabel(key: string, t: T): string {
 	return entry ? entry() : t.privacy.cookieCategoryFallback({ key });
 }
 
-function buildCookies(config: PrivacyPolicyConfig, t: T): DocumentSection {
+function buildCookies(config: PolicyStackConfig, t: T): DocumentSection {
+	const cookies = config.cookies ?? ESSENTIAL_ONLY_COOKIES;
 	const rows: TableRowNode[] = [];
-	for (const [key, enabled] of Object.entries(config.cookies.used)) {
+	for (const [key, enabled] of Object.entries(cookies.used)) {
 		if (!enabled) continue;
 		const label = cookieCategoryLabel(key, t);
-		const basis = config.cookies.context[key]?.lawfulBasis;
+		const basis = cookies.context[key]?.lawfulBasis;
 		rows.push(row([cell([label]), cell([basis ? t.shared.legalBasisLabels[basis]() : ""])]));
 	}
 
@@ -224,14 +227,15 @@ function buildCookies(config: PrivacyPolicyConfig, t: T): DocumentSection {
 	]);
 }
 
-function buildThirdParties(config: PrivacyPolicyConfig, t: T): DocumentSection {
-	if (config.thirdParties.length === 0) {
+function buildThirdParties(config: PolicyStackConfig, t: T): DocumentSection {
+	const thirdParties = config.thirdParties ?? [];
+	if (thirdParties.length === 0) {
 		return section("third-parties", [
 			heading(t.privacy.thirdParties.heading()),
 			p([t.privacy.thirdParties.empty()]),
 		]);
 	}
-	const rows: TableRowNode[] = config.thirdParties.map((tp) =>
+	const rows: TableRowNode[] = thirdParties.map((tp) =>
 		row([
 			cell([bold(tp.name)]),
 			cell([tp.purpose]),
@@ -245,9 +249,10 @@ function buildThirdParties(config: PrivacyPolicyConfig, t: T): DocumentSection {
 	]);
 }
 
-function buildUserRights(config: PrivacyPolicyConfig, t: T): DocumentSection | null {
-	if (config.userRights.length === 0) return null;
-	const items = config.userRights.map((right) => li([t.privacy.userRights.labels[right]()]));
+function buildUserRights(config: PolicyStackConfig, t: T): DocumentSection | null {
+	const userRights = deriveUserRights(config.jurisdictions);
+	if (userRights.length === 0) return null;
+	const items = userRights.map((right) => li([t.privacy.userRights.labels[right]()]));
 	return section("user-rights", [
 		heading(t.privacy.userRights.heading()),
 		p([t.privacy.userRights.intro()]),
@@ -255,7 +260,7 @@ function buildUserRights(config: PrivacyPolicyConfig, t: T): DocumentSection | n
 	]);
 }
 
-function dpoParagraph(config: PrivacyPolicyConfig, t: T): ContentNode {
+function dpoParagraph(config: PolicyStackConfig, t: T): ContentNode {
 	const { dpo } = config.company;
 	if (dpo && "email" in dpo) {
 		const parts: (string | InlineNode)[] = [bold(t.shared.contactLabels.dpo()), " "];
@@ -273,7 +278,7 @@ function dpoParagraph(config: PrivacyPolicyConfig, t: T): ContentNode {
 	return p([t.privacy.dpo.absentFallback()]);
 }
 
-function euRepresentativeParagraph(config: PrivacyPolicyConfig, t: T): ContentNode | null {
+function euRepresentativeParagraph(config: PolicyStackConfig, t: T): ContentNode | null {
 	const rep = config.company.euRepresentative;
 	if (!rep) return null;
 	const { prefix, suffix } = t.privacy.euRepresentative.body({
@@ -284,7 +289,7 @@ function euRepresentativeParagraph(config: PrivacyPolicyConfig, t: T): ContentNo
 	return p([prefix, bold(rep.name), suffix]);
 }
 
-function buildGdprSupplement(config: PrivacyPolicyConfig, t: T): DocumentSection | null {
+function buildGdprSupplement(config: PolicyStackConfig, t: T): DocumentSection | null {
 	if (!config.jurisdictions.includes("eea")) return null;
 	const content: ContentNode[] = [
 		heading(t.privacy.gdprSupplement.heading(), {
@@ -326,7 +331,7 @@ function buildGdprSupplement(config: PrivacyPolicyConfig, t: T): DocumentSection
 	return section("gdpr-supplement", content);
 }
 
-function buildUkGdprSupplement(config: PrivacyPolicyConfig, t: T): DocumentSection | null {
+function buildUkGdprSupplement(config: PolicyStackConfig, t: T): DocumentSection | null {
 	if (!config.jurisdictions.includes("uk")) return null;
 	return section("uk-gdpr-supplement", [
 		heading(t.privacy.ukGdprSupplement.heading(), {
@@ -354,7 +359,7 @@ function buildUkGdprSupplement(config: PrivacyPolicyConfig, t: T): DocumentSecti
 	]);
 }
 
-function buildCcpaSupplement(config: PrivacyPolicyConfig, t: T): DocumentSection | null {
+function buildCcpaSupplement(config: PolicyStackConfig, t: T): DocumentSection | null {
 	if (!config.jurisdictions.includes("us-ca")) return null;
 	const { email, phone } = config.company.contact;
 	const submissionMethods: ListItemNode[] = [
@@ -384,7 +389,7 @@ function buildCcpaSupplement(config: PrivacyPolicyConfig, t: T): DocumentSection
 	]);
 }
 
-function buildContact(config: PrivacyPolicyConfig, t: T): DocumentSection {
+function buildContact(config: PolicyStackConfig, t: T): DocumentSection {
 	const items = [
 		li([bold(t.shared.contactLabels.legalName()), " ", config.company.legalName]),
 		li([bold(t.shared.contactLabels.address()), " ", config.company.address]),
@@ -412,7 +417,7 @@ function buildContact(config: PrivacyPolicyConfig, t: T): DocumentSection {
 	]);
 }
 
-const SECTION_BUILDERS: ((config: PrivacyPolicyConfig, t: T) => DocumentSection | null)[] = [
+const SECTION_BUILDERS: ((config: PolicyStackConfig, t: T) => DocumentSection | null)[] = [
 	buildIntroduction,
 	buildChildrenPrivacy,
 	buildDataCollected,
@@ -429,7 +434,7 @@ const SECTION_BUILDERS: ((config: PrivacyPolicyConfig, t: T) => DocumentSection 
 	buildContact,
 ];
 
-export function compilePrivacyDocument(config: PrivacyPolicyConfig, t: T): DocumentSection[] {
+export function compilePrivacyDocument(config: PolicyStackConfig, t: T): DocumentSection[] {
 	if (Object.keys(config.data.collected).length === 0) {
 		throw new Error(
 			"PolicyStack: cannot compile a privacy policy with no data collected. " +

--- a/packages/core/src/documents/types.ts
+++ b/packages/core/src/documents/types.ts
@@ -6,10 +6,11 @@ import type { LegalBasis } from "../types";
  * {@link ComplianceReason} — *why* that node was emitted. This is a distinct
  * axis from the validator's diagnostic `IssueCode` (issue-codes.ts): a
  * provenance code traces emitted document structure, a diagnostic code flags a
- * config problem. Frozen registry (house style, like `ISSUE_CODES`) so the
- * union is derived with no drift and a builder typo is a compile error.
+ * config problem. Module-local frozen list: it exists only to derive the
+ * `ProvenanceCode` union so a builder typo is a compile error — nothing
+ * enumerates it at runtime (unlike `ISSUE_CODES`), so it stays internal.
  */
-export const PROVENANCE_CODES = [
+const PROVENANCE_CODES = [
 	"automated-decision-making",
 	"ccpa-supplement",
 	"children-privacy",

--- a/packages/core/src/documents/types.ts
+++ b/packages/core/src/documents/types.ts
@@ -2,13 +2,27 @@ import type { JurisdictionId } from "../jurisdiction-id";
 import type { LegalBasis } from "../types";
 
 /**
- * A stable validator/compliance issue code.
- *
- * Placeholder: narrowed to the validator `IssueCode` union by the §2.1
- * validator-consolidation ticket. Narrowing a `string` alias to a union is a
- * non-breaking change for *producers* of the AST (see ADR 0001).
+ * The closed set of provenance codes a section builder stamps onto a node's
+ * {@link ComplianceReason} — *why* that node was emitted. This is a distinct
+ * axis from the validator's diagnostic `IssueCode` (issue-codes.ts): a
+ * provenance code traces emitted document structure, a diagnostic code flags a
+ * config problem. Frozen registry (house style, like `ISSUE_CODES`) so the
+ * union is derived with no drift and a builder typo is a compile error.
  */
-export type IssueCode = string;
+export const PROVENANCE_CODES = [
+	"automated-decision-making",
+	"ccpa-supplement",
+	"children-privacy",
+	"consent-withdrawal",
+	"cookie-jurisdiction-eu-uk",
+	"data-collected",
+	"gdpr-supplement",
+	"provision-requirement",
+	"uk-gdpr-supplement",
+] as const;
+
+/** A stable, machine-keyable reason a node exists. Derived from {@link PROVENANCE_CODES}. */
+export type ProvenanceCode = (typeof PROVENANCE_CODES)[number];
 
 /**
  * A typed, machine-readable trace of *why* a node exists — the compliance
@@ -17,7 +31,7 @@ export type IssueCode = string;
  * `citation` carries the verbatim legal article text for render/audit display.
  */
 export type ComplianceReason = {
-	code: IssueCode;
+	code: ProvenanceCode;
 	jurisdiction?: JurisdictionId | readonly JurisdictionId[];
 	lawfulBasis?: LegalBasis;
 	citation?: string; // verbatim legal article text — display only

--- a/packages/core/src/emit.ts
+++ b/packages/core/src/emit.ts
@@ -1,0 +1,23 @@
+import type { PolicyCategory, PolicyStackConfig } from "./types";
+
+const PRIVACY_FIELDS = ["data", "children"] as const;
+
+function hasAnyPrivacyField(config: PolicyStackConfig): boolean {
+	return PRIVACY_FIELDS.some((field) => config[field] !== undefined);
+}
+
+function hasCookieField(config: PolicyStackConfig): boolean {
+	return config.cookies !== undefined;
+}
+
+/**
+ * The single decision for whether a config emits a given policy document.
+ * Read by the compiler entry points (index.ts), the validator (validate.ts),
+ * and the per-document version hash (policy-version.ts) so all three agree on
+ * which documents a config produces. Lives in its own module so validate.ts
+ * does not have to import the index barrel (which would re-introduce a cycle).
+ */
+export function shouldEmit(category: PolicyCategory, config: PolicyStackConfig): boolean {
+	if (config.policies) return config.policies.includes(category);
+	return category === "privacy" ? hasAnyPrivacyField(config) : hasCookieField(config);
+}

--- a/packages/core/src/i18n/i18n.test.ts
+++ b/packages/core/src/i18n/i18n.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vite-plus/test";
-import { compile } from "../documents";
-import type { Locale, PolicyInput } from "../types";
+import { compilePrivacyPolicy } from "../index";
+import type { Locale, PolicyStackConfig } from "../types";
 import { de } from "./de";
 import { en } from "./en";
 import { es } from "./es";
@@ -43,7 +43,7 @@ test("createT returns a caller-supplied dictionary verbatim (full replacement)",
 });
 
 test("compile uses a custom dictionary for emitted strings; locale still drives dates", () => {
-	const doc = compile(buildPrivacyInput("fr"), customDictionary);
+	const doc = compilePrivacyPolicy(buildPrivacyConfig("fr"), customDictionary);
 	const blob = JSON.stringify(doc);
 	expect(blob).toContain("CUSTOM_INTRO_HEADING_XYZ");
 	// `locale: "fr"` still governs date formatting independently of the dictionary.
@@ -222,9 +222,8 @@ const NON_EN_CANARIES: LocaleCanary[] = [
 	},
 ];
 
-function buildPrivacyInput(locale: Locale): PolicyInput {
+function buildPrivacyConfig(locale: Locale): PolicyStackConfig {
 	return {
-		type: "privacy",
 		effectiveDate: "2026-01-01",
 		locale,
 		company: {
@@ -252,14 +251,13 @@ function buildPrivacyInput(locale: Locale): PolicyInput {
 			context: { essential: { lawfulBasis: "legal_obligation" } },
 		},
 		thirdParties: [],
-		userRights: ["access", "rectification", "erasure"],
 		jurisdictions: ["eea"],
 	};
 }
 
 for (const { locale, mustContain } of NON_EN_CANARIES) {
 	test(`${locale} privacy document compiles without English leakage`, () => {
-		const doc = compile(buildPrivacyInput(locale));
+		const doc = compilePrivacyPolicy(buildPrivacyConfig(locale));
 		const blob = JSON.stringify(doc);
 		for (const phrase of ENGLISH_CANARIES) {
 			expect(blob, `${locale}: unexpected English phrase "${phrase}"`).not.toContain(phrase);

--- a/packages/core/src/i18n/locales.ts
+++ b/packages/core/src/i18n/locales.ts
@@ -6,10 +6,9 @@ import { fr } from "./fr";
 import { nl } from "./nl";
 import type { Dictionary } from "./types";
 
-export const LOCALES: readonly Locale[] = ["en", "fr", "de", "nl", "es"] as const;
+// `LOCALES`/`isLocale` live in ../locale (dependency-free) so the consent
+// runtime can share them without pulling these dictionaries in. Re-exported
+// here to keep the historical `@policystack/core` import path unchanged.
+export { isLocale, LOCALES } from "../locale";
 
 export const dictionaries: Record<Locale, Dictionary> = { en, fr, de, nl, es };
-
-export function isLocale(value: unknown): value is Locale {
-	return typeof value === "string" && (LOCALES as readonly string[]).includes(value);
-}

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,50 +1,11 @@
 import { expect, test } from "vite-plus/test";
-import { compile } from "./documents";
 import {
 	compileCookiePolicy,
 	compilePrivacyPolicy,
-	expandPolicyStackConfig,
 	isPolicyStackConfig,
 	shouldEmit,
 } from "./index";
-import type { PolicyStackConfig, PolicyInput } from "./types";
-
-const input: PolicyInput = {
-	type: "privacy",
-	effectiveDate: "2026-01-01",
-	locale: "en",
-	company: {
-		name: "Acme Inc.",
-		legalName: "Acme Corporation",
-		address: "123 Main St, Springfield, USA",
-		contact: { email: "privacy@acme.com" },
-	},
-	data: {
-		collected: { "Account Information": ["Name", "Email"] },
-		context: {
-			"Account Information": {
-				purpose: "To authenticate users",
-				lawfulBasis: "contract",
-				retention: "Until deletion",
-				provision: {
-					basis: "contract-prerequisite",
-					consequences: "We cannot create or operate your account.",
-				},
-			},
-		},
-	},
-	cookies: {
-		used: { essential: true, analytics: false, marketing: false },
-		context: {
-			essential: { lawfulBasis: "legal_obligation" },
-			analytics: { lawfulBasis: "consent" },
-			marketing: { lawfulBasis: "consent" },
-		},
-	},
-	thirdParties: [],
-	userRights: ["access"],
-	jurisdictions: ["ca"],
-};
+import type { PolicyStackConfig } from "./types";
 
 const company = {
 	name: "Acme Inc.",
@@ -86,8 +47,10 @@ test("isPolicyStackConfig returns true for flat config", () => {
 	expect(isPolicyStackConfig(fullConfig)).toBe(true);
 });
 
-test("isPolicyStackConfig returns false for PolicyInput (has type discriminator)", () => {
-	expect(isPolicyStackConfig(input)).toBe(false);
+test("isPolicyStackConfig returns false for an object carrying a type discriminator", () => {
+	expect(isPolicyStackConfig({ type: "privacy", company, effectiveDate: "2026-01-01" })).toBe(
+		false,
+	);
 });
 
 test("isPolicyStackConfig returns false for null/non-object", () => {
@@ -100,96 +63,27 @@ test("isPolicyStackConfig returns false for object without effectiveDate", () =>
 	expect(isPolicyStackConfig({ company })).toBe(false);
 });
 
-test("expandPolicyStackConfig emits both inputs when all fields present", () => {
-	const inputs = expandPolicyStackConfig(fullConfig);
-	expect(inputs).toHaveLength(2);
-	expect(inputs[0]?.type).toBe("privacy");
-	expect(inputs[1]?.type).toBe("cookie");
+test("shouldEmit auto-detects privacy and cookie when both field sets are present", () => {
+	expect(shouldEmit("privacy", fullConfig)).toBe(true);
+	expect(shouldEmit("cookie", fullConfig)).toBe(true);
 });
 
-test("expandPolicyStackConfig merges company and shared fields into each input", () => {
-	const inputs = expandPolicyStackConfig(fullConfig);
-	expect(inputs[0]?.company).toEqual(company);
-	expect(inputs[1]?.company).toEqual(company);
-	expect(inputs[0]?.effectiveDate).toBe("2026-01-01");
-	expect(inputs[1]?.effectiveDate).toBe("2026-01-01");
-	expect(inputs[0]?.jurisdictions).toEqual(["ca"]);
-	expect(inputs[1]?.jurisdictions).toEqual(["ca"]);
-});
-
-test("expandPolicyStackConfig auto-detects privacy-only when cookies omitted", () => {
+test("shouldEmit auto-detects privacy-only when cookies omitted", () => {
 	const { cookies: _, ...privacyOnly } = fullConfig;
-	const inputs = expandPolicyStackConfig(privacyOnly);
-	expect(inputs).toHaveLength(1);
-	expect(inputs[0]?.type).toBe("privacy");
+	expect(shouldEmit("privacy", privacyOnly)).toBe(true);
+	expect(shouldEmit("cookie", privacyOnly)).toBe(false);
 });
 
-test("expandPolicyStackConfig emits cookie-only when policies excludes privacy", () => {
-	const inputs = expandPolicyStackConfig({
-		company,
-		effectiveDate: "2026-01-01",
-		jurisdictions: ["ca"],
-		data: { collected: {}, context: {} },
-		cookies: {
-			used: { essential: true },
-			context: { essential: { lawfulBasis: "legal_obligation" } },
-		},
-		policies: ["cookie"],
-	});
-	expect(inputs).toHaveLength(1);
-	expect(inputs[0]?.type).toBe("cookie");
-});
-
-test("expandPolicyStackConfig returns empty array when policies is empty", () => {
-	const inputs = expandPolicyStackConfig({
-		company,
-		effectiveDate: "2026-01-01",
-		jurisdictions: ["ca"],
-		data: { collected: {}, context: {} },
-		policies: [],
-	});
-	expect(inputs).toHaveLength(0);
-});
-
-test("expandPolicyStackConfig passes automatedDecisionMaking through unchanged when set", () => {
-	const inputs = expandPolicyStackConfig({
-		...fullConfig,
-		automatedDecisionMaking: [
-			{ name: "Fraud scoring", logic: "Rules engine", significance: "May decline" },
-		],
-	});
-	const privacy = inputs.find((i) => i.type === "privacy");
-	expect(privacy?.type).toBe("privacy");
-	if (privacy?.type !== "privacy") throw new Error("expected privacy input");
-	expect(privacy.automatedDecisionMaking).toEqual([
-		{ name: "Fraud scoring", logic: "Rules engine", significance: "May decline" },
-	]);
-});
-
-test("expandPolicyStackConfig preserves undefined automatedDecisionMaking (no default)", () => {
-	const inputs = expandPolicyStackConfig(fullConfig);
-	const privacy = inputs.find((i) => i.type === "privacy");
-	if (privacy?.type !== "privacy") throw new Error("expected privacy input");
-	expect(privacy.automatedDecisionMaking).toBeUndefined();
-});
-
-test("expandPolicyStackConfig preserves explicit empty automatedDecisionMaking array", () => {
-	const inputs = expandPolicyStackConfig({ ...fullConfig, automatedDecisionMaking: [] });
-	const privacy = inputs.find((i) => i.type === "privacy");
-	if (privacy?.type !== "privacy") throw new Error("expected privacy input");
-	expect(privacy.automatedDecisionMaking).toEqual([]);
-});
-
-test("shouldEmit honours explicit policies override", () => {
-	const config: PolicyStackConfig = {
-		...fullConfig,
-		policies: ["privacy"],
-	};
+test("shouldEmit honours an explicit policies override", () => {
+	const config: PolicyStackConfig = { ...fullConfig, policies: ["privacy"] };
 	expect(shouldEmit("privacy", config)).toBe(true);
 	expect(shouldEmit("cookie", config)).toBe(false);
-	const inputs = expandPolicyStackConfig(config);
-	expect(inputs).toHaveLength(1);
-	expect(inputs[0]?.type).toBe("privacy");
+});
+
+test("shouldEmit emits neither when policies is an empty array", () => {
+	const config: PolicyStackConfig = { ...fullConfig, policies: [] };
+	expect(shouldEmit("privacy", config)).toBe(false);
+	expect(shouldEmit("cookie", config)).toBe(false);
 });
 
 test("compilePrivacyPolicy returns a privacy Document when privacy should emit", () => {
@@ -215,48 +109,28 @@ test("compileCookiePolicy returns null when only privacy fields are present", ()
 	expect(compileCookiePolicy(privacyOnly)).toBeNull();
 });
 
-test("compilePrivacyPolicy matches compile(expand(...).find(privacy))", () => {
-	const expanded = expandPolicyStackConfig(fullConfig).find((i) => i.type === "privacy");
-	if (!expanded) throw new Error("expected privacy input");
-	expect(compilePrivacyPolicy(fullConfig)).toEqual(compile(expanded));
+test("compilePrivacyPolicy intro renders version when privacyVersion is set", () => {
+	const doc = compilePrivacyPolicy({ ...fullConfig, privacyVersion: "priv1234" });
+	const intro = doc?.sections.find((s) => s.id === "introduction");
+	expect(JSON.stringify(intro)).toContain("Version: priv1234");
 });
 
-test("compileCookiePolicy matches compile(expand(...).find(cookie))", () => {
-	const expanded = expandPolicyStackConfig(fullConfig).find((i) => i.type === "cookie");
-	if (!expanded) throw new Error("expected cookie input");
-	expect(compileCookiePolicy(fullConfig)).toEqual(compile(expanded));
+test("compilePrivacyPolicy intro omits version when privacyVersion is unset", () => {
+	const doc = compilePrivacyPolicy(fullConfig);
+	const intro = doc?.sections.find((s) => s.id === "introduction");
+	expect(JSON.stringify(intro)).not.toContain("Version:");
 });
 
 test("compileCookiePolicy intro renders version when cookieVersion is set", () => {
 	const doc = compileCookiePolicy({ ...fullConfig, cookieVersion: "cook12345" });
-	const intro = doc?.sections.find((s) => s.id === "cookie-introduction")!;
+	const intro = doc?.sections.find((s) => s.id === "cookie-introduction");
 	expect(JSON.stringify(intro)).toContain("Version: cook12345");
 });
 
 test("compileCookiePolicy intro omits version when cookieVersion is unset", () => {
 	const doc = compileCookiePolicy(fullConfig);
-	const intro = doc?.sections.find((s) => s.id === "cookie-introduction")!;
+	const intro = doc?.sections.find((s) => s.id === "cookie-introduction");
 	expect(JSON.stringify(intro)).not.toContain("Version:");
-});
-
-test("compilePrivacyPolicy intro renders version when privacyVersion is set", () => {
-	const doc = compilePrivacyPolicy({ ...fullConfig, privacyVersion: "priv1234" });
-	const intro = doc?.sections.find((s) => s.id === "introduction")!;
-	expect(JSON.stringify(intro)).toContain("Version: priv1234");
-});
-
-test("expandPolicyStackConfig threads privacyVersion onto privacy input", () => {
-	const inputs = expandPolicyStackConfig({ ...fullConfig, privacyVersion: "priv1234" });
-	const privacy = inputs.find((i) => i.type === "privacy");
-	if (privacy?.type !== "privacy") throw new Error("expected privacy input");
-	expect(privacy.version).toBe("priv1234");
-});
-
-test("expandPolicyStackConfig threads cookieVersion onto cookie input", () => {
-	const inputs = expandPolicyStackConfig({ ...fullConfig, cookieVersion: "cook1234" });
-	const cookie = inputs.find((i) => i.type === "cookie");
-	if (cookie?.type !== "cookie") throw new Error("expected cookie input");
-	expect(cookie.version).toBe("cook1234");
 });
 
 test("company.url renders the Website label in both contact sections (en)", () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export type {
 	NodeContext,
 	ParagraphNode,
 	PolicyType,
+	ProvenanceCode,
 	TableCellNode,
 	TableHeaderCellNode,
 	TableHeaderRowNode,
@@ -22,15 +23,15 @@ export type {
 	TextNode,
 	UnknownNode,
 	Visitor,
-	// `IssueCode` is re-exported once from "./types" (PS-11 froze it there
-	// alongside `Issue`); the duplicate "./documents" re-export was a latent
-	// TS2300 inherited from the v1 base and is dropped here.
+	// The frozen validator `IssueCode` is re-exported once from "./types"
+	// (PS-11). It is a different axis from the AST's `ProvenanceCode` (above):
+	// diagnostics vs. why-a-node-exists.
 } from "./documents";
 export {
 	AST_VERSION,
+	PROVENANCE_CODES,
 	bold,
 	cell,
-	compile,
 	headerCell,
 	headerRow,
 	heading,
@@ -73,7 +74,6 @@ export type {
 	Contact,
 	CookieContext,
 	CookieContextEntry,
-	CookiePolicyConfig,
 	CookiePolicyCookies,
 	CookieUsage,
 	DataCollection,
@@ -90,8 +90,6 @@ export type {
 	PolicyStackConfig,
 	OutputFormat,
 	PolicyCategory,
-	PolicyInput,
-	PrivacyPolicyConfig,
 	ProvisionBasis,
 	ProvisionRequirement,
 	ThirdParty,
@@ -108,102 +106,44 @@ export { ISSUE_CATALOG } from "./issue-catalog";
 export type { IssueExplanation } from "./issue-catalog";
 export { createT, isLocale, LOCALES } from "./i18n";
 export type { Dictionary, T } from "./i18n";
+export { shouldEmit } from "./emit";
 
-import { compile } from "./documents";
+import { AST_VERSION, compileCookieDocument, compilePrivacyDocument } from "./documents";
 import type { Document } from "./documents";
+import { shouldEmit } from "./emit";
+import { createT } from "./i18n";
 import type { Dictionary } from "./i18n";
-import type {
-	CookiePolicyCookies,
-	DataConfig,
-	PolicyStackConfig,
-	PolicyCategory,
-	PolicyInput,
-} from "./types";
-import { deriveConsentMechanism } from "./normalize";
-import { deriveUserRights } from "./user-rights";
+import type { PolicyStackConfig } from "./types";
 
-const PRIVACY_FIELDS = ["data", "children"] as const;
-
-function hasAnyPrivacyField(config: PolicyStackConfig): boolean {
-	return PRIVACY_FIELDS.some((field) => config[field] !== undefined);
-}
-
-function hasCookieField(config: PolicyStackConfig): boolean {
-	return config.cookies !== undefined;
-}
-
-export function shouldEmit(category: PolicyCategory, config: PolicyStackConfig): boolean {
-	if (config.policies) return config.policies.includes(category);
-	return category === "privacy" ? hasAnyPrivacyField(config) : hasCookieField(config);
-}
-
-const EMPTY_DATA: DataConfig = {
-	collected: {},
-	context: {},
-};
-const EMPTY_COOKIES: CookiePolicyCookies = { used: { essential: true }, context: {} };
-
-type PrivacyInput = Extract<PolicyInput, { type: "privacy" }>;
-type CookieInput = Extract<PolicyInput, { type: "cookie" }>;
-
-function buildPrivacyInput(config: PolicyStackConfig): PrivacyInput | null {
-	if (!shouldEmit("privacy", config)) return null;
-	return {
-		type: "privacy",
-		company: config.company,
-		effectiveDate: config.effectiveDate,
-		locale: config.locale ?? "en",
-		jurisdictions: config.jurisdictions,
-		data: config.data ?? EMPTY_DATA,
-		cookies: config.cookies ?? EMPTY_COOKIES,
-		thirdParties: config.thirdParties ?? [],
-		userRights: deriveUserRights(config.jurisdictions),
-		children: config.children,
-		automatedDecisionMaking: config.automatedDecisionMaking,
-		version: config.privacyVersion,
-	};
-}
-
-function buildCookieInput(config: PolicyStackConfig): CookieInput | null {
-	if (!shouldEmit("cookie", config)) return null;
-	return {
-		type: "cookie",
-		company: config.company,
-		effectiveDate: config.effectiveDate,
-		locale: config.locale ?? "en",
-		jurisdictions: config.jurisdictions,
-		cookies: config.cookies ?? EMPTY_COOKIES,
-		thirdParties: config.thirdParties ?? [],
-		trackingTechnologies: config.trackingTechnologies,
-		// Always derived — never the author's hand-written value. This is the
-		// single choke point feeding the cookie renderer, so raw compile()
-		// callers that bypass defineConfig/validate still get the truth.
-		consentMechanism: deriveConsentMechanism(config),
-		version: config.cookieVersion,
-	};
-}
-
-export function expandPolicyStackConfig(config: PolicyStackConfig): PolicyInput[] {
-	const inputs: PolicyInput[] = [];
-	const privacy = buildPrivacyInput(config);
-	if (privacy) inputs.push(privacy);
-	const cookie = buildCookieInput(config);
-	if (cookie) inputs.push(cookie);
-	return inputs;
-}
-
+// The two public compile entry points. Each takes the flat, public
+// PolicyStackConfig directly — there is no intermediate per-document
+// projection. shouldEmit() gates emission; the section builders derive
+// userRights / consentMechanism and read privacyVersion / cookieVersion
+// straight off the config (the derivations live at their single point of use).
 export function compilePrivacyPolicy(
 	config: PolicyStackConfig,
 	dictionary?: Dictionary,
 ): Document | null {
-	const input = buildPrivacyInput(config);
-	return input ? compile(input, dictionary) : null;
+	if (!shouldEmit("privacy", config)) return null;
+	const t = createT(config.locale ?? "en", dictionary);
+	return {
+		type: "document",
+		astVersion: AST_VERSION,
+		policyType: "privacy",
+		sections: compilePrivacyDocument(config, t),
+	};
 }
 
 export function compileCookiePolicy(
 	config: PolicyStackConfig,
 	dictionary?: Dictionary,
 ): Document | null {
-	const input = buildCookieInput(config);
-	return input ? compile(input, dictionary) : null;
+	if (!shouldEmit("cookie", config)) return null;
+	const t = createT(config.locale ?? "en", dictionary);
+	return {
+		type: "document",
+		astVersion: AST_VERSION,
+		policyType: "cookie",
+		sections: compileCookieDocument(config, t),
+	};
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,6 @@ export type {
 	NodeContext,
 	ParagraphNode,
 	PolicyType,
-	ProvenanceCode,
 	TableCellNode,
 	TableHeaderCellNode,
 	TableHeaderRowNode,
@@ -23,13 +22,14 @@ export type {
 	TextNode,
 	UnknownNode,
 	Visitor,
-	// The frozen validator `IssueCode` is re-exported once from "./types"
-	// (PS-11). It is a different axis from the AST's `ProvenanceCode` (above):
-	// diagnostics vs. why-a-node-exists.
+	// `IssueCode` is re-exported once from "./types" (PS-11 froze it there
+	// alongside `Issue`); the duplicate "./documents" re-export was a latent
+	// TS2300 inherited from the v1 base and is dropped here. The AST's
+	// `ProvenanceCode` (a different axis: why-a-node-exists, not diagnostics)
+	// stays internal to ./documents — nothing outside core consumes it.
 } from "./documents";
 export {
 	AST_VERSION,
-	PROVENANCE_CODES,
 	bold,
 	cell,
 	headerCell,

--- a/packages/core/src/jurisdiction-id.ts
+++ b/packages/core/src/jurisdiction-id.ts
@@ -81,8 +81,10 @@ export const JURISDICTION_TABLE: JurisdictionTable = {
 
 const JURISDICTION_IDS = Object.keys(JURISDICTION_TABLE) as readonly JurisdictionId[];
 
-export function isJurisdictionId(value: string): value is JurisdictionId {
-	return Object.hasOwn(JURISDICTION_TABLE, value);
+// Accepts `unknown` (symmetric with `isLocale`) so callers validating raw
+// input — e.g. a persisted consent record — can guard in one call.
+export function isJurisdictionId(value: unknown): value is JurisdictionId {
+	return typeof value === "string" && Object.hasOwn(JURISDICTION_TABLE, value);
 }
 
 /**

--- a/packages/core/src/locale.ts
+++ b/packages/core/src/locale.ts
@@ -1,0 +1,13 @@
+import type { Locale } from "./types";
+
+// The canonical locale codes PolicyStack emits, and the single runtime mirror
+// of the frozen `Locale` union. Kept here — dependency-free, deliberately NOT
+// in ./i18n (which imports the policy dictionaries) — so the lean ./consent
+// runtime can share one list/predicate without dragging the compiler bundle
+// in. `satisfies` ties the list to `Locale` (./types, the single source of
+// truth): a stray or missing code is a compile error.
+export const LOCALES = ["en", "fr", "de", "nl", "es"] as const satisfies readonly Locale[];
+
+export function isLocale(value: unknown): value is Locale {
+	return typeof value === "string" && (LOCALES as readonly string[]).includes(value);
+}

--- a/packages/core/src/normalize.ts
+++ b/packages/core/src/normalize.ts
@@ -40,9 +40,9 @@ export function seedCompany(
 }
 
 // The single normalization seam. Applied at the boundary of BOTH defineConfig
-// (sdk) and validate()/buildCookieInput (core) so every consumer — the §4.1
-// bridge, buildConsent(), the React parity copy, validate's required-field
-// checks — observes one internally-consistent config regardless of entry path.
+// (sdk) and validate() (core) so every consumer — the §4.1 bridge,
+// buildConsent(), the React parity copy, validate's required-field checks —
+// observes one internally-consistent config regardless of entry path.
 // Idempotent: normalize∘normalize == normalize.
 export function normalizePolicyStackConfig(config: PolicyStackConfig): PolicyStackConfig {
 	return {

--- a/packages/core/src/policy-version.ts
+++ b/packages/core/src/policy-version.ts
@@ -1,3 +1,4 @@
+import { shouldEmit } from "./emit";
 import type { PolicyStackConfig } from "./types";
 
 function stableSerialize(value: unknown): string {
@@ -63,26 +64,14 @@ function hashSlice(
 	return fnv1a32(stableSerialize(slice));
 }
 
-function hasAnyPrivacyField(config: PolicyStackConfig): boolean {
-	return config.data !== undefined || config.children !== undefined;
-}
-
-function shouldHashPrivacy(config: PolicyStackConfig): boolean {
-	if (config.policies) return config.policies.includes("privacy");
-	return hasAnyPrivacyField(config);
-}
-
-function shouldHashCookie(config: PolicyStackConfig): boolean {
-	if (config.policies) return config.policies.includes("cookie");
-	return config.cookies !== undefined;
-}
-
+// Hash a document's slice only when that document is actually emitted — the
+// same gate the compiler and validator use (one shared `shouldEmit`).
 export function computePrivacyVersion(config: PolicyStackConfig): string | undefined {
-	if (!shouldHashPrivacy(config)) return undefined;
+	if (!shouldEmit("privacy", config)) return undefined;
 	return hashSlice(config, PRIVACY_HASH_FIELDS);
 }
 
 export function computeCookieVersion(config: PolicyStackConfig): string | undefined {
-	if (!shouldHashCookie(config)) return undefined;
+	if (!shouldEmit("cookie", config)) return undefined;
 	return hashSlice(config, COOKIE_HASH_FIELDS);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -156,6 +156,14 @@ export type CookiePolicyCookies = {
 	context: CookieContext;
 };
 
+// The strictly-necessary-only fallback used when a privacy/cookie policy is
+// compiled from a config that declared no `cookies` block. One definition,
+// shared by both document builders.
+export const ESSENTIAL_ONLY_COOKIES: CookiePolicyCookies = {
+	used: { essential: true },
+	context: {},
+};
+
 export type TrackingTechnology = string;
 
 export type ConsentMechanism = {
@@ -163,40 +171,6 @@ export type ConsentMechanism = {
 	hasPreferencePanel: boolean;
 	canWithdraw: boolean;
 };
-
-// Internal type consumed by section builders via PolicyInput.
-// Produced by expandPolicyStackConfig() — not part of the public API.
-export type PrivacyPolicyConfig = {
-	effectiveDate: EffectiveDate;
-	locale: Locale;
-	company: CompanyConfig;
-	data: DataConfig;
-	cookies: CookiePolicyCookies;
-	thirdParties: ThirdParty[];
-	userRights: UserRight[];
-	jurisdictions: JurisdictionId[];
-	children?: ChildrenConfig;
-	automatedDecisionMaking?: AutomatedDecisionMaking;
-	version?: string;
-};
-
-// Internal type consumed by section builders via PolicyInput.
-// Produced by expandPolicyStackConfig() — not part of the public API.
-export type CookiePolicyConfig = {
-	effectiveDate: EffectiveDate;
-	locale: Locale;
-	company: CompanyConfig;
-	cookies: CookiePolicyCookies;
-	thirdParties: ThirdParty[];
-	trackingTechnologies?: TrackingTechnology[];
-	consentMechanism?: ConsentMechanism;
-	jurisdictions: JurisdictionId[];
-	version?: string;
-};
-
-export type PolicyInput =
-	| ({ type: "privacy" } & PrivacyPolicyConfig)
-	| ({ type: "cookie" } & CookiePolicyConfig);
 
 // Public config passed to defineConfig(). All fields live at the top level.
 export type PolicyStackConfig = {

--- a/packages/core/src/user-rights.test.ts
+++ b/packages/core/src/user-rights.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vite-plus/test";
-import { compile } from "./documents";
-import type { PolicyStackConfig, PolicyInput, UserRight } from "./types";
+import { compilePrivacyPolicy } from "./index";
+import type { PolicyStackConfig, UserRight } from "./types";
 import { deriveUserRights } from "./user-rights";
 import { validate } from "./validate";
 
@@ -55,8 +55,7 @@ test("deriveUserRights: a reserved jurisdiction with no shipped content returns 
 });
 
 test("buildUserRights: privacy policy omits 'Your Rights' section when derivation is empty", () => {
-	const input: PolicyInput = {
-		type: "privacy",
+	const config: PolicyStackConfig = {
 		effectiveDate: "2026-01-01",
 		locale: "en",
 		company: {
@@ -88,11 +87,11 @@ test("buildUserRights: privacy policy omits 'Your Rights' section when derivatio
 			},
 		},
 		thirdParties: [],
-		userRights: [],
 		jurisdictions: ["ca"],
 	};
-	const document = compile(input);
-	const hasRightsSection = document.sections.some((s) => s.id === "user-rights");
+	const document = compilePrivacyPolicy(config);
+	expect(document).not.toBeNull();
+	const hasRightsSection = document?.sections.some((s) => s.id === "user-rights");
 	expect(hasRightsSection).toBe(false);
 });
 

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -1,5 +1,5 @@
 import { isLocale, LOCALES } from "./i18n";
-import { shouldEmit } from "./index";
+import { shouldEmit } from "./emit";
 import { JURISDICTION_IDS, JURISDICTION_TABLE, resolveJurisdiction } from "./jurisdiction-id";
 import { deriveConsentMechanism } from "./normalize";
 import type { Issue, PolicyStackConfig } from "./types";
@@ -16,8 +16,9 @@ import { isConsentGated } from "./types";
  * deterministic, and in the real pipeline validate() runs on the
  * already-seeded defineConfig output. Privacy and cookie checks are gated by
  * {@link shouldEmit} so a policy is only validated when it will actually be
- * emitted; nothing here depends on the expanded `PolicyInput` shape, so there
- * is no `EMPTY_*`-default false-positive class and no need to dedupe.
+ * emitted; this runs directly on the flat config (there is no intermediate
+ * per-document projection), so there is no default-fill false-positive class
+ * and no need to dedupe.
  */
 export function validate(rawConfig: PolicyStackConfig): Issue[] {
 	const config: PolicyStackConfig = {

--- a/packages/react/src/components/CookiePolicy.tsx
+++ b/packages/react/src/components/CookiePolicy.tsx
@@ -1,9 +1,6 @@
 import {
-	compile,
 	compileCookiePolicy,
-	type CookiePolicyConfig,
 	type Dictionary,
-	isPolicyStackConfig,
 	type Locale,
 	type PolicyStackConfig,
 } from "@policystack/core";
@@ -14,7 +11,7 @@ import type { PolicyComponents } from "../types";
 import { DefaultRoot } from "./defaults";
 
 type CookiePolicyProps = {
-	config?: PolicyStackConfig | CookiePolicyConfig;
+	config?: PolicyStackConfig;
 	locale?: Locale;
 	dictionary?: Dictionary;
 	components?: PolicyComponents;
@@ -32,9 +29,7 @@ export function CookiePolicy({
 	const baseConfig = configProp ?? contextConfig ?? undefined;
 	if (!baseConfig) return null;
 	const config = locale ? { ...baseConfig, locale } : baseConfig;
-	const doc = isPolicyStackConfig(config)
-		? compileCookiePolicy(config, dictionary)
-		: compile({ type: "cookie", ...config }, dictionary);
+	const doc = compileCookiePolicy(config, dictionary);
 	if (!doc) return null;
 	const Root = components?.Root ?? DefaultRoot;
 	return (

--- a/packages/react/src/components/PrivacyPolicy.tsx
+++ b/packages/react/src/components/PrivacyPolicy.tsx
@@ -1,11 +1,8 @@
 import {
-	compile,
 	compilePrivacyPolicy,
 	type Dictionary,
-	isPolicyStackConfig,
 	type Locale,
 	type PolicyStackConfig,
-	type PrivacyPolicyConfig,
 } from "@policystack/core";
 import { useContext } from "react";
 import { PolicyStackContext } from "../context";
@@ -14,7 +11,7 @@ import type { PolicyComponents } from "../types";
 import { DefaultRoot } from "./defaults";
 
 type PrivacyPolicyProps = {
-	config?: PolicyStackConfig | PrivacyPolicyConfig;
+	config?: PolicyStackConfig;
 	locale?: Locale;
 	dictionary?: Dictionary;
 	components?: PolicyComponents;
@@ -32,9 +29,7 @@ export function PrivacyPolicy({
 	const baseConfig = configProp ?? contextConfig ?? undefined;
 	if (!baseConfig) return null;
 	const config = locale ? { ...baseConfig, locale } : baseConfig;
-	const doc = isPolicyStackConfig(config)
-		? compilePrivacyPolicy(config, dictionary)
-		: compile({ type: "privacy", ...config }, dictionary);
+	const doc = compilePrivacyPolicy(config, dictionary);
 	if (!doc) return null;
 	const Root = components?.Root ?? DefaultRoot;
 	return (

--- a/packages/react/src/consent.tsx
+++ b/packages/react/src/consent.tsx
@@ -7,7 +7,7 @@ import {
 	type ConsentRecord,
 	type ConsentRecordSource,
 	type ConsentStore,
-	type Jurisdiction,
+	type JurisdictionId,
 	type PolicyStackConsentConfig,
 	type RepromptReason,
 	type Route,
@@ -49,7 +49,7 @@ export type UseConsentResult = {
 	route: Route;
 	categories: Category[];
 	decisions: Record<string, boolean>;
-	jurisdiction: Jurisdiction | null;
+	jurisdiction: JurisdictionId | null;
 	policyVersion: string;
 	decidedAt: string | null;
 	repromptReason: RepromptReason | null;

--- a/packages/react/src/policy.test.tsx
+++ b/packages/react/src/policy.test.tsx
@@ -1,5 +1,5 @@
-import type { PrivacyPolicyConfig, SlotName } from "@policystack/core";
-import { compile } from "@policystack/core";
+import type { Document, PolicyStackConfig, SlotName } from "@policystack/core";
+import { compilePrivacyPolicy } from "@policystack/core";
 import { isValidElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { expect, test } from "vite-plus/test";
@@ -13,7 +13,7 @@ const company = {
 	contact: { email: "privacy@acme.com" },
 };
 
-const privacyConfig: PrivacyPolicyConfig = {
+const privacyConfig: PolicyStackConfig = {
 	effectiveDate: "2026-01-01",
 	locale: "en",
 	company,
@@ -40,18 +40,23 @@ const privacyConfig: PrivacyPolicyConfig = {
 		},
 	},
 	thirdParties: [],
-	userRights: ["access", "erasure"],
 	jurisdictions: ["ca"],
 };
 
+function privacyDoc(): Document {
+	const doc = compilePrivacyPolicy(privacyConfig);
+	if (!doc) throw new Error("expected a privacy document");
+	return doc;
+}
+
 test("renderDocument returns a React element", () => {
-	const doc = compile({ type: "privacy", ...privacyConfig });
+	const doc = privacyDoc();
 	const result = renderDocument(doc);
 	expect(isValidElement(result)).toBe(true);
 });
 
 test("renderDocument works with PolicyStackConfig via compile", () => {
-	const doc = compile({ type: "privacy", ...privacyConfig });
+	const doc = privacyDoc();
 	const result = renderDocument(doc);
 	expect(result).toBeTruthy();
 });
@@ -107,7 +112,7 @@ test("PrivacyPolicy with full overrides emits no host DOM tags", () => {
 });
 
 test("renderDocument with full overrides emits no host DOM tags", () => {
-	const doc = compile({ type: "privacy", ...privacyConfig });
+	const doc = privacyDoc();
 	const html = renderToStaticMarkup(<>{renderDocument(doc, rnLikeComponents)}</>);
 	expect(html).not.toMatch(forbiddenTagPattern);
 });

--- a/packages/react/src/provider.test.tsx
+++ b/packages/react/src/provider.test.tsx
@@ -145,10 +145,10 @@ describe("PolicyStackProvider — consent store derived from the one config", ()
 		const { result } = renderHook(() => useConsent(), {
 			wrapper: wrapper({
 				...withCookies,
-				consent: { jurisdictionResolver: { resolve: () => "EEA" } },
+				consent: { jurisdictionResolver: { resolve: () => "eea" } },
 			}),
 		});
-		expect(result.current.jurisdiction).toBe("EEA");
+		expect(result.current.jurisdiction).toBe("eea");
 	});
 
 	it("isolates the store per provider instance (no cross-request leak)", () => {
@@ -169,7 +169,7 @@ describe("deriveConsentConfig parity with @policystack/sdk toPolicyStackConsentC
 			...withCookies,
 			consent: {
 				adapter: { read: () => null, write: () => {}, clear: () => {} },
-				jurisdictionResolver: { resolve: () => "EEA" },
+				jurisdictionResolver: { resolve: () => "eea" },
 				initialRoute: "preferences",
 				triggers: { policyVersionChanged: false, jurisdictionChanged: true },
 			},

--- a/packages/renderers/src/index.test.ts
+++ b/packages/renderers/src/index.test.ts
@@ -1,9 +1,8 @@
 import { expect, test } from "vite-plus/test";
-import type { PolicyInput } from "@policystack/core";
+import type { PolicyStackConfig } from "@policystack/core";
 import { compilePolicy } from "./index";
 
-const input: PolicyInput = {
-	type: "privacy",
+const config: PolicyStackConfig = {
 	effectiveDate: "2026-01-01",
 	locale: "en",
 	company: {
@@ -35,13 +34,24 @@ const input: PolicyInput = {
 		},
 	},
 	thirdParties: [],
-	userRights: ["access"],
 	jurisdictions: ["ca"],
 };
 
-test("compilePolicy routes privacy input to markdown", async () => {
-	const results = await compilePolicy(input);
+test("compilePolicy routes a privacy config to markdown", async () => {
+	const results = await compilePolicy(config, "privacy");
 	expect(Array.isArray(results)).toBe(true);
 	expect(results[0]?.format).toBe("markdown");
 	expect(results[0]?.content).toContain("Acme Inc.");
+	expect(results[0]?.filename).toBe("privacy-policy.md");
+});
+
+test("compilePolicy routes a cookie config to markdown", async () => {
+	const results = await compilePolicy(config, "cookie");
+	expect(results[0]?.filename).toBe("cookie-policy.md");
+});
+
+test("compilePolicy throws when the requested policy is not emitted", async () => {
+	await expect(compilePolicy({ ...config, policies: ["cookie"] }, "privacy")).rejects.toThrow(
+		/does not emit a privacy policy/,
+	);
 });

--- a/packages/renderers/src/index.ts
+++ b/packages/renderers/src/index.ts
@@ -1,11 +1,16 @@
-import type { CompileOptions, OutputFormat, PolicyInput } from "@policystack/core";
-import { compile } from "@policystack/core";
+import type {
+	CompileOptions,
+	OutputFormat,
+	PolicyStackConfig,
+	PolicyType,
+} from "@policystack/core";
+import { compileCookiePolicy, compilePrivacyPolicy } from "@policystack/core";
 
 export { renderHTML } from "./html";
 export { renderMarkdown } from "./markdown";
 export { renderPDF } from "./pdf";
 
-function filenameFor(type: PolicyInput["type"], ext: string): string {
+function filenameFor(type: PolicyType, ext: string): string {
 	switch (type) {
 		case "privacy":
 			return `privacy-policy.${ext}`;
@@ -15,10 +20,16 @@ function filenameFor(type: PolicyInput["type"], ext: string): string {
 }
 
 export async function compilePolicy(
-	input: PolicyInput,
+	config: PolicyStackConfig,
+	type: PolicyType,
 	options?: CompileOptions,
 ): Promise<{ format: OutputFormat; filename: string; content: string | Buffer }[]> {
-	const doc = compile(input);
+	const doc = type === "privacy" ? compilePrivacyPolicy(config) : compileCookiePolicy(config);
+	if (!doc) {
+		throw new Error(
+			`PolicyStack: this config does not emit a ${type} policy — check the fields/\`policies\` that gate ${type} emission.`,
+		);
+	}
 	const formats = options?.formats ?? ["markdown"];
 	return Promise.all(
 		formats.map(async (format) => {
@@ -27,7 +38,7 @@ export async function compilePolicy(
 					const { renderMarkdown } = await import("./markdown");
 					return {
 						format,
-						filename: filenameFor(input.type, "md"),
+						filename: filenameFor(type, "md"),
 						content: renderMarkdown(doc),
 					};
 				}
@@ -35,7 +46,7 @@ export async function compilePolicy(
 					const { renderHTML } = await import("./html");
 					return {
 						format,
-						filename: filenameFor(input.type, "html"),
+						filename: filenameFor(type, "html"),
 						content: renderHTML(doc),
 					};
 				}
@@ -43,7 +54,7 @@ export async function compilePolicy(
 					const { renderPDF } = await import("./pdf");
 					return {
 						format,
-						filename: filenameFor(input.type, "pdf"),
+						filename: filenameFor(type, "pdf"),
 						content: await renderPDF(doc),
 					};
 				}

--- a/packages/renderers/src/pdf.test.ts
+++ b/packages/renderers/src/pdf.test.ts
@@ -1,9 +1,8 @@
 import { expect, test } from "vite-plus/test";
-import { compile, type PolicyInput } from "@policystack/core";
+import { compilePrivacyPolicy, type Document, type PolicyStackConfig } from "@policystack/core";
 import { renderPDF } from "./pdf";
 
-const input: PolicyInput = {
-	type: "privacy",
+const config: PolicyStackConfig = {
 	effectiveDate: "2026-01-01",
 	locale: "en",
 	company: {
@@ -17,10 +16,10 @@ const input: PolicyInput = {
 		context: {
 			"Account Information": {
 				purpose: "To authenticate users",
-				lawfulBasis: "contract" as const,
+				lawfulBasis: "contract",
 				retention: "Until deletion",
 				provision: {
-					basis: "contract-prerequisite" as const,
+					basis: "contract-prerequisite",
 					consequences: "We cannot create or operate your account.",
 				},
 			},
@@ -29,25 +28,28 @@ const input: PolicyInput = {
 	cookies: {
 		used: { essential: true, analytics: false, marketing: false },
 		context: {
-			essential: { lawfulBasis: "legal_obligation" as const },
-			analytics: { lawfulBasis: "consent" as const },
-			marketing: { lawfulBasis: "consent" as const },
+			essential: { lawfulBasis: "legal_obligation" },
+			analytics: { lawfulBasis: "consent" },
+			marketing: { lawfulBasis: "consent" },
 		},
 	},
 	thirdParties: [],
-	userRights: ["access" as const],
-	jurisdictions: ["ca" as const],
+	jurisdictions: ["ca"],
 };
 
+function privacyDoc(): Document {
+	const doc = compilePrivacyPolicy(config);
+	if (!doc) throw new Error("expected a privacy document");
+	return doc;
+}
+
 test("renderPDF returns a Buffer", async () => {
-	const doc = compile(input);
-	const result = await renderPDF(doc);
+	const result = await renderPDF(privacyDoc());
 	expect(result).toBeInstanceOf(Buffer);
 	expect(result.length).toBeGreaterThan(100);
 });
 
 test("renderPDF output begins with PDF magic bytes", async () => {
-	const doc = compile(input);
-	const result = await renderPDF(doc);
+	const result = await renderPDF(privacyDoc());
 	expect(result.slice(0, 5).toString("ascii")).toBe("%PDF-");
 });

--- a/packages/sdk/src/consent.test.ts
+++ b/packages/sdk/src/consent.test.ts
@@ -47,7 +47,7 @@ test("returns no categories when policy has no cookies block", () => {
 });
 
 test("passes through overrides without mutating categories", () => {
-	const resolver: JurisdictionResolver = { resolve: () => "EEA" };
+	const resolver: JurisdictionResolver = { resolve: () => "eea" };
 	const config = toPolicyStackConsentConfig(policy, {
 		policyVersion: "v3",
 		jurisdictionResolver: resolver,
@@ -203,7 +203,7 @@ test("locale is omitted when neither policy nor options provide one", () => {
 });
 
 test("PolicyStackConfig.consent is the canonical options object (single-config flow)", () => {
-	const resolver: JurisdictionResolver = { resolve: () => "EEA" };
+	const resolver: JurisdictionResolver = { resolve: () => "eea" };
 	const consent: PolicyStackConsentOptions = {
 		adapter: { read: () => null, write: () => {}, clear: () => {} },
 		jurisdictionResolver: resolver,

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -16,7 +16,7 @@ import {
 	type ConsentRecordSource,
 	type ConsentState,
 	type ConsentStore,
-	type Jurisdiction,
+	type JurisdictionId,
 	type PolicyStackConsentConfig,
 	type RepromptReason,
 	type Route,
@@ -60,7 +60,7 @@ export type UseConsentResult = {
 	route: Accessor<Route>;
 	categories: Accessor<Category[]>;
 	decisions: Accessor<Record<string, boolean>>;
-	jurisdiction: Accessor<Jurisdiction | null>;
+	jurisdiction: Accessor<JurisdictionId | null>;
 	policyVersion: Accessor<string>;
 	decidedAt: Accessor<string | null>;
 	repromptReason: Accessor<RepromptReason | null>;
@@ -156,7 +156,7 @@ export type {
 	ConsentRecordSource,
 	ConsentState,
 	ConsentStore,
-	Jurisdiction,
+	JurisdictionId,
 	PolicyStackConsentConfig,
 	RepromptReason,
 	Route,

--- a/packages/svelte/src/index.test.ts
+++ b/packages/svelte/src/index.test.ts
@@ -1,4 +1,4 @@
-import type { PolicyStackConfig, PrivacyPolicyConfig, SlotName } from "@policystack/core";
+import type { PolicyStackConfig, SlotName } from "@policystack/core";
 import { render } from "svelte/server";
 import { expect, test } from "vite-plus/test";
 import CookiePolicy from "./lib/CookiePolicy.svelte";
@@ -13,7 +13,7 @@ const company = {
 	contact: { email: "privacy@acme.com" },
 };
 
-const privacyConfig: PrivacyPolicyConfig = {
+const privacyConfig: PolicyStackConfig = {
 	effectiveDate: "2026-01-01",
 	locale: "en",
 	company,
@@ -40,7 +40,6 @@ const privacyConfig: PrivacyPolicyConfig = {
 		},
 	},
 	thirdParties: [],
-	userRights: ["access", "erasure"],
 	jurisdictions: ["ca"],
 };
 

--- a/packages/svelte/src/lib/CookiePolicy.svelte
+++ b/packages/svelte/src/lib/CookiePolicy.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { CookiePolicyConfig, PolicyStackConfig } from "@policystack/core";
+import type { PolicyStackConfig } from "@policystack/core";
 import { visit } from "@policystack/core";
 import { setOverridesContext } from "./context.svelte";
 import DefaultRoot from "./defaults/DefaultRoot.svelte";
@@ -9,7 +9,7 @@ import type { PolicyComponents } from "./types";
 import { resolveDocument } from "./usePolicyDocument.svelte";
 
 type Props = {
-	config?: PolicyStackConfig | CookiePolicyConfig;
+	config?: PolicyStackConfig;
 	style?: string;
 } & PolicyComponents;
 

--- a/packages/svelte/src/lib/PrivacyPolicy.svelte
+++ b/packages/svelte/src/lib/PrivacyPolicy.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { PolicyStackConfig, PrivacyPolicyConfig } from "@policystack/core";
+import type { PolicyStackConfig } from "@policystack/core";
 import { visit } from "@policystack/core";
 import { setOverridesContext } from "./context.svelte";
 import DefaultRoot from "./defaults/DefaultRoot.svelte";
@@ -9,7 +9,7 @@ import type { PolicyComponents } from "./types";
 import { resolveDocument } from "./usePolicyDocument.svelte";
 
 type Props = {
-	config?: PolicyStackConfig | PrivacyPolicyConfig;
+	config?: PolicyStackConfig;
 	style?: string;
 } & PolicyComponents;
 

--- a/packages/svelte/src/lib/consent/context.svelte.ts
+++ b/packages/svelte/src/lib/consent/context.svelte.ts
@@ -6,7 +6,7 @@ import {
 	type ConsentRecord,
 	type ConsentState,
 	type ConsentStore,
-	type Jurisdiction,
+	type JurisdictionId,
 	type PolicyStackConsentConfig,
 	type RepromptReason,
 	type Route,
@@ -49,7 +49,7 @@ export class ConsentRune {
 		return this.#state.decisions;
 	}
 
-	get jurisdiction(): Jurisdiction | null {
+	get jurisdiction(): JurisdictionId | null {
 		return this.#state.jurisdiction;
 	}
 

--- a/packages/svelte/src/lib/consent/index.ts
+++ b/packages/svelte/src/lib/consent/index.ts
@@ -6,7 +6,7 @@ export type {
 	ConsentRecordSource,
 	ConsentState,
 	ConsentStore,
-	Jurisdiction,
+	JurisdictionId,
 	PolicyStackConsentConfig,
 	RepromptReason,
 	Route,

--- a/packages/svelte/src/lib/usePolicyDocument.svelte.ts
+++ b/packages/svelte/src/lib/usePolicyDocument.svelte.ts
@@ -1,26 +1,17 @@
 import {
-	compile,
 	compileCookiePolicy,
 	compilePrivacyPolicy,
-	type CookiePolicyConfig,
 	type Document,
-	isPolicyStackConfig,
 	type PolicyStackConfig,
 	type PolicyType,
-	type PrivacyPolicyConfig,
 } from "@policystack/core";
 import { getConfigContext } from "./context.svelte";
 
-type ConfigInput = PolicyStackConfig | PrivacyPolicyConfig | CookiePolicyConfig | undefined;
+type ConfigInput = PolicyStackConfig | undefined;
 
 export function compileDocument(type: PolicyType, config: ConfigInput): Document | null {
 	if (!config) return null;
-
-	if (isPolicyStackConfig(config)) {
-		return type === "privacy" ? compilePrivacyPolicy(config) : compileCookiePolicy(config);
-	}
-
-	return compile({ type, ...config } as Parameters<typeof compile>[0]);
+	return type === "privacy" ? compilePrivacyPolicy(config) : compileCookiePolicy(config);
 }
 
 export function resolveDocument(type: PolicyType, configProp: ConfigInput): Document | null {

--- a/packages/vue/src/components/CookiePolicy.ts
+++ b/packages/vue/src/components/CookiePolicy.ts
@@ -1,4 +1,4 @@
-import type { CookiePolicyConfig, PolicyStackConfig } from "@policystack/core";
+import type { PolicyStackConfig } from "@policystack/core";
 import { type CSSProperties, defineComponent, h, type PropType } from "vue";
 import { usePolicyDocument } from "../composables/usePolicyDocument";
 import { DefaultRoot } from "../defaults";
@@ -9,7 +9,7 @@ export const CookiePolicy = defineComponent({
 	name: "CookiePolicy",
 	props: {
 		config: {
-			type: Object as PropType<PolicyStackConfig | CookiePolicyConfig>,
+			type: Object as PropType<PolicyStackConfig>,
 			required: false,
 		},
 		components: {

--- a/packages/vue/src/components/PrivacyPolicy.ts
+++ b/packages/vue/src/components/PrivacyPolicy.ts
@@ -1,4 +1,4 @@
-import type { PolicyStackConfig, PrivacyPolicyConfig } from "@policystack/core";
+import type { PolicyStackConfig } from "@policystack/core";
 import { type CSSProperties, defineComponent, h, type PropType } from "vue";
 import { usePolicyDocument } from "../composables/usePolicyDocument";
 import { DefaultRoot } from "../defaults";
@@ -9,7 +9,7 @@ export const PrivacyPolicy = defineComponent({
 	name: "PrivacyPolicy",
 	props: {
 		config: {
-			type: Object as PropType<PolicyStackConfig | PrivacyPolicyConfig>,
+			type: Object as PropType<PolicyStackConfig>,
 			required: false,
 		},
 		components: {

--- a/packages/vue/src/composables/usePolicyDocument.ts
+++ b/packages/vue/src/composables/usePolicyDocument.ts
@@ -1,18 +1,14 @@
 import {
-	compile,
 	compileCookiePolicy,
 	compilePrivacyPolicy,
-	type CookiePolicyConfig,
 	type Document,
-	isPolicyStackConfig,
 	type PolicyStackConfig,
 	type PolicyType,
-	type PrivacyPolicyConfig,
 } from "@policystack/core";
 import { computed, type ComputedRef, inject, type MaybeRefOrGetter, toValue } from "vue";
 import { PolicyStackContextKey } from "../context";
 
-type ConfigInput = PolicyStackConfig | PrivacyPolicyConfig | CookiePolicyConfig | undefined;
+type ConfigInput = PolicyStackConfig | undefined;
 
 export function usePolicyDocument(
 	type: PolicyType,
@@ -23,11 +19,6 @@ export function usePolicyDocument(
 	return computed(() => {
 		const config = toValue(configProp) ?? context?.config.value;
 		if (!config) return null;
-
-		if (isPolicyStackConfig(config)) {
-			return type === "privacy" ? compilePrivacyPolicy(config) : compileCookiePolicy(config);
-		}
-
-		return compile({ type, ...config } as Parameters<typeof compile>[0]);
+		return type === "privacy" ? compilePrivacyPolicy(config) : compileCookiePolicy(config);
 	});
 }

--- a/packages/vue/src/consent.ts
+++ b/packages/vue/src/consent.ts
@@ -20,7 +20,7 @@ import {
 	type ConsentRecordSource,
 	type ConsentState,
 	type ConsentStore,
-	type Jurisdiction,
+	type JurisdictionId,
 	type PolicyStackConsentConfig,
 	type RepromptReason,
 	type Route,
@@ -90,7 +90,7 @@ export type UseConsentResult = {
 	route: ComputedRef<Route>;
 	categories: ComputedRef<Category[]>;
 	decisions: ComputedRef<Record<string, boolean>>;
-	jurisdiction: ComputedRef<Jurisdiction | null>;
+	jurisdiction: ComputedRef<JurisdictionId | null>;
 	policyVersion: ComputedRef<string>;
 	decidedAt: ComputedRef<string | null>;
 	repromptReason: ComputedRef<RepromptReason | null>;
@@ -172,7 +172,7 @@ export type {
 	ConsentRecordSource,
 	ConsentState,
 	ConsentStore,
-	Jurisdiction,
+	JurisdictionId,
 	PolicyStackConsentConfig,
 	RepromptReason,
 	Route,

--- a/packages/vue/src/policy.test.ts
+++ b/packages/vue/src/policy.test.ts
@@ -1,7 +1,8 @@
 import {
-	compile,
+	compilePrivacyPolicy,
+	type Document,
 	type HeadingNode,
-	type PrivacyPolicyConfig,
+	type PolicyStackConfig,
 	type SlotName,
 } from "@policystack/core";
 import { expect, test } from "vite-plus/test";
@@ -15,7 +16,7 @@ const company = {
 	contact: { email: "privacy@acme.com" },
 };
 
-const privacyConfig: PrivacyPolicyConfig = {
+const privacyConfig: PolicyStackConfig = {
 	effectiveDate: "2026-01-01",
 	locale: "en",
 	company,
@@ -42,12 +43,17 @@ const privacyConfig: PrivacyPolicyConfig = {
 		},
 	},
 	thirdParties: [],
-	userRights: ["access", "erasure"],
 	jurisdictions: ["ca"],
 };
 
+function privacyDoc(): Document {
+	const doc = compilePrivacyPolicy(privacyConfig);
+	if (!doc) throw new Error("expected a privacy document");
+	return doc;
+}
+
 test("renderDocument returns Vue VNodes", () => {
-	const doc = compile({ type: "privacy", ...privacyConfig });
+	const doc = privacyDoc();
 	const result = renderDocument(doc);
 	expect(Array.isArray(result)).toBe(true);
 	if (!Array.isArray(result)) throw new Error("Expected array result");
@@ -56,7 +62,7 @@ test("renderDocument returns Vue VNodes", () => {
 });
 
 test("renderDocument works with PolicyStackConfig via compile", () => {
-	const doc = compile({ type: "privacy", ...privacyConfig });
+	const doc = privacyDoc();
 	const result = renderDocument(doc);
 	expect(result).toBeTruthy();
 });
@@ -76,7 +82,7 @@ test("custom components in PolicyComponents override defaults", () => {
 	});
 
 	const components: PolicyComponents = { Heading: CustomHeading };
-	const doc = compile({ type: "privacy", ...privacyConfig });
+	const doc = privacyDoc();
 	const result = renderDocument(doc, components);
 
 	const containsCustomHeading = (value: unknown): boolean => {


### PR DESCRIPTION
## Summary

Pre-1.0 manual review pass over **`@policystack/core`**, removing redundant indirection and collapsing duplicated single-source-of-truth surfaces. Four related refactors; net **−204 LOC** (666 insertions / 870 deletions across 61 files). Verified green across the whole monorepo at every step.

Targets **`v1`** per the repo rules (1.0 work; no changeset).

## What changed

**1. Remove the per-document projection layer**
`buildPrivacyInput`/`buildCookieInput`/`expandPolicyStackConfig`/`compile(input)` and the `PolicyInput`/`PrivacyPolicyConfig`/`CookiePolicyConfig` types are gone. Section builders take `PolicyStackConfig` directly; `userRights`/`consentMechanism` derive at their single point of use. The three derivations were each used in exactly one builder, so this is genuinely lean — not a scatter.

**2. Unify jurisdiction representation**
The consent runtime dropped its parallel uppercase `Jurisdiction` union and now speaks the canonical `JurisdictionId` everywhere (resolvers, store, GPC, triggers, persisted record). The `toJurisdictionId` bridge collapsed accordingly.

**3. Deduplicate the locale list/predicate**
One dependency-free `core/src/locale.ts` consumed by both the i18n compiler and the lean consent runtime — the `.` ⊥ `./consent` tree-shake split is preserved (consent never pulls the policy dictionaries).

**4. Decoupling / cleanup batch**
- `shouldEmit` → `core/src/emit.ts`: breaks the `validate ↔ index` barrel cycle and removes 3-way emit-gating duplication (`index`/`validate`/`policy-version`).
- `documents/types.ts`: stale `IssueCode = string` placeholder → frozen `ProvenanceCode` union (builder typo is now a compile error; distinct axis from the validator `IssueCode`).
- Finished the PS-35 rebrand: DOM event `oncookies:reprompt` → `policystack:reprompt`.
- Dropped the now-trivial `toJurisdictionId`; consolidated the duplicated `ESSENTIAL_ONLY_COOKIES`.

## Breaking changes (allowed on `v1`)

- Framework `PrivacyPolicy`/`CookiePolicy` components + `usePolicyDocument` accept **`PolicyStackConfig` only** (the projected-config half of the prop union is gone).
- `@policystack/renderers` `compilePolicy(config, type, options?)` — new signature (was `compilePolicy(PolicyInput, options?)`).
- Jurisdiction ids are canonical lowercase (`eea`, `us-ca`, …). **`AU` folds to `row`** — posture-identical to before (AU was already `row` via the old bridge); only the stored/displayed label changes. There is no canonical `au` (the 11-member union is frozen per ADR 0001).
- **Persisted `ConsentRecord` format change**: a pre-canonical uppercase jurisdiction reads back as `null`. Decisions are preserved and the `jurisdictionChanged` reprompt needs both sides non-null, so an upgrading visitor is **not** spuriously re-prompted.
- DOM event renamed `oncookies:reprompt` → `policystack:reprompt` (public doc updated).
- `ProvenanceCode` narrows `ComplianceReason.code` (string → union; non-breaking for AST consumers per ADR 0001).
- Removed public surface: `PolicyInput`/`PrivacyPolicyConfig`/`CookiePolicyConfig`, `expandPolicyStackConfig`, `compile(input)`, `toJurisdictionId`.

## Verification

Run at each refactor and again before this PR:

| Step | Result |
|---|---|
| `vp run -r build` | ✅ |
| `vp check` | ✅ format + lint clean |
| `vp run -r check-types` | ✅ 11 packages |
| `vp run -r test` | ✅ core **462** + ~500 across the other 9 packages |

## Reviewer notes

- One genuine behavioral change beyond the type swaps: `userRights` is now strictly jurisdiction-derived (it always was internally; the projected config just exposed an overridable field). A Canada-only config correctly renders no user-rights section — covered by an explicit test.
- `AU → row` and the `ConsentRecord` format break are the two judgement calls; both preserve runtime posture/behavior. Flagging for explicit sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
