### PR TITLE
ci: make knip a required gate; retune knip.json for src-in-dev layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
       # @sveltejs/vite-plugin-svelte) so solid renders SSR-only and svelte SFCs
       # fail to transform. Recursive run fixes both; no exclusions needed.
       - run: vp run -r test
-      # Non-blocking for now: knip surfaces dead deps/exports but still has
-      # per-workspace entry-config noise. Tracked as a follow-up to retune
-      # knip.json then drop continue-on-error.
+      # Required gate: knip.json is tuned to the src-in-dev / dist-on-publish
+      # layout (per-workspace source entry points), so dead deps/exports/files
+      # fail CI like any other check.
       - run: vp run knip
-        continue-on-error: true

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,16 +28,12 @@
 		"@tanstack/react-devtools": "^0.10.2",
 		"@tanstack/react-router": "^1.169.1",
 		"@tanstack/react-router-devtools": "^1.166.13",
-		"@tanstack/react-router-ssr-query": "^1.166.12",
 		"@tanstack/react-start": "^1.167.59",
-		"@tanstack/router-plugin": "^1.167.32",
-		"@types/hast": "^3.0.4",
 		"nitro": "^3.0.260311-beta",
 		"react": "^19.2.0",
 		"react-dom": "^19.2.0",
 		"shiki": "^4.0.2",
 		"tailwindcss": "^4.2.1",
-		"unist-util-visit": "^5.1.0",
 		"zod": "^4.4.2"
 	},
 	"devDependencies": {
@@ -51,7 +47,6 @@
 		"rehype-autolink-headings": "^7.1.0",
 		"rehype-slug": "^6.0.0",
 		"remark-gfm": "^4.0.1",
-		"tsx": "^4.21.0",
 		"vite": "catalog:",
 		"vite-plus": "catalog:"
 	}

--- a/knip.json
+++ b/knip.json
@@ -2,21 +2,99 @@
 	"$schema": "https://unpkg.com/knip@5/schema.json",
 	"tags": ["-lintignore"],
 	"ignoreBinaries": ["tsc"],
