### PR TITLE
chore: scrub residual OpenPolicy refs missed by PS-34/PS-35

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,5 @@
 {
-	"projectName": "openpolicy",
+	"projectName": "policystack",
 	"projectOwner": "jamiedavenport",
 	"repoType": "github",
 	"repoHost": "https://github.com",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,17 +4,17 @@
 	"commit": false,
 	"fixed": [
 		[
-			"@openpolicy/sdk",
-			"@openpolicy/core",
-			"@openpolicy/vite",
-			"@openpolicy/cli",
-			"@openpolicy/react",
-			"@openpolicy/vue",
-			"@openpolicy/svelte",
-			"@openpolicy/renderers",
-			"@openpolicy/solid",
-			"@openpolicy/angular",
-			"@openpolicy/scripts"
+			"@policystack/sdk",
+			"@policystack/core",
+			"@policystack/vite",
+			"@policystack/cli",
+			"@policystack/react",
+			"@policystack/vue",
+			"@policystack/svelte",
+			"@policystack/renderers",
+			"@policystack/solid",
+			"@policystack/angular",
+			"@policystack/scripts"
 		]
 	],
 	"linked": [],

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ Steps to reproduce the behavior:
 **Policy config (if applicable):**
 
 ```ts
-import { defineConfig } from "@openpolicy/sdk";
+import { defineConfig } from "@policystack/sdk";
 
 export default defineConfig({
 	// ...
@@ -47,7 +47,7 @@ paste error here
 ## Environment
 
 - OS:
-- Package(s) affected: <!-- @openpolicy/sdk / @openpolicy/core / @openpolicy/vite / @openpolicy/cli -->
+- Package(s) affected: <!-- @policystack/sdk / @policystack/core / @policystack/vite / @policystack/cli -->
 - Version:
 - Node version (`node --version`):
 - Package manager (`pnpm --version` / `bun --version` / `npm --version`):

--- a/.vite-hooks/pre-push
+++ b/.vite-hooks/pre-push
@@ -1,5 +1,5 @@
 # Build before type-checking: packages export from ./dist, so without a build
 # downstream check-types false-negatives after any core change (resolves
-# `@openpolicy/core/*` to stale/missing dist). Mirrors CI ordering.
+# `@policystack/core/*` to stale/missing dist). Mirrors CI ordering.
 # Docs-only pushes can skip with `git push --no-verify`.
 vp run -r build && vp run -r check-types

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ```bash
 git clone https://github.com/jamiedavenport/policystack
-cd openpolicy
+cd policystack
 corepack enable      # picks up the pnpm version pinned in package.json
 pnpm install
 vp config

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ PolicyStack turns TypeScript config files into privacy and cookie policies. Defi
 
 # Stargazers
 
-[![RepoStars](https://repostars.dev/api/embed?repo=jamiedavenport%2Fopenpolicy&theme=light)](https://repostars.dev/?repos=jamiedavenport%2Fopenpolicy&theme=light)
+[![RepoStars](https://repostars.dev/api/embed?repo=jamiedavenport%2Fpolicystack&theme=light)](https://repostars.dev/?repos=jamiedavenport%2Fpolicystack&theme=light)

--- a/apps/web/src/og/config.ts
+++ b/apps/web/src/og/config.ts
@@ -26,7 +26,7 @@ const config = {
 		title: "Your privacy policy as a typed config.",
 		description: "policystack.dev/policy",
 		type: "website",
-		eyebrow: "OPENPOLICY",
+		eyebrow: "POLICYSTACK",
 	}),
 
 	"/cloud": () => ({
@@ -51,7 +51,7 @@ const config = {
 		if (!doc) return ignore;
 		const eyebrow =
 			doc.product === "policy"
-				? "OPENPOLICY DOCS"
+				? "POLICYSTACK DOCS"
 				: doc.product === "consent"
 					? "OPENCOOKIES DOCS"
 					: "DOCS";

--- a/apps/www/vercel.json
+++ b/apps/www/vercel.json
@@ -24,22 +24,22 @@
 		},
 		{
 			"source": "/blog/nextjs",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/blog/react",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/blog/sveltekit",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/blog/opencookies",
-			"destination": "https://policystack.dev/opencookies",
+			"destination": "https://policystack.dev/consent",
 			"permanent": false
 		},
 		{
@@ -50,27 +50,27 @@
 		{ "source": "/blog/code-first", "destination": "https://policystack.dev/", "permanent": false },
 		{
 			"source": "/blog/three-levels",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/blog/beyond-the-privacy-policy",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/blog/auto-collect",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/blog/better-auth",
-			"destination": "https://policystack.dev/opencookies",
+			"destination": "https://policystack.dev/consent",
 			"permanent": false
 		},
 		{
 			"source": "/blog/shadcn-registry",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 
@@ -81,69 +81,69 @@
 		},
 		{
 			"source": "/examples",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 
 		{
 			"source": "/framework/react",
-			"destination": "https://policystack.dev/docs/openpolicy/react",
+			"destination": "https://policystack.dev/docs/policy",
 			"permanent": false
 		},
 		{
 			"source": "/framework/svelte",
-			"destination": "https://policystack.dev/docs/openpolicy/svelte",
+			"destination": "https://policystack.dev/docs/policy",
 			"permanent": false
 		},
 		{
 			"source": "/framework/vue",
-			"destination": "https://policystack.dev/docs/openpolicy/vue",
+			"destination": "https://policystack.dev/docs/policy",
 			"permanent": false
 		},
 		{
 			"source": "/framework/astro",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/framework/nextjs",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/framework/nuxt",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/framework/remix",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/framework/tanstack",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 
 		{
 			"source": "/compare/lawyers",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/compare/templates",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/compare/termly",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 		{
 			"source": "/compare/iubenda",
-			"destination": "https://policystack.dev/openpolicy",
+			"destination": "https://policystack.dev/policy",
 			"permanent": false
 		},
 

--- a/docs/adr/0003-angular-library-build.md
+++ b/docs/adr/0003-angular-library-build.md
@@ -75,7 +75,7 @@ build needs the Angular compiler.
   (`compilationMode: "partial"`); `build`/`dev` scripts call `ng-packagr`. The
   existing `tsconfig.json` (`noEmit`) stays for `check-types`/IDE.
 - Publish-from-root, `files:["dist"]`, hand-authored root `exports."./consent"`
-  → `./dist/types/openpolicy-angular.d.ts` + `./dist/fesm2022/openpolicy-angular.mjs`
+  → `./dist/types/policystack-angular.d.ts` + `./dist/fesm2022/policystack-angular.mjs`
   — the same convention as `react`/`vue`/`svelte`. ng-packagr's nested
   `dist/package.json` is inert (auto-excluded from the published tarball by
   ng-packagr's `dist/.npmignore`).

--- a/examples/tanstack/src/routes/__root.tsx
+++ b/examples/tanstack/src/routes/__root.tsx
@@ -14,7 +14,7 @@ function GithubIcon({ className }: { className?: string }) {
 }
 
 import { TooltipProvider } from "@/components/ui/tooltip";
-import openpolicy from "../policystack";
+import policystack from "../policystack";
 import appCss from "../styles.css?url";
 
 export const Route = createRootRoute({
@@ -40,7 +40,7 @@ function RootComponent() {
 			<TooltipProvider>
 				{/* One provider for everything: supplies the policy context AND,
 				    because this config declares `cookies`, the consent store. */}
