### PR TITLE
react: simplify — de-fork consent derivation, de-dup components, trim surface

### DIFF
--- a/packages/core/src/consent/config.ts
+++ b/packages/core/src/consent/config.ts
@@ -1,0 +1,60 @@
+import { isConsentGated } from "../types";
+import type { PolicyStackConfig } from "../types";
+import type { Category, PolicyStackConsentConfig } from "./types";
+
+export type ToConsentConfigOptions = Omit<PolicyStackConsentConfig, "categories">;
+
+// Derives a PolicyStackConsentConfig from the policy: categories + `locked` flags come
+// from `cookies.used`/`.context`, version/locale/canWithdraw from the policy.
+// `options` are the runtime-only knobs that cannot be derived.
+//
+// This is the single canonical derivation. `@policystack/sdk/consent` re-exports
+// it for power users / non-React frameworks; `@policystack/react`'s
+// `<PolicyStackProvider>` calls `toPolicyStackConsentConfig(config, config.consent)`
+// internally. `PolicyStackConsentOptions` (the authored knobs — a `Pick` of
+// `PolicyStackConsentConfig`) is a strict subset of `ToConsentConfigOptions`
+// (everything bar `categories`, which is always derived), so passing
+// `config.consent` here type-checks with no cast.
+export function toPolicyStackConsentConfig(
+	policy: PolicyStackConfig,
+	options?: ToConsentConfigOptions,
+): PolicyStackConsentConfig {
+	const used: Record<string, boolean> = policy.cookies?.used ?? {};
+	const context = policy.cookies?.context ?? {};
+	const categories: Category[] = Object.keys(used)
+		.filter((key) => used[key])
+		.map((key) => {
+			const lawfulBasis = context[key]?.lawfulBasis;
+			return {
+				key,
+				label: key.charAt(0).toUpperCase() + key.slice(1),
+				// Gating is the explicit, exhaustive bridge table (§4.1) — not a
+				// `=== "consent"` string heuristic. `consent` ⇒ gated (not
+				// locked); every other basis ⇒ locked; a missing basis stays
+				// gated (privacy-safe; validate() hard-errors it separately).
+				// The basis itself rides on the Category so the §4.2 posture
+				// resolver and audit keep the full signal.
+				locked: !isConsentGated(lawfulBasis),
+				...(lawfulBasis ? { lawfulBasis } : {}),
+			};
+		});
+	const policyVersion = options?.policyVersion ?? policy.cookieVersion;
+	const canWithdraw = options?.canWithdraw ?? policy.consentMechanism?.canWithdraw;
+	// The PolicyStack version hash drives an automatic re-prompt on policy
+	// change: default `policyVersionChanged` on so a changed `cookieVersion`
+	// actually invalidates stored consent. Callers can still override any
+	// individual trigger via `options.triggers`.
+	const triggers = { policyVersionChanged: true, ...options?.triggers };
+	// PS-26: one shared Locale — the policy's canonical Locale flows into the
+	// PolicyStack Consent config so policy text and consent UI agree. An explicit
+	// options.locale still wins (same override convention as policyVersion).
+	const locale = options?.locale ?? policy.locale;
+	return {
+		...options,
+		...(policyVersion ? { policyVersion } : {}),
+		...(canWithdraw != null ? { canWithdraw } : {}),
+		...(locale ? { locale } : {}),
+		triggers,
+		categories,
+	};
+}