-	"ignore": ["**/*.gen.ts"],
+	"ignore": ["**/*.gen.ts", "**/__fixtures__/**"],
+	"ignoreDependencies": ["@policystack/tooling"],
+	"ignoreExportsUsedInFile": true,
+	"ignoreIssues": {
+		"pnpm-workspace.yaml": ["catalog"]
+	},
 	"workspaces": {
 		".": {
 			"entry": ["vite.config.ts"]
 		},
-		"packages/*": {
-			"entry": ["vite.config.ts", "**/*.test.{ts,tsx}"],
-			"ignoreDependencies": ["@policystack/tooling"]
+		"packages/core": {
+			"entry": [
+				"src/index.ts",
+				"src/consent/index.ts",
+				"src/consent/storage/*.ts",
+				"vite.config.ts",
+				"**/*.test.ts"
+			]
+		},
+		"packages/sdk": {
+			"entry": ["src/index.ts", "src/consent.ts", "scripts/*.mjs", "vite.config.ts", "**/*.test.ts"]
+		},
+		"packages/vite": {
+			"entry": ["src/index.ts", "src/consent/index.ts", "vite.config.ts", "**/*.test.ts"],
+			"ignoreDependencies": ["@policystack/sdk"]
+		},
+		"packages/cli": {
+			"entry": ["src/cli.ts", "src/index.ts", "vite.config.ts", "**/*.test.ts"]
+		},
+		"packages/react": {
+			"entry": [
+				"src/policy.ts",
+				"src/consent.tsx",
+				"src/provider.tsx",
+				"vite.config.ts",
+				"**/*.test.{ts,tsx}"
+			]
+		},
+		"packages/vue": {
+			"entry": ["src/policy.ts", "src/consent.ts", "vite.config.ts", "**/*.test.{ts,tsx}"]
 		},
 		"packages/svelte": {
-			"entry": ["src/lib/index.ts", "**/*.test.{ts,tsx}"],
-			"ignoreDependencies": ["@policystack/tooling"]
+			"entry": [
+				"src/lib/policy.ts",
+				"src/lib/consent/index.ts",
+				"src/lib/consent/stores.ts",
+				"vite.config.ts",
+				"**/*.test.{ts,tsx}"
+			]
+		},
+		"packages/solid": {
+			"entry": ["src/index.ts", "vite.config.ts", "**/*.test.{ts,tsx}"]
+		},
+		"packages/angular": {
+			"entry": ["src/public-api.ts", "vite.config.ts", "**/*.test.ts"],
+			"ignoreDependencies": ["@angular/common"]
+		},
+		"packages/scripts": {
+			"entry": [
+				"src/index.ts",
+				"src/ga4.ts",
+				"src/google-tag-manager.ts",
+				"src/hotjar.ts",
+				"src/meta-pixel.ts",
+				"src/posthog.ts",
+				"src/segment.ts",
+				"vite.config.ts",
+				"**/*.test.ts"
+			]
+		},
+		"packages/renderers": {
+			"entry": ["src/index.ts", "**/*.test.ts"]
+		},
+		"apps/web": {
+			"entry": [
+				"vite.config.ts",
+				"content-collections.ts",
+				"scripts/*.mjs",
+				"src/router.tsx",
+				"src/routes/**/*.{ts,tsx}",
+				"src/policystack.ts",
+				"src/og/**/*.{ts,tsx}"
+			],
+			"ignoreDependencies": ["@resvg/resvg-js", "pagefind"]
 		},
 		"examples/tanstack": {
-			"entry": ["src/policystack.ts", "src/lib/collection.ts", "src/lib/stripe.ts"]
+			"entry": [
+				"src/router.tsx",
+				"src/routes/**/*.{ts,tsx}",
+				"src/policystack.ts",
+				"src/lib/collection.ts",
+				"src/lib/stripe.ts"
+			]
 		}
 	}
 }

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,1 +1,0 @@
-export * from "./public-api";

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -35,8 +35,6 @@ export const TOOL_NAMES = [
 	"scan_ungated",
 ] as const;
 
-export type ToolName = (typeof TOOL_NAMES)[number];
-
 // Runtime-derived enums — the no-drift seam. `JURISDICTION_IDS` and
 // `Object.keys(ISSUE_CATALOG)` ARE the frozen unions at runtime.
 const jurisdictionIds = [...JURISDICTION_IDS] as [JurisdictionId, ...JurisdictionId[]];

--- a/packages/vite/src/consent/reporter.ts
+++ b/packages/vite/src/consent/reporter.ts
@@ -106,8 +106,4 @@ function keyForUngated(u: Ungated): string {
 	return `${h.file}:${h.line}:${h.column}:${tag}`;
 }
 
-export function firstUngated(result: ScanResult): Ungated | undefined {
-	return result.ungated[0];
-}
-
 export type { Cookie, VendorHit };

--- a/packages/vite/src/known-packages.ts
+++ b/packages/vite/src/known-packages.ts
@@ -1,7 +1,0 @@
-/**
- * Back-compat shim. The two legacy registries (`known-packages.ts` and
- * `consent/vendors.json`) were merged into the one canonical {@link
- * ./registry} (PS-25, decision 13). These two maps are now derived from it;
- * this module stays as a stable import path for existing consumers.
- */
-export { KNOWN_COOKIE_PACKAGES, KNOWN_PACKAGES } from "./registry";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,18 +85,9 @@ importers:
       '@tanstack/react-router-devtools':
         specifier: ^1.166.13
         version: 1.167.0(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.169.2)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-router-ssr-query':
-        specifier: ^1.166.12
-        version: 1.167.0(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.6))(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.169.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start':
         specifier: ^1.167.59
         version: 1.167.65(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))(solid-js@1.9.13))
-      '@tanstack/router-plugin':
-        specifier: ^1.167.32
-        version: 1.167.35(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))(solid-js@1.9.13))
-      '@types/hast':
-        specifier: ^3.0.4
-        version: 3.0.4
       nitro:
         specifier: ^3.0.260311-beta
         version: 3.0.260311-beta(@vercel/functions@2.2.13)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))(chokidar@5.0.0)(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)