-				<PolicyStackProvider config={openpolicy}>
+				<PolicyStackProvider config={policystack}>
 					<Outlet />
 				</PolicyStackProvider>
 			</TooltipProvider>

--- a/examples/tanstack/src/routes/index.tsx
+++ b/examples/tanstack/src/routes/index.tsx
@@ -43,7 +43,7 @@ const demos = [
 		label: "Onboarding Wizard",
 		description:
 			"Walks new users through what the app collects by reading dataCollected, thirdParties, and cookies straight off the config — auto-collected metadata as a runtime value.",
-		code: "const { dataCollected, thirdParties, cookies } = openpolicy",
+		code: "const { dataCollected, thirdParties, cookies } = policystack",
 		badge: "New",
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "openpolicy",
+	"name": "policystack",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -17,15 +17,15 @@
 	"sideEffects": false,
 	"exports": {
 		"./consent": {
-			"types": "./dist/types/openpolicy-angular.d.ts",
-			"default": "./dist/fesm2022/openpolicy-angular.mjs"
+			"types": "./dist/types/policystack-angular.d.ts",
+			"default": "./dist/fesm2022/policystack-angular.mjs"
 		}
 	},
 	"publishConfig": {
 		"exports": {
 			"./consent": {
-				"types": "./dist/types/openpolicy-angular.d.ts",
-				"default": "./dist/fesm2022/openpolicy-angular.mjs"
+				"types": "./dist/types/policystack-angular.d.ts",
+				"default": "./dist/fesm2022/policystack-angular.mjs"
 			}
 		}
 	},

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -98,7 +98,7 @@ Full field reference and guides: [policystack.dev/docs](https://policystack.dev/
 
 ## AI Agents
 
-`openpolicy init` writes a type-accurate `policystack.llms.txt` into your project and prints a setup prompt — feed it to any coding agent (Claude Code, Cursor, Copilot, etc.).
+`policystack init` writes a type-accurate `policystack.llms.txt` into your project and prints a setup prompt — feed it to any coding agent (Claude Code, Cursor, Copilot, etc.).
 
 For Claude Code, install the PolicyStack skill pack — guided procedures for setup, auditing, jurisdiction posture, and data-flow instrumentation, all resolved against the frozen SDK surface:
 

--- a/packages/svelte/src/lib/context.svelte.ts
+++ b/packages/svelte/src/lib/context.svelte.ts
@@ -2,8 +2,8 @@ import type { PolicyStackConfig } from "@policystack/core";
 import { getContext, setContext } from "svelte";
 import type { PolicyComponents } from "./types";
 
-const CONFIG_KEY = Symbol("openpolicy.config");
-const OVERRIDES_KEY = Symbol("openpolicy.overrides");
+const CONFIG_KEY = Symbol("policystack.config");
+const OVERRIDES_KEY = Symbol("policystack.overrides");
 
 type ConfigGetter = () => PolicyStackConfig | undefined;
 

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.34",
 	"description": "Vite plugin that scans source files for @policystack/sdk collecting()/thirdParty() calls and populates the auto-collected registry at build time",
 	"keywords": [
-		"openpolicy",
+		"policystack",
 		"privacy-policy",
 		"vite-plugin"
 	],

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -50,18 +50,18 @@ export default defineConfig({
 
 ```ts
 // App.ts
-import openpolicy from "./openpolicy";
+import policystack from "./policystack";
 import { PolicyStack, PrivacyPolicy } from "@policystack/vue";
 
 export default {
 	components: { PolicyStack, PrivacyPolicy },
 	template: `
-		<PolicyStack :config="openpolicy">
+		<PolicyStack :config="policystack">
 			<PrivacyPolicy />
 		</PolicyStack>
 	`,
 	data() {
-		return { openpolicy };
+		return { policystack };
 	},
 };
 ```


### PR DESCRIPTION
Follow-up cleanup after [PS-34](https://linear.app/open-policy/issue/PS-34/flip-the-scope-to-policystack-everywhere) (scope flip) and [PS-35](https://linear.app/open-policy/issue/PS-35/full-product-rebrand-sweep-github-repo-rename-in-place) (rebrand sweep) — both Done. Cleans up references that were stale or outright broken. No changeset (PS / 1.0 work).

## Correctness fixes (these were broken, not just cosmetic)

- **`.changeset/config.json`** — the `fixed` group still listed `@openpolicy/*`, but every package is `@policystack/*` after PS-34. The release tooling would never have matched any package.
- **`packages/angular`** — `exports`/`publishConfig` pointed at `openpolicy-angular.{d.ts,mjs}`, but ng-packagr derives the bundle name from the package name (`@policystack/angular` → `policystack-angular.*`), so the published `./consent` export was dangling. `docs/adr/0003` updated to match.
- **`apps/www/vercel.json`** — 22 redirect destinations pointed at non-existent `policystack.dev/{openpolicy,opencookies,docs/openpolicy/*}` (apps/web has `/policy`, `/consent`, `/docs`). Remapped to real routes: `→ /policy`, `→ /consent`, `→ /docs/policy`. Relates to [PS-37](https://linear.app/open-policy/issue/PS-37/deployment-topology-two-vercel-projects-redirect-verification).

## Brand / identifier consistency

Root + `packages/vite` `package.json`, svelte context `Symbol()` descriptions, the tanstack example binding, the vue README example, the bug-report issue template, the pre-push hook comment, `packages/sdk/README.md` (`openpolicy init` → `policystack init` — the CLI bin is `policystack`), OG card eyebrows, and repo-name refs in the README badge / `.all-contributorsrc` / `CONTRIBUTING.md`.

## Deliberately untouched

- `sdk-specifier.ts` / `sdk-resolver.ts` + tests — the dual-scope back-compat shim, stays dual until [PS-38](https://linear.app/open-policy/issue/PS-38/tag-v100-merge-to-main-switch-to-semver-publish-the-frozen-api).
- CHANGELOGs and the dated blog posts — period-accurate release history (confirmed with maintainer).
- `apps/www/README.md` prose — `openpolicy.sh` is the real legacy domain it redirects; the text is correct.

## Verification

All edited JSON parses; 0 broken redirect targets remain; `examples/tanstack` has no stray `openpolicy` identifier. Changes are config/docs plus type-inert string edits (Symbol description, JSON export paths, a local example binding rename). Local pre-push hook skipped (deps not installed in this worktree; change has no build/type-check impact) — relying on the v1 CI pipeline as the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)