--- a/packages/core/src/consent/index.ts
+++ b/packages/core/src/consent/index.ts
@@ -1,3 +1,5 @@
+export { toPolicyStackConsentConfig } from "./config";
+export type { ToConsentConfigOptions } from "./config";
 export { PolicyStackConsentError } from "./errors";
 export type { PolicyStackConsentErrorCode } from "./errors";
 export { evaluate } from "./expr";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,6 @@
 	},
 	"devDependencies": {
 		"@policystack/core": "workspace:*",
-		"@policystack/sdk": "workspace:*",
 		"@policystack/tooling": "workspace:*",
 		"@testing-library/react": "^16.3.2",
 		"@types/react": "^18.0.0 || ^19.0.0",

--- a/packages/react/src/components/CookiePolicy.tsx
+++ b/packages/react/src/components/CookiePolicy.tsx
@@ -1,40 +1,6 @@
-import {
-	compileCookiePolicy,
-	type Dictionary,
-	type Locale,
-	type PolicyStackConfig,
-} from "@policystack/core";
-import { useContext } from "react";
-import { PolicyStackContext } from "../context";
-import { renderDocument } from "../render";
-import type { PolicyComponents } from "../types";
-import { DefaultRoot } from "./defaults";
+import { compileCookiePolicy } from "@policystack/core";
+import { PolicyDocument, type PolicyDocumentProps } from "./PolicyDocument";
 
-type CookiePolicyProps = {
-	config?: PolicyStackConfig;
-	locale?: Locale;
-	dictionary?: Dictionary;
-	components?: PolicyComponents;
-	style?: unknown;
-};
-
-export function CookiePolicy({
-	config: configProp,
-	locale,
-	dictionary,
-	components,
-	style,
-}: CookiePolicyProps) {
-	const { config: contextConfig } = useContext(PolicyStackContext);
-	const baseConfig = configProp ?? contextConfig ?? undefined;
-	if (!baseConfig) return null;
-	const config = locale ? { ...baseConfig, locale } : baseConfig;
-	const doc = compileCookiePolicy(config, dictionary);
-	if (!doc) return null;
-	const Root = components?.Root ?? DefaultRoot;
-	return (
-		<Root node={doc} style={style}>
-			{renderDocument(doc, components)}
-		</Root>
-	);
+export function CookiePolicy(props: PolicyDocumentProps) {
+	return <PolicyDocument {...props} compile={compileCookiePolicy} />;
 }

--- a/packages/react/src/components/PolicyDocument.tsx
+++ b/packages/react/src/components/PolicyDocument.tsx
@@ -1,0 +1,42 @@
+import type { Dictionary, Document, Locale, PolicyStackConfig } from "@policystack/core";
+import { useContext } from "react";
+import { PolicyStackContext } from "../context";
+import { renderDocument } from "../render";
+import type { PolicyComponents } from "../types";
+import { DefaultRoot } from "./defaults";
+
+export type PolicyDocumentProps = {
+	config?: PolicyStackConfig;
+	locale?: Locale;
+	dictionary?: Dictionary;
+	components?: PolicyComponents;
+	style?: unknown;
+};
+
+// Shared body for <PrivacyPolicy>/<CookiePolicy>: identical context-fallback,
+// locale-merge, compile-or-null, Root-wrap. Only the `compile` fn differs
+// (compilePrivacyPolicy vs compileCookiePolicy). Internal — not exported from
+// any subpath barrel.
+export function PolicyDocument({
+	compile,
+	config: configProp,
+	locale,
+	dictionary,
+	components,
+	style,
+}: PolicyDocumentProps & {
+	compile: (config: PolicyStackConfig, dictionary?: Dictionary) => Document | null;
+}) {
+	const { config: contextConfig } = useContext(PolicyStackContext);
+	const baseConfig = configProp ?? contextConfig ?? undefined;
+	if (!baseConfig) return null;
+	const config = locale ? { ...baseConfig, locale } : baseConfig;
+	const doc = compile(config, dictionary);
+	if (!doc) return null;
+	const Root = components?.Root ?? DefaultRoot;
+	return (
+		<Root node={doc} style={style}>
+			{renderDocument(doc, components)}
+		</Root>
+	);
+}

--- a/packages/react/src/components/PrivacyPolicy.tsx
+++ b/packages/react/src/components/PrivacyPolicy.tsx
@@ -1,40 +1,6 @@
-import {
-	compilePrivacyPolicy,
-	type Dictionary,
-	type Locale,
-	type PolicyStackConfig,
-} from "@policystack/core";
-import { useContext } from "react";
-import { PolicyStackContext } from "../context";
-import { renderDocument } from "../render";
-import type { PolicyComponents } from "../types";
-import { DefaultRoot } from "./defaults";
+import { compilePrivacyPolicy } from "@policystack/core";
+import { PolicyDocument, type PolicyDocumentProps } from "./PolicyDocument";
 
-type PrivacyPolicyProps = {
-	config?: PolicyStackConfig;
-	locale?: Locale;
-	dictionary?: Dictionary;
-	components?: PolicyComponents;
-	style?: unknown;
-};
-
-export function PrivacyPolicy({
-	config: configProp,
-	locale,
-	dictionary,
-	components,
-	style,
-}: PrivacyPolicyProps) {
-	const { config: contextConfig } = useContext(PolicyStackContext);
-	const baseConfig = configProp ?? contextConfig ?? undefined;
-	if (!baseConfig) return null;
-	const config = locale ? { ...baseConfig, locale } : baseConfig;
-	const doc = compilePrivacyPolicy(config, dictionary);
-	if (!doc) return null;
-	const Root = components?.Root ?? DefaultRoot;
-	return (
-		<Root node={doc} style={style}>
-			{renderDocument(doc, components)}
-		</Root>
-	);
+export function PrivacyPolicy(props: PolicyDocumentProps) {
+	return <PolicyDocument {...props} compile={compilePrivacyPolicy} />;
 }

--- a/packages/react/src/consent.tsx
+++ b/packages/react/src/consent.tsx
@@ -45,6 +45,9 @@ function useStore(): ConsentStore {
 	return store;
 }
 
+// State slice flows through useSyncExternalStore; the actions are the store's
+// own closures, passed by reference (stable identity, no per-render wrappers).
+// `subscribe`/`getState`/`refreshJurisdiction` are intentionally not exposed.
 export type UseConsentResult = {
 	route: Route;
 	categories: Category[];
@@ -53,16 +56,18 @@ export type UseConsentResult = {
 	policyVersion: string;
 	decidedAt: string | null;
 	repromptReason: RepromptReason | null;
-	acceptAll: ConsentStore["acceptAll"];
-	acceptNecessary: ConsentStore["acceptNecessary"];
-	reject: ConsentStore["reject"];
-	toggle: ConsentStore["toggle"];
-	save: ConsentStore["save"];
-	setRoute: ConsentStore["setRoute"];
-	has: ConsentStore["has"];
-	getConsentRecord: ConsentStore["getConsentRecord"];
-	getPreviousRecord: ConsentStore["getPreviousRecord"];
-};
+} & Pick<
+	ConsentStore,
+	| "acceptAll"
+	| "acceptNecessary"
+	| "reject"
+	| "toggle"
+	| "save"
+	| "setRoute"
+	| "has"
+	| "getConsentRecord"
+	| "getPreviousRecord"
+>;
 
 export function useConsent(): UseConsentResult {
 	const store = useStore();
@@ -79,15 +84,15 @@ export function useConsent(): UseConsentResult {
 		policyVersion: state.policyVersion,
 		decidedAt: state.decidedAt,
 		repromptReason: state.repromptReason,
-		acceptAll: (opts) => store.acceptAll(opts),
-		acceptNecessary: (opts) => store.acceptNecessary(opts),
-		reject: (opts) => store.reject(opts),
-		toggle: (key, opts) => store.toggle(key, opts),
-		save: (opts) => store.save(opts),
-		setRoute: (route) => store.setRoute(route),
-		has: (expr) => store.has(expr),
-		getConsentRecord: () => store.getConsentRecord(),
-		getPreviousRecord: () => store.getPreviousRecord(),
+		acceptAll: store.acceptAll,
+		acceptNecessary: store.acceptNecessary,
+		reject: store.reject,
+		toggle: store.toggle,
+		save: store.save,
+		setRoute: store.setRoute,
+		has: store.has,
+		getConsentRecord: store.getConsentRecord,
+		getPreviousRecord: store.getPreviousRecord,
 	};
 }
 

--- a/packages/react/src/policy.ts
+++ b/packages/react/src/policy.ts
@@ -17,7 +17,6 @@ export {
 	DefaultTableRow,
 	DefaultText,
 	DefaultUnknown,
-	renderNode,
 } from "./components/defaults";
 export { PrivacyPolicy } from "./components/PrivacyPolicy";
 // Context / Provider

--- a/packages/react/src/provider.test.tsx
+++ b/packages/react/src/provider.test.tsx
@@ -1,13 +1,12 @@
 // @vitest-environment happy-dom
 import type { PolicyStackConfig } from "@policystack/core";
 import type { ConsentRecord, StorageAdapter } from "@policystack/core/consent";
-import { toPolicyStackConsentConfig } from "@policystack/sdk/consent";
 import { act, cleanup, render, renderHook, screen } from "@testing-library/react";
 import { useContext, type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { ConsentGate, useConsent } from "./consent";
 import { PolicyStackContext } from "./context";
-import { deriveConsentConfig, PolicyStackProvider } from "./provider";
+import { PolicyStackProvider } from "./provider";
 
 const company = {
 	name: "Acme Inc.",
@@ -160,33 +159,4 @@ describe("PolicyStackProvider — consent store derived from the one config", ()
 		expect(a.result.current.decisions.analytics).toBe(true);
 		expect(b.result.current.decisions.analytics).toBe(false);
 	});
-});
-
-describe("deriveConsentConfig parity with @policystack/sdk toPolicyStackConsentConfig", () => {
-	const cases: Record<string, PolicyStackConfig> = {
-		"no consent block": withCookies,
-		"with runtime knobs": {
-			...withCookies,
-			consent: {
-				adapter: { read: () => null, write: () => {}, clear: () => {} },
-				jurisdictionResolver: { resolve: () => "eea" },
-				initialRoute: "preferences",
-				triggers: { policyVersionChanged: false, jurisdictionChanged: true },
-			},
-		},
-		"with consentMechanism + locale": {
-			...withCookies,
-			locale: "fr",
-			consentMechanism: { hasBanner: true, hasPreferencePanel: true, canWithdraw: true },
-		},
-		"policy-only (no cookies)": policyOnly,
-	};
-
-	for (const [name, config] of Object.entries(cases)) {
-		it(`matches toPolicyStackConsentConfig for: ${name}`, () => {
-			expect(deriveConsentConfig(config)).toEqual(
-				toPolicyStackConsentConfig(config, config.consent),
-			);
-		});
-	}
 });

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,48 +1,13 @@
 "use client";
 
-import { isConsentGated, type PolicyStackConfig } from "@policystack/core";
-import type { Category, PolicyStackConsentConfig } from "@policystack/core/consent";
+import type { PolicyStackConfig } from "@policystack/core";
+import {
+	toPolicyStackConsentConfig,
+	type PolicyStackConsentConfig,
+} from "@policystack/core/consent";
 import { useState, type ReactNode } from "react";
 import { PolicyStackConsentProvider } from "./consent";
 import { PolicyStackContext } from "./context";
-
-// Local copy of the @policystack/sdk `toPolicyStackConsentConfig` derivation, narrowed
-// to the authored `PolicyStackConfig.consent` shape (policyVersion / locale /
-// canWithdraw are ALWAYS derived from the policy, never authored in `consent`).
-// Kept here — rather than importing `toPolicyStackConsentConfig` — so @policystack/
-// react's only @policystack/* runtime dependency stays @policystack/core (no
-// react → sdk edge). The canonical bridge is @policystack/sdk's
-// `toPolicyStackConsentConfig`; provider.test.tsx pins this copy to it, so if either
-// drifts the parity test fails. Exported as that parity seam and a legitimate
-// escape hatch — equivalent to `toPolicyStackConsentConfig(policy, policy.consent)`.
-export function deriveConsentConfig(policy: PolicyStackConfig): PolicyStackConsentConfig {
-	const used: Record<string, boolean> = policy.cookies?.used ?? {};
-	const context = policy.cookies?.context ?? {};
-	const categories: Category[] = Object.keys(used)
-		.filter((key) => used[key])
-		.map((key) => {
-			const lawfulBasis = context[key]?.lawfulBasis;
-			return {
-				key,
-				label: key.charAt(0).toUpperCase() + key.slice(1),
-				locked: !isConsentGated(lawfulBasis),
-				...(lawfulBasis ? { lawfulBasis } : {}),
-			};
-		});
-	const consent = policy.consent;
-	// Default the policy-change re-prompt on; authored triggers merge over it.
-	const triggers = { policyVersionChanged: true, ...consent?.triggers };
-	return {
-		...consent,
-		...(policy.cookieVersion ? { policyVersion: policy.cookieVersion } : {}),
-		...(policy.consentMechanism?.canWithdraw != null
-			? { canWithdraw: policy.consentMechanism.canWithdraw }
-			: {}),
-		...(policy.locale ? { locale: policy.locale } : {}),
-		triggers,
-		categories,
-	};
-}
 
 export type PolicyStackProviderProps = {
 	config: PolicyStackConfig;
@@ -69,7 +34,9 @@ export function PolicyStackProvider({ config, children }: PolicyStackProviderPro
 	// Derive once per provider instance. Each SSR request mounts its own
 	// provider, so the consent store never leaks across requests — same
 	// rationale as PolicyStackConsentProvider's own useState store memoization.
-	const [consentConfig] = useState<PolicyStackConsentConfig>(() => deriveConsentConfig(config));
+	const [consentConfig] = useState<PolicyStackConsentConfig>(() =>
+		toPolicyStackConsentConfig(config, config.consent),
+	);
 
 	return (
 		<PolicyStackContext.Provider value={{ config }}>

--- a/packages/sdk/src/consent.ts
+++ b/packages/sdk/src/consent.ts
@@ -1,66 +1,13 @@
-import type { PolicyStackConfig } from "@policystack/core";
-import { isConsentGated } from "@policystack/core";
-import type { Category, PolicyStackConsentConfig } from "@policystack/core/consent";
-
-export type ToConsentConfigOptions = Omit<PolicyStackConsentConfig, "categories">;
-
-// The canonical home for these options is `PolicyStackConfig.consent` — re-export
-// the type here so power users authoring the field import it alongside the
-// bridge that consumes it.
-export type { PolicyStackConsentOptions } from "@policystack/core/consent";
-
-// Derives a PolicyStackConsentConfig from the policy: categories + `locked` flags come
-// from `cookies.used`/`.context`, version/locale/canWithdraw from the policy.
-// `options` are the runtime-only knobs that cannot be derived.
-//
-// This stays the public, pure derivation primitive for non-React frameworks and
-// power users — but it is OFF the documented happy path. The single-config flow
-// is: author `PolicyStackConfig.consent` and pass the whole config to
-// `<PolicyStackProvider>`, which calls `toPolicyStackConsentConfig(config, config.consent)`
-// internally. `PolicyStackConsentOptions` (the authored knobs — a `Pick` of
-// `PolicyStackConsentConfig`) is a strict subset of `ToConsentConfigOptions`
-// (everything bar `categories`, which is always derived), so passing
-// `config.consent` here type-checks with no cast.
-export function toPolicyStackConsentConfig(
-	policy: PolicyStackConfig,
-	options?: ToConsentConfigOptions,
-): PolicyStackConsentConfig {
-	const used: Record<string, boolean> = policy.cookies?.used ?? {};
-	const context = policy.cookies?.context ?? {};
-	const categories: Category[] = Object.keys(used)
-		.filter((key) => used[key])
-		.map((key) => {
-			const lawfulBasis = context[key]?.lawfulBasis;
-			return {
-				key,
-				label: key.charAt(0).toUpperCase() + key.slice(1),
-				// Gating is the explicit, exhaustive bridge table (§4.1) — not a
-				// `=== "consent"` string heuristic. `consent` ⇒ gated (not
-				// locked); every other basis ⇒ locked; a missing basis stays
-				// gated (privacy-safe; validate() hard-errors it separately).
-				// The basis itself rides on the Category so the §4.2 posture
-				// resolver and audit keep the full signal.
-				locked: !isConsentGated(lawfulBasis),
-				...(lawfulBasis ? { lawfulBasis } : {}),
-			};
-		});
-	const policyVersion = options?.policyVersion ?? policy.cookieVersion;
-	const canWithdraw = options?.canWithdraw ?? policy.consentMechanism?.canWithdraw;
-	// The PolicyStack version hash drives an automatic re-prompt on policy
-	// change: default `policyVersionChanged` on so a changed `cookieVersion`
-	// actually invalidates stored consent. Callers can still override any
-	// individual trigger via `options.triggers`.
-	const triggers = { policyVersionChanged: true, ...options?.triggers };
-	// PS-26: one shared Locale — the policy's canonical Locale flows into the
-	// PolicyStack Consent config so policy text and consent UI agree. An explicit
-	// options.locale still wins (same override convention as policyVersion).
-	const locale = options?.locale ?? policy.locale;
-	return {
-		...options,
-		...(policyVersion ? { policyVersion } : {}),
-		...(canWithdraw != null ? { canWithdraw } : {}),
-		...(locale ? { locale } : {}),
-		triggers,
-		categories,
-	};
-}
+// The canonical derivation now lives in @policystack/core/consent so
+// @policystack/sdk and @policystack/react import one copy (no react → sdk edge,
+// no forked parity test). This file stays as the stable public
+// `@policystack/sdk/consent` entry point — re-exporting the bridge plus the
+// authored-knobs type so SDK power users and the single-config provider flow
+// are unaffected. The single-config flow is: author `PolicyStackConfig.consent`
+// and pass the whole config to `<PolicyStackProvider>`, which calls
+// `toPolicyStackConsentConfig(config, config.consent)` internally.
+export {
+	toPolicyStackConsentConfig,
+	type ToConsentConfigOptions,
+	type PolicyStackConsentOptions,
+} from "@policystack/core/consent";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,9 +319,6 @@ importers:
       '@policystack/core':
         specifier: workspace:*
         version: link:../core
-      '@policystack/sdk':
-        specifier: workspace:*
-        version: link:../sdk
       '@policystack/tooling':
         specifier: workspace:*
         version: link:../../tooling/tsconfig


### PR DESCRIPTION
## Why

`@policystack/react` carried avoidable complexity. The biggest source was a **deliberately forked** copy of the SDK's consent-config derivation (`deriveConsentConfig`), kept in sync only by a parity test — a standing maintenance hazard. Alongside it: two 40-line near-clone components, a redundant public export, and a hand-maintained `useConsent` return type with per-render closure wrappers. Goal: make the package as simple as possible without changing behavior.

## What changed

**Cross-package — eliminated the SDK-derivation fork:**
- Moved the canonical `toPolicyStackConsentConfig` into `@policystack/core/consent` (`packages/core/src/consent/config.ts`). The function had zero SDK-specific deps, and the only new reverse import edge is `import type` (erased to zero JS) — **no runtime import cycle**.
- `packages/sdk/src/consent.ts` is now a thin re-export. **`@policystack/sdk/consent`'s public API is byte-for-byte unchanged**; `sdk/consent.test.ts` passes untouched via the re-export.
- `packages/react/src/provider.tsx` deletes the forked `deriveConsentConfig` and calls the one canonical copy. React's only `@policystack/*` runtime dep stays `@policystack/core` (no react → sdk edge) — now with **no fork to keep in sync and no parity test**.
- `@policystack/sdk` is no longer referenced anywhere in `packages/react`, so the dead devDependency was removed.

**React-internal trims (no behavior change):**
- Collapsed the `PrivacyPolicy`/`CookiePolicy` 40-line near-clones onto a shared internal `<PolicyDocument>` parameterized by the compile fn (both public components unchanged).
- Dropped the redundant public `renderNode` export from `./policy` (keeps `renderDocument`; matches `@policystack/vue`, which keeps `renderNode` internal).
- Replaced `useConsent`'s hand-maintained `UseConsentResult` literal + 9 per-render arrow wrappers with a `Pick<ConsentStore, …>`-derived type returning the store's own methods by reference (stable identities; store methods are plain closures, not `this`-bound).

Net **−77 LOC** (235 deleted / 158 added).

## Breaking changes (allowed on `v1`)

- `@policystack/react/policy` no longer exports `renderNode` (use `renderDocument`).
- `@policystack/react/provider` no longer exports `deriveConsentConfig` (use `toPolicyStackConsentConfig` from `@policystack/core/consent` or `@policystack/sdk/consent`).

No SDK-consumer breakage — `@policystack/sdk/consent` is unchanged.

## Deliberately left alone

- `PolicyStack` (policy-only provider) — live cross-framework public API, used by the tanstack example; `vue`/`svelte` export it too.
- Frozen `Visitor<ReactNode>` no-op arms in `defaults.tsx` — mandated by core's frozen `visit()` exhaustiveness.
- `render.tsx` wrapper — byte-identical to vue's; kept for cross-framework parity.

## Verification

All gates green:
- `vp run -r build` — 15 packages
- `vp run -r test` — 11 packages, **960 tests passing** (incl. `sdk/consent.test.ts` via re-export, `react/provider.test.tsx` with parity block removed, llms.txt drift test — llms.txt unchanged)
- `vp check` — lint/format clean
- `vp run -r check-types` — 11 packages, 0 errors

No changeset (PolicyStack 1.0 work is versioned as a single event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)