@@ -112,9 +103,6 @@ importers:
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.4
-      unist-util-visit:
-        specifier: ^5.1.0
-        version: 5.1.0
       zod:
         specifier: ^4.4.2
         version: 4.4.3
@@ -149,9 +137,6 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)'
@@ -3492,9 +3477,6 @@ packages:
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/query-core@5.100.10':
-    resolution: {integrity: sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==}
-
   '@tanstack/react-devtools@0.10.5':
     resolution: {integrity: sha512-orVsRJ7oAXFb7oyafQCgx9YuK44jpILh5T/ddYuxAsolNfN5DZBr5/NLrWErD7HCGIzvYzg1TZI4sPxmiKvtvA==}
     engines: {node: '>=18'}
@@ -3503,11 +3485,6 @@ packages:
       '@types/react-dom': '>=16.8'
       react: '>=16.8'
       react-dom: '>=16.8'
-
-  '@tanstack/react-query@5.100.10':
-    resolution: {integrity: sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==}
-    peerDependencies:
-      react: ^18 || ^19
 
   '@tanstack/react-router-devtools@1.167.0':
     resolution: {integrity: sha512-nGw095EG7IHx0h5NtlEmzf6vcCTaFNPWdTSuDKazajhN0ct/v/TkekJ9J6KYUCeV1a8/2ZmToc58M+0rrOyn7w==}
@@ -3520,16 +3497,6 @@ packages:
     peerDependenciesMeta:
       '@tanstack/router-core':
         optional: true
-
-  '@tanstack/react-router-ssr-query@1.167.0':
-    resolution: {integrity: sha512-lJC/qySnlB0RaPCwCS4BQbdsDwyaPP2C8tzuEUsrwPTxm8TVYonYv3sptoSVhY0C2f8i5041X8gbRL7+lSY8BQ==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@tanstack/query-core': '>=5.90.0'
-      '@tanstack/react-query': '>=5.90.0'
-      '@tanstack/react-router': '>=1.127.0'
-      react: '>=18.0.0 || >=19.0.0'
-      react-dom: '>=18.0.0 || >=19.0.0'
 
   '@tanstack/react-router@1.169.2':
     resolution: {integrity: sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ==}
@@ -3630,13 +3597,6 @@ packages:
         optional: true
       webpack:
         optional: true
-
-  '@tanstack/router-ssr-query-core@1.169.0':
-    resolution: {integrity: sha512-zueXiVsF1BbVc8iaalHILRGURDCVlTTOVdUy/36VVeKVKr778vqJzyus+erEoVu5x4vl4DBGGM8RHqCaus1TQQ==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@tanstack/query-core': '>=5.90.0'
-      '@tanstack/router-core': '>=1.127.0'
 
   '@tanstack/router-utils@1.161.8':
     resolution: {integrity: sha512-xyiLWEKjfBAVhauDSSjXxyf7s8elU6SM+V050sbkofvGmIIvkwPFtDsX7Gvwh14kBd6iCwAT+RiPvXTxAptY0Q==}
@@ -9772,8 +9732,6 @@ snapshots:
 
   '@tanstack/history@1.161.6': {}
 
-  '@tanstack/query-core@5.100.10': {}
-
   '@tanstack/react-devtools@0.10.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.13)':
     dependencies:
       '@tanstack/devtools': 0.12.2(csstype@3.2.3)(solid-js@1.9.13)
@@ -9787,11 +9745,6 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-query@5.100.10(react@19.2.6)':
-    dependencies:
-      '@tanstack/query-core': 5.100.10
-      react: 19.2.6
-
   '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.169.2)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/react-router': 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -9802,17 +9755,6 @@ snapshots:
       '@tanstack/router-core': 1.169.2
     transitivePeerDependencies:
       - csstype
-
-  '@tanstack/react-router-ssr-query@1.167.0(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.6))(@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.169.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@tanstack/query-core': 5.100.10
-      '@tanstack/react-query': 5.100.10(react@19.2.6)
-      '@tanstack/react-router': 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/router-ssr-query-core': 1.169.0(@tanstack/query-core@5.100.10)(@tanstack/router-core@1.169.2)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    transitivePeerDependencies:
-      - '@tanstack/router-core'
 
   '@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -10011,11 +9953,6 @@ snapshots:
       vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))(solid-js@1.9.13)
     transitivePeerDependencies:
       - supports-color
-
-  '@tanstack/router-ssr-query-core@1.169.0(@tanstack/query-core@5.100.10)(@tanstack/router-core@1.169.2)':
-    dependencies:
-      '@tanstack/query-core': 5.100.10
-      '@tanstack/router-core': 1.169.2
 
   '@tanstack/router-utils@1.161.8':
     dependencies:
@@ -11442,6 +11379,7 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+    optional: true
 
   github-slugger@2.0.0: {}
 
@@ -13341,7 +13279,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   resolve@1.22.12:
     dependencies:
@@ -13889,6 +13828,7 @@ snapshots:
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   tw-animate-css@1.4.0: {}
 


### PR DESCRIPTION
## What

Makes `vp run knip` a **required CI gate** (drops `continue-on-error: true`) and retunes `knip.json` so it exits cleanly with zero issues.

## Why

Knip ran non-blocking because the config false-flagged ~300 exports/types, 59 files, and the consent fixture trees. **Root cause:** every package's `exports`/`bin` map points at `./dist/*` (build output) while source lives in `./src/*`, and the old `entry` override *replaced* Knip's package-exports detection — so Knip never entered the source tree from the real public API.

## Changes

**`knip.json` rewrite**
- Per-workspace **source** entry points (mapping `dist→src`): e.g. react `src/{consent,provider}.tsx` (not `.ts`), angular `src/public-api.ts`, svelte `src/lib/*`, cli `src/cli.ts`, sdk `scripts/*.mjs`.
- `ignoreExportsUsedInFile: true` — drops co-located internal-type noise.
- `**/__fixtures__/**` ignored (intentional standalone scanner test inputs).
- The long-standing `vitest` catalog false-positive suppressed via `ignoreIssues`.
- Scoped `ignoreDependencies` for build/native/fixture-only deps Knip can't statically see.

**Genuine findings actioned (not masked)**
- Deleted dead code: `packages/angular/src/index.ts` (ng-package entry is `public-api.ts`), `packages/vite/src/known-packages.ts` (zero-import back-compat shim), dead `firstUngated` fn (`vite/consent/reporter.ts`) and `ToolName` type (`cli/mcp/tools.ts`).
- Removed genuinely-unused `apps/web` deps: `@tanstack/react-router-ssr-query`, `@tanstack/router-plugin`, `unist-util-visit`, `@types/hast`, `tsx`.
- `pnpm-lock.yaml` synced — removals + orphan pruning only, **no version bumps** (verified; `solid-js` stays 1.9.13).

**CI**
- `.github/workflows/ci.yml`: dropped `continue-on-error` on the knip step.

## Reviewer notes

- **`@policystack/sdk` in `packages/vite` is intentionally kept + knip-ignored, not removed.** It only appears inside template-literal fixtures, but `validate.test.ts` esbuild-*bundles* those fixtures so the import is genuinely resolved at test time. (Caught by the test suite mid-work and reverted.)
- 4 residual Knip *config hints* remain (`.gen.ts` ignore; 3 "redundant" `vite.config.ts` entries). Hints don't affect exit code and are kept deliberately — the explicit `vite.config.ts` entry is required for 8 of 11 packages, so keeping it everywhere is more robust than an inconsistent config.
- Lockfile sync used the documented one-time `pnpm install --config.minimumReleaseAge=0` (removals only, inside the 7-day grace window because `solid-js@1.9.13` is <7d old — no actual bump).

## Verification

Full pipeline run locally, all green: `vp run -r build` → `vp check` → `vp run -r check-types` → `vp run -r test` → `vp run knip` (exit 0).

Targets `v1` per the project's 1.0 workflow (branch cut from `v1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)