### PR TITLE
fix(core): stage preference toggles in a draft until save

### DIFF
--- a/.changeset/staged-consent-toggles.md
+++ b/.changeset/staged-consent-toggles.md
@@ -1,0 +1,12 @@
+---
+"@policystack/core": minor
+"@policystack/react": minor
+"@policystack/vue": minor
+"@policystack/svelte": minor
+"@policystack/solid": minor
+"@policystack/angular": minor
+---
+
+Consent preference toggles are now staged. `toggle()` writes to `state.draft` instead of live decisions, and nothing is gated, persisted, or script-loaded until `save()` promotes the draft in one step — scripts no longer load on checkbox tick before "Save", and returning visitors no longer get their stored record rewritten on every tick (#157). Leaving the preferences route without saving discards the draft.
+
+API changes: `toggle(key)` no longer accepts `ActionOptions` (name the record source at `save()` instead), and `ConsentState` gains a required `draft` field. Per-category `granted` accessors in all framework bindings read `draft ?? decisions` so checkboxes respond instantly; custom panels rendering checkboxes from raw `decisions` should apply the same merge.

--- a/apps/web/content/blog/astro-cookie-banner.mdx
+++ b/apps/web/content/blog/astro-cookie-banner.mdx
@@ -144,7 +144,8 @@ Astro's `<script>` tags are bundled by Vite, so this looks like a normal module 
     prefs.hidden = state.route !== "preferences";
     for (const cb of checkboxes) {
       const key = cb.dataset.category;
-      if (key) cb.checked = state.decisions[key] ?? false;
+      // draft holds staged (unsaved) toggles; decisions is what save() applied.
+      if (key) cb.checked = (state.draft ?? state.decisions)[key] ?? false;
     }
   };
   store.subscribe(render);

--- a/apps/web/content/docs/consent/angular.md
+++ b/apps/web/content/docs/consent/angular.md
@@ -77,13 +77,15 @@ export class BannerComponent {
 }
 ```
 
-Signal properties: `route`, `categories`, `decisions`, `jurisdiction`, `policyVersion`, `decidedAt`, `repromptReason`, `state`.
+Signal properties: `route`, `categories`, `decisions`, `draft`, `jurisdiction`, `policyVersion`, `decidedAt`, `repromptReason`, `state`.
 
 Methods: `acceptAll`, `acceptNecessary`, `reject`, `toggle`, `save`, `setRoute`, `has`, `getConsentRecord`, `getPreviousRecord`.
 
 ### `injectCategory(key)`
 
 Granular per-category access. Must be called inside an injection context (e.g. a component constructor or field initializer).
+
+`toggle` stages the change and `granted()` reflects it instantly (it reads the pending `state.draft`), but nothing is applied — `has()`, `<ConsentGate>`, script gating, and storage only change when `save()` promotes the draft. Leaving the preferences route without saving discards it.
 
 ```ts
 import { Component } from "@angular/core";

--- a/apps/web/content/docs/consent/core.md
+++ b/apps/web/content/docs/consent/core.md
@@ -35,6 +35,12 @@ store.acceptAll();
 
 The store's surface: `getState()`, `subscribe()`, `acceptAll()`, `acceptNecessary()`, `reject()`, `toggle(key)`, `save()`, `setRoute()`, `has(expr)`, `getConsentRecord()`, `getPreviousRecord()`, `refreshJurisdiction()`. See [`types.ts`](./src/types.ts) for the full shape.
 
+### Staged preferences (`state.draft`)
+
+`toggle(key)` never changes live consent. It stages the flip in `state.draft`, and gating (`has()` / `<ConsentGate>`), storage, and gated scripts keep reading `decisions` until `save()` promotes the draft in one step and stamps `decidedAt`. Leaving the preferences flow without saving — any `setRoute` that does not land on `"preferences"` — discards the draft, so "Back" genuinely abandons unsaved edits and nothing was loaded or persisted in the meantime.
+
+Render preference checkboxes from `draft ?? decisions` so the panel responds instantly; the framework bindings' per-category `granted` accessor does exactly this.
+
 ## Storage adapters
 
 Decisions persist via a `StorageAdapter` passed to `createConsentStore({ adapter })`. Three adapters ship as subpath imports:
@@ -104,7 +110,7 @@ const store = createConsentStore({ categories });
 // Brave (and any browser asserting GPC) starts with all opt-outs denied.
 ```
 
-Once a user makes an explicit decision (`acceptAll`, `toggle`, etc.) the resulting record has `state.source === "user"` and is preserved on reload — `applyGPC` will not overwrite it.
+Once a user makes an explicit decision (`acceptAll`, `save`, etc.) the resulting record has `state.source === "user"` and is preserved on reload — `applyGPC` will not overwrite it.
 
 To scope GPC to the legally-required US states only:
 
@@ -158,7 +164,7 @@ type ConsentRecord = {
 - `"api"` — set via a programmatic call (override with `acceptAll({ source: "api" })`, etc.).
 - `"import"` — migrated from a legacy or unrecognised record.
 
-The store infers `source` from `state.route` at the moment the decision is taken; pass `{ source }` to any action to override it.
+The store infers `source` from `state.route` at the moment the decision is taken; pass `{ source }` to any decision action (`acceptAll`, `acceptNecessary`, `reject`, `save`) to override it. `toggle` takes no options — it only stages a draft, and the eventual `save` names the source.
 
 Read the current record via `store.getConsentRecord()` (or the binding-level `useConsent().getConsentRecord()`). It returns `null` until a decision has been recorded.
 
@@ -184,7 +190,7 @@ store.getConsentRecord();
 
 Records produced by older versions of Consent are tolerated on read: missing fields fall back to safe defaults, the legacy `source: "user"` flag is mapped to `"banner"`, and any other unrecognised legacy source becomes `"import"`. The next user decision rewrites the record in the v1 shape.
 
-GPC alone does not produce a record — the visitor has not made a decision. `getConsentRecord()` keeps returning `null` until the user accepts, rejects, saves, or toggles a category.
+GPC alone does not produce a record — the visitor has not made a decision. `getConsentRecord()` keeps returning `null` until the user accepts, rejects, or saves their preference changes.
 
 ## Re-consent triggers
 

--- a/apps/web/content/docs/consent/react.md
+++ b/apps/web/content/docs/consent/react.md
@@ -59,6 +59,8 @@ function Banner() {
 
 Granular per-category access. Returns `{ granted, toggle }`.
 
+`toggle` stages the change and `granted` reflects it instantly (it reads the pending `state.draft`), but nothing is applied — `has()`, `<ConsentGate>`, script gating, and storage only change when `save()` promotes the draft. Leaving the preferences route without saving discards it.
+
 ```tsx
 import { useCategory } from "@policystack/react/consent";
 

--- a/apps/web/content/docs/consent/solid.md
+++ b/apps/web/content/docs/consent/solid.md
@@ -63,6 +63,8 @@ function Banner() {
 
 Granular per-category access.
 
+`toggle` stages the change and `granted()` reflects it instantly (it reads the pending `state.draft`), but nothing is applied — `has()`, `<ConsentGate>`, script gating, and storage only change when `save()` promotes the draft. Leaving the preferences route without saving discards it.
+
 ```tsx
 import { useCategory } from "@policystack/solid/consent";
 

--- a/apps/web/content/docs/consent/svelte.md
+++ b/apps/web/content/docs/consent/svelte.md
@@ -65,6 +65,8 @@ Returns a reactive object whose properties are tracked via `$state`. Read direct
 
 Granular per-category access.
 
+`toggle` stages the change and `granted` reflects it instantly (it reads the pending `state.draft`), but nothing is applied — `has()`, `<ConsentGate>`, script gating, and storage only change when `save()` promotes the draft. Leaving the preferences route without saving discards it.
+
 ```svelte
 <script lang="ts">
   import { getCategory } from "@policystack/svelte/consent";

--- a/apps/web/content/docs/consent/vue.md
+++ b/apps/web/content/docs/consent/vue.md
@@ -59,6 +59,8 @@ const { route, decisions, acceptAll, acceptNecessary, setRoute } = useConsent();
 
 Granular per-category access. Returns a `granted` computed and a `toggle` action.
 
+`toggle` stages the change and `granted` reflects it instantly (it reads the pending `state.draft`), but nothing is applied — `has()`, `<ConsentGate>`, script gating, and storage only change when `save()` promotes the draft. Leaving the preferences route without saving discards it.
+
 ```vue
 <script setup lang="ts">
 import { useCategory } from "@policystack/vue/consent";

--- a/packages/angular/src/category.ts
+++ b/packages/angular/src/category.ts
@@ -6,9 +6,8 @@ export type CategoryRef = {
 	toggle: () => void;
 };
 
-// `granted` is the checkbox view: it reflects staged (unsaved) edits from the
-// draft. Effective consent — what gates content and scripts — is `has()` /
-// <ConsentGate>, which only move on save().
+// `granted` is the checkbox view and includes staged draft edits; effective
+// consent (`has()` / <ConsentGate>) only moves on save().
 export function injectCategory(key: string): CategoryRef {
 	const consent = inject(ConsentService);
 	return {

--- a/packages/angular/src/category.ts
+++ b/packages/angular/src/category.ts
@@ -6,10 +6,13 @@ export type CategoryRef = {
 	toggle: () => void;
 };
 
+// `granted` is the checkbox view: it reflects staged (unsaved) edits from the
+// draft. Effective consent — what gates content and scripts — is `has()` /
+// <ConsentGate>, which only move on save().
 export function injectCategory(key: string): CategoryRef {
 	const consent = inject(ConsentService);
 	return {
-		granted: computed(() => consent.decisions()[key] === true),
+		granted: computed(() => (consent.draft() ?? consent.decisions())[key] === true),
 		toggle: () => consent.toggle(key),
 	};
 }

--- a/packages/angular/src/consent.service.ts
+++ b/packages/angular/src/consent.service.ts
@@ -21,6 +21,7 @@ export class ConsentService {
 	readonly route: Signal<Route> = computed(() => this._state().route);
 	readonly categories: Signal<Category[]> = computed(() => this._state().categories);
 	readonly decisions: Signal<Record<string, boolean>> = computed(() => this._state().decisions);
+	readonly draft: Signal<Record<string, boolean> | null> = computed(() => this._state().draft);
 	readonly jurisdiction: Signal<JurisdictionId | null> = computed(() => this._state().jurisdiction);
 	readonly policyVersion: Signal<string> = computed(() => this._state().policyVersion);
 	readonly decidedAt: Signal<string | null> = computed(() => this._state().decidedAt);
@@ -45,8 +46,8 @@ export class ConsentService {
 		this.store.reject(opts);
 	}
 
-	toggle(category: string, opts?: ActionOptions): void {
-		this.store.toggle(category, opts);
+	toggle(category: string): void {
+		this.store.toggle(category);
 	}
 
 	save(opts?: ActionOptions): void {

--- a/packages/angular/src/index.test.ts
+++ b/packages/angular/src/index.test.ts
@@ -62,9 +62,12 @@ describe("ConsentService", () => {
 		const store = createConsentStore({ categories: baseCategories });
 		const consent = injectorWithStore(store).get(ConsentService);
 		consent.toggle("analytics");
-		expect(consent.decisions().analytics).toBe(true);
+		expect(consent.draft()?.analytics).toBe(true);
+		expect(consent.decisions().analytics).toBe(false);
 		expect(consent.decidedAt()).toBeNull();
 		consent.save();
+		expect(consent.decisions().analytics).toBe(true);
+		expect(consent.draft()).toBeNull();
 		expect(consent.decidedAt()).not.toBeNull();
 		expect(consent.route()).toBe("closed");
 	});
@@ -92,6 +95,9 @@ describe("ConsentService", () => {
 		expect(consent.has({ and: ["analytics", "marketing"] })).toBe(false);
 		store.toggle("analytics");
 		store.toggle("marketing");
+		// Staged toggles never satisfy has() — only save() applies them.
+		expect(consent.has({ and: ["analytics", "marketing"] })).toBe(false);
+		store.save();
 		expect(consent.has({ and: ["analytics", "marketing"] })).toBe(true);
 	});
 });

--- a/packages/core/src/consent/expr.test.ts
+++ b/packages/core/src/consent/expr.test.ts
@@ -208,6 +208,7 @@ describe("store.has", () => {
 		const store = createConsentStore({ categories: baseCategories });
 		expect(store.has("analytics")).toBe(false);
 		store.toggle("analytics");
+		store.save();
 		expect(store.has("analytics")).toBe(true);
 	});
 

--- a/packages/core/src/consent/gpc.test.ts
+++ b/packages/core/src/consent/gpc.test.ts
@@ -90,6 +90,7 @@ describe("applyGPC", () => {
 			route: "cookie",
 			categories: baseCategories,
 			decisions: { essential: true, analytics: true, marketing: true },
+			draft: null,
 			jurisdiction: "us-ca",
 			policyVersion: "",
 			decidedAt: null,

--- a/packages/core/src/consent/scripts.test.ts
+++ b/packages/core/src/consent/scripts.test.ts
@@ -18,6 +18,7 @@ function makeStore(initialAccept: string[] = []): ConsentStore {
 		gpc: { enabled: false },
 	});
 	for (const k of initialAccept) store.toggle(k);
+	if (initialAccept.length > 0) store.save();
 	return store;
 }
 

--- a/packages/core/src/consent/storage/record.test.ts
+++ b/packages/core/src/consent/storage/record.test.ts
@@ -9,6 +9,7 @@ const baseState: ConsentState = {
 		{ key: "analytics", label: "Analytics" },
 	],
 	decisions: { essential: true, analytics: true },
+	draft: null,
 	jurisdiction: "eea",
 	policyVersion: "v2",
 	decidedAt: "2026-04-29T00:00:00.000Z",

--- a/packages/core/src/consent/store.test.ts
+++ b/packages/core/src/consent/store.test.ts
@@ -409,11 +409,17 @@ describe("createConsentStore", () => {
 	});
 
 	describe("toggle", () => {
-		it("flips a non-locked category", () => {
+		it("stages the flip in the draft without touching live decisions", () => {
 			const store = createConsentStore(makeConfig());
 			store.toggle("analytics");
-			expect(store.getState().decisions.analytics).toBe(true);
+			expect(store.getState().draft).toEqual({
+				essential: true,
+				analytics: true,
+				marketing: false,
+			});
+			expect(store.getState().decisions.analytics).toBe(false);
 			store.toggle("analytics");
+			expect(store.getState().draft?.analytics).toBe(false);
 			expect(store.getState().decisions.analytics).toBe(false);
 		});
 
@@ -439,16 +445,93 @@ describe("createConsentStore", () => {
 		});
 	});
 
-	describe("save", () => {
-		it("sets decidedAt and closes route without touching decisions", () => {
+	describe("draft (staged) decisions", () => {
+		it("gating ignores staged toggles until save", () => {
+			const store = createConsentStore(makeConfig());
+			store.setRoute("preferences");
+			store.toggle("marketing");
+			expect(store.has("marketing")).toBe(false);
+			store.save();
+			expect(store.has("marketing")).toBe(true);
+		});
+
+		it("leaving preferences without saving discards the draft", () => {
+			const store = createConsentStore(makeConfig());
+			store.setRoute("preferences");
+			store.toggle("marketing");
+			expect(store.getState().draft?.marketing).toBe(true);
+			store.setRoute("cookie");
+			expect(store.getState().draft).toBeNull();
+			expect(store.has("marketing")).toBe(false);
+		});
+
+		it("keeps staged edits when moving from the banner into preferences", () => {
 			const store = createConsentStore(makeConfig());
 			store.toggle("analytics");
+			store.setRoute("preferences");
+			expect(store.getState().draft?.analytics).toBe(true);
+		});
+
+		it("acceptAll / acceptNecessary / reject clear the draft", () => {
+			for (const action of ["acceptAll", "acceptNecessary", "reject"] as const) {
+				const store = createConsentStore(makeConfig());
+				store.toggle("marketing");
+				store[action]();
+				expect(store.getState().draft).toBeNull();
+			}
+		});
+
+		it("a reprompt invalidation clears the draft", async () => {
+			const adapter: StorageAdapter = {
+				read: () => ({
+					schemaVersion: 1,
+					decisions: { essential: true, analytics: true, marketing: true },
+					policyVersion: "",
+					decidedAt: "2026-01-01T00:00:00.000Z",
+					jurisdiction: "eea",
+					locale: "en",
+					source: "banner",
+				}),
+				write: () => {},
+				clear: () => {},
+			};
+			const store = createConsentStore(
+				makeConfig({
+					adapter,
+					jurisdictionResolver: { resolve: () => Promise.resolve("us") },
+					triggers: { jurisdictionChanged: true },
+				}),
+			);
+			store.setRoute("preferences");
+			store.toggle("marketing");
+			expect(store.getState().draft?.marketing).toBe(false);
+			await flushMicrotasks();
+			expect(store.getState().repromptReason).toBe("jurisdiction");
+			expect(store.getState().draft).toBeNull();
+		});
+	});
+
+	describe("save", () => {
+		it("promotes the draft into live decisions, sets decidedAt, and closes route", () => {
+			const store = createConsentStore(makeConfig());
+			store.setRoute("preferences");
+			store.toggle("analytics");
+			store.save();
+			const s = store.getState();
+			expect(s.decisions).toEqual({ essential: true, analytics: true, marketing: false });
+			expect(s.draft).toBeNull();
+			expect(s.decidedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+			expect(s.route).toBe("closed");
+		});
+
+		it("with no staged edits, saves the current decisions unchanged", () => {
+			const store = createConsentStore(makeConfig());
 			const decisionsBefore = store.getState().decisions;
 			store.save();
 			const s = store.getState();
+			expect(s.decisions).toEqual(decisionsBefore);
 			expect(s.decidedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 			expect(s.route).toBe("closed");
-			expect(s.decisions).toEqual(decisionsBefore);
 		});
 	});
 
@@ -484,9 +567,11 @@ describe("createConsentStore", () => {
 			expect(createConsentStore(makeConfig()).has("analytics")).toBe(false);
 		});
 
-		it("reflects toggles", () => {
+		it("reflects toggles only after save", () => {
 			const store = createConsentStore(makeConfig());
 			store.toggle("analytics");
+			expect(store.has("analytics")).toBe(false);
+			store.save();
 			expect(store.has("analytics")).toBe(true);
 		});
 
@@ -555,13 +640,20 @@ describe("createConsentStore", () => {
 			expect(store.getState().source).toBe("user");
 		});
 
-		it("flips to 'user' on acceptNecessary, reject, toggle, save", () => {
-			for (const action of ["acceptNecessary", "reject", "toggle", "save"] as const) {
+		it("flips to 'user' on acceptNecessary, reject, and save", () => {
+			for (const action of ["acceptNecessary", "reject", "save"] as const) {
 				const store = createConsentStore(makeConfig());
-				if (action === "toggle") store.toggle("analytics");
-				else store[action]();
+				store[action]();
 				expect(store.getState().source).toBe("user");
 			}
+		});
+
+		it("does not change on a bare toggle — staged edits are not a decision", () => {
+			const store = createConsentStore(makeConfig());
+			store.toggle("analytics");
+			expect(store.getState().source).toBe("default");
+			store.save();
+			expect(store.getState().source).toBe("user");
 		});
 
 		it("does not change on setRoute", () => {
@@ -659,6 +751,7 @@ describe("createConsentStore", () => {
 			});
 			const decisions = { ...store.getState().decisions };
 			store.toggle("analytics");
+			store.save();
 			expect(store.getState().decisions.analytics).toBe(!decisions.analytics);
 		});
 
@@ -802,7 +895,7 @@ describe("createConsentStore", () => {
 			expect(writes).toEqual([]);
 		});
 
-		it("persists each user decision via adapter.write", () => {
+		it("persists on save — staged toggles never write", () => {
 			const { adapter, writes } = makeAdapter();
 			const store = createConsentStore(makeConfig({ adapter, locale: "en" }));
 			store.acceptAll();
@@ -817,8 +910,27 @@ describe("createConsentStore", () => {
 			expect(writes[0]?.source).toBe("banner");
 
 			store.toggle("marketing");
+			expect(writes).toHaveLength(1);
+			store.save();
 			expect(writes).toHaveLength(2);
 			expect(writes[1]?.decisions.marketing).toBe(false);
+		});
+
+		it("a returning visitor's staged toggles never reach storage before save", () => {
+			// Canonical locale on the stored record: a non-canonical one (e.g.
+			// "en-GB") is rewritten on the first commit as a normalization pass,
+			// which would muddy the no-write-before-save assertion below.
+			const { adapter, writes } = makeAdapter(v1Record({ locale: "en" }));
+			const store = createConsentStore(makeConfig({ adapter, locale: "en" }));
+			store.setRoute("preferences");
+			store.toggle("marketing");
+			expect(writes).toEqual([]);
+			store.save();
+			expect(writes).toHaveLength(1);
+			expect(writes[0]?.decisions.marketing).toBe(true);
+			// The record's timestamp is the save, not the stored decision it replaced.
+			expect(writes[0]?.decidedAt).not.toBe("2026-04-01T00:00:00.000Z");
+			expect(writes[0]?.source).toBe("preferences");
 		});
 
 		it("writes the canonical Locale to the persisted record (PS-26 shim)", () => {

--- a/packages/core/src/consent/store.test.ts
+++ b/packages/core/src/consent/store.test.ts
@@ -917,9 +917,8 @@ describe("createConsentStore", () => {
 		});
 
 		it("a returning visitor's staged toggles never reach storage before save", () => {
-			// Canonical locale on the stored record: a non-canonical one (e.g.
-			// "en-GB") is rewritten on the first commit as a normalization pass,
-			// which would muddy the no-write-before-save assertion below.
+			// Canonical locale: a non-canonical stored one ("en-GB") is rewritten
+			// on the first commit, which would muddy the no-write assertion below.
 			const { adapter, writes } = makeAdapter(v1Record({ locale: "en" }));
 			const store = createConsentStore(makeConfig({ adapter, locale: "en" }));
 			store.setRoute("preferences");

--- a/packages/core/src/consent/store.ts
+++ b/packages/core/src/consent/store.ts
@@ -280,9 +280,7 @@ export function createConsentStore(
 		toggle(category: string) {
 			const cat = state.categories.find((c) => c.key === category);
 			if (!cat || cat.locked === true) return;
-			// Stage the flip in the draft only: live decisions — and with them
-			// gating, persistence, and gated scripts — must not move before the
-			// user confirms with save().
+			// Stage in the draft only; live decisions must not move before save().
 			const base = state.draft ?? state.decisions;
 			commit({ ...state, draft: { ...base, [category]: base[category] !== true } });
 		},
@@ -301,8 +299,7 @@ export function createConsentStore(
 		},
 		setRoute(route: Route) {
 			if (state.route === route) return;
-			// Any navigation that does not land on the preferences panel abandons
-			// staged edits (banner → customise keeps them; Back/close drops them).
+			// Only landing on "preferences" keeps the draft; Back/close abandons it.
 			commit({ ...state, route, draft: route === "preferences" ? state.draft : null });
 		},
 		has(expr: ConsentExpr) {

--- a/packages/core/src/consent/store.ts
+++ b/packages/core/src/consent/store.ts
@@ -43,6 +43,7 @@ export function createConsentStore(
 		route: config.initialRoute ?? "cookie",
 		categories: config.categories,
 		decisions: postureDecisions(config.categories, initialModel),
+		draft: null,
 		jurisdiction: initialJurisdiction.value,
 		policyVersion: config.policyVersion ?? "",
 		decidedAt: null,
@@ -164,6 +165,7 @@ export function createConsentStore(
 		return {
 			...current,
 			decisions: postureDecisions(current.categories, model),
+			draft: null,
 			decidedAt: null,
 			route: "cookie",
 			source: "default",
@@ -242,6 +244,7 @@ export function createConsentStore(
 			commit({
 				...state,
 				decisions: decisionsAll(true),
+				draft: null,
 				decidedAt: new Date().toISOString(),
 				route: "closed",
 				source: "user",
@@ -254,6 +257,7 @@ export function createConsentStore(
 			commit({
 				...state,
 				decisions: decisionsNecessary(),
+				draft: null,
 				decidedAt: new Date().toISOString(),
 				route: "closed",
 				source: "user",
@@ -266,30 +270,29 @@ export function createConsentStore(
 			commit({
 				...state,
 				decisions: decisionsNecessary(),
+				draft: null,
 				decidedAt: new Date().toISOString(),
 				route: "closed",
 				source: "user",
 				repromptReason: null,
 			});
 		},
-		toggle(category: string, opts?: ActionOptions) {
+		toggle(category: string) {
 			const cat = state.categories.find((c) => c.key === category);
 			if (!cat || cat.locked === true) return;
-			lastDecisionSource = inferSource(state.route, opts);
-			commit({
-				...state,
-				decisions: {
-					...state.decisions,
-					[category]: !state.decisions[category],
-				},
-				source: "user",
-			});
+			// Stage the flip in the draft only: live decisions — and with them
+			// gating, persistence, and gated scripts — must not move before the
+			// user confirms with save().
+			const base = state.draft ?? state.decisions;
+			commit({ ...state, draft: { ...base, [category]: base[category] !== true } });
 		},
 		save(opts?: ActionOptions) {
 			lastDecisionSource = inferSource(state.route, opts);
 			previousRecord = null;
 			commit({
 				...state,
+				decisions: state.draft ?? state.decisions,
+				draft: null,
 				decidedAt: new Date().toISOString(),
 				route: "closed",
 				source: "user",
@@ -298,7 +301,9 @@ export function createConsentStore(
 		},
 		setRoute(route: Route) {
 			if (state.route === route) return;
-			commit({ ...state, route });
+			// Any navigation that does not land on the preferences panel abandons
+			// staged edits (banner → customise keeps them; Back/close drops them).
+			commit({ ...state, route, draft: route === "preferences" ? state.draft : null });
 		},
 		has(expr: ConsentExpr) {
 			return evaluate(expr, state, {

--- a/packages/core/src/consent/types.ts
+++ b/packages/core/src/consent/types.ts
@@ -44,11 +44,10 @@ export type ConsentState = {
 	route: Route;
 	categories: Category[];
 	decisions: Record<string, boolean>;
-	// Staged, unsaved preference edits. `toggle()` writes here — never straight
-	// to `decisions` — so gating (`has`/ConsentGate), persistence, and gated
-	// scripts are untouched until `save()` promotes the draft. Discarded on any
-	// route change that does not land on "preferences". Null when there are no
-	// unsaved edits. Checkbox UIs render `(draft ?? decisions)[key]`.
+	// Staged, unsaved preference edits: `toggle()` writes here; gating,
+	// persistence, and gated scripts read `decisions` until `save()` promotes
+	// the draft. Any route change not landing on "preferences" discards it.
+	// Checkbox UIs render `(draft ?? decisions)[key]`.
 	draft: Record<string, boolean> | null;
 	jurisdiction: JurisdictionId | null;
 	policyVersion: string;
@@ -140,8 +139,7 @@ export type ConsentStore = {
 	acceptAll(opts?: ActionOptions): void;
 	acceptNecessary(opts?: ActionOptions): void;
 	reject(opts?: ActionOptions): void;
-	// Stages a flip into `state.draft`; takes no ActionOptions because nothing
-	// is recorded until `save()`, whose options name the record source.
+	// Stages the flip in `state.draft`; the record source is named at `save()`.
 	toggle(category: string): void;
 	save(opts?: ActionOptions): void;
 	setRoute(route: Route): void;

--- a/packages/core/src/consent/types.ts
+++ b/packages/core/src/consent/types.ts
@@ -44,6 +44,12 @@ export type ConsentState = {
 	route: Route;
 	categories: Category[];
 	decisions: Record<string, boolean>;
+	// Staged, unsaved preference edits. `toggle()` writes here — never straight
+	// to `decisions` — so gating (`has`/ConsentGate), persistence, and gated
+	// scripts are untouched until `save()` promotes the draft. Discarded on any
+	// route change that does not land on "preferences". Null when there are no
+	// unsaved edits. Checkbox UIs render `(draft ?? decisions)[key]`.
+	draft: Record<string, boolean> | null;
 	jurisdiction: JurisdictionId | null;
 	policyVersion: string;
 	decidedAt: string | null;
@@ -134,7 +140,9 @@ export type ConsentStore = {
 	acceptAll(opts?: ActionOptions): void;
 	acceptNecessary(opts?: ActionOptions): void;
 	reject(opts?: ActionOptions): void;
-	toggle(category: string, opts?: ActionOptions): void;
+	// Stages a flip into `state.draft`; takes no ActionOptions because nothing
+	// is recorded until `save()`, whose options name the record source.
+	toggle(category: string): void;
 	save(opts?: ActionOptions): void;
 	setRoute(route: Route): void;
 	has(expr: ConsentExpr): boolean;

--- a/packages/react/src/consent.test.tsx
+++ b/packages/react/src/consent.test.tsx
@@ -104,11 +104,14 @@ describe("useConsent", () => {
 		act(() => {
 			result.current.toggle("analytics");
 		});
-		expect(result.current.decisions.analytics).toBe(true);
+		expect(result.current.draft?.analytics).toBe(true);
+		expect(result.current.decisions.analytics).toBe(false);
 		expect(result.current.decidedAt).toBeNull();
 		act(() => {
 			result.current.save();
 		});
+		expect(result.current.decisions.analytics).toBe(true);
+		expect(result.current.draft).toBeNull();
 		expect(result.current.decidedAt).not.toBeNull();
 		expect(result.current.route).toBe("closed");
 	});
@@ -242,7 +245,7 @@ describe("ConsentGate", () => {
 
 	it("evaluates compound expressions via the shared evaluator", () => {
 		function ToggleBoth() {
-			const { toggle } = useConsent();
+			const { toggle, save } = useConsent();
 			return (
 				<>
 					<button type="button" onClick={() => toggle("analytics")}>
@@ -250,6 +253,9 @@ describe("ConsentGate", () => {
 					</button>
 					<button type="button" onClick={() => toggle("marketing")}>
 						tog-m
+					</button>
+					<button type="button" onClick={() => save()}>
+						save-prefs
 					</button>
 				</>
 			);
@@ -269,9 +275,13 @@ describe("ConsentGate", () => {
 		act(() => {
 			screen.getByText("tog-a").click();
 		});
-		expect(screen.queryByTestId("child")).toBeNull();
 		act(() => {
 			screen.getByText("tog-m").click();
+		});
+		// Staged toggles alone never open the gate — only save() applies them.
+		expect(screen.queryByTestId("child")).toBeNull();
+		act(() => {
+			screen.getByText("save-prefs").click();
 		});
 		expect(screen.getByTestId("child").textContent).toBe("both granted");
 	});

--- a/packages/react/src/consent.tsx
+++ b/packages/react/src/consent.tsx
@@ -34,6 +34,7 @@ export type UseConsentResult = {
 	route: Route;
 	categories: Category[];
 	decisions: Record<string, boolean>;
+	draft: Record<string, boolean> | null;
 	jurisdiction: JurisdictionId | null;
 	policyVersion: string;
 	decidedAt: string | null;
@@ -62,6 +63,7 @@ export function useConsent(): UseConsentResult {
 		route: state.route,
 		categories: state.categories,
 		decisions: state.decisions,
+		draft: state.draft,
 		jurisdiction: state.jurisdiction,
 		policyVersion: state.policyVersion,
 		decidedAt: state.decidedAt,
@@ -85,12 +87,20 @@ export type UseCategoryResult = {
 	toggle: () => void;
 };
 
+// `granted` is the checkbox view: it reflects staged (unsaved) edits from the
+// draft so the UI responds instantly. Effective consent — what actually gates
+// content and scripts — is `has()` / <ConsentGate>, which only move on save().
+function grantedSnapshot(store: ConsentStore, key: string): boolean {
+	const state = store.getState();
+	return (state.draft ?? state.decisions)[key] === true;
+}
+
 export function useCategory(key: string): UseCategoryResult {
 	const store = useStore();
 	const granted = useSyncExternalStore(
 		(cb) => store.subscribe(cb),
-		() => store.getState().decisions[key] === true,
-		() => store.getState().decisions[key] === true,
+		() => grantedSnapshot(store, key),
+		() => grantedSnapshot(store, key),
 	);
 	const toggle = useCallback(() => {
 		store.toggle(key);

--- a/packages/react/src/consent.tsx
+++ b/packages/react/src/consent.tsx
@@ -87,9 +87,8 @@ export type UseCategoryResult = {
 	toggle: () => void;
 };
 
-// `granted` is the checkbox view: it reflects staged (unsaved) edits from the
-// draft so the UI responds instantly. Effective consent — what actually gates
-// content and scripts — is `has()` / <ConsentGate>, which only move on save().
+// `granted` is the checkbox view and includes staged draft edits; effective
+// consent (`has()` / <ConsentGate>) only moves on save().
 function grantedSnapshot(store: ConsentStore, key: string): boolean {
 	const state = store.getState();
 	return (state.draft ?? state.decisions)[key] === true;

--- a/packages/scripts/src/test-helpers.ts
+++ b/packages/scripts/src/test-helpers.ts
@@ -15,6 +15,7 @@ export function makeStore(initialAccept: string[] = []): ConsentStore {
 		gpc: { enabled: false },
 	});
 	for (const k of initialAccept) store.toggle(k);
+	if (initialAccept.length > 0) store.save();
 	return store;
 }
 

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -95,9 +95,12 @@ describe("useConsent", () => {
 	it("toggle and save flow works", () => {
 		const consent = withProvider(() => {});
 		consent.toggle("analytics");
-		expect(consent.decisions().analytics).toBe(true);
+		expect(consent.draft()?.analytics).toBe(true);
+		expect(consent.decisions().analytics).toBe(false);
 		expect(consent.decidedAt()).toBeNull();
 		consent.save();
+		expect(consent.decisions().analytics).toBe(true);
+		expect(consent.draft()).toBeNull();
 		expect(consent.decidedAt()).not.toBeNull();
 		expect(consent.route()).toBe("closed");
 	});
@@ -202,6 +205,9 @@ describe("ConsentGate", () => {
 		expect(screen.queryByTestId("child")).toBeNull();
 		expect(screen.queryByTestId("fb")?.textContent).toBe("nope");
 		consent?.toggle("analytics");
+		// Staged toggles never open the gate — only save() applies them.
+		expect(screen.queryByTestId("child")).toBeNull();
+		consent?.save();
 		expect(screen.queryByTestId("child")?.textContent).toBe("visible");
 		expect(screen.queryByTestId("fb")).toBeNull();
 	});
@@ -224,12 +230,13 @@ describe("ConsentGate", () => {
 		));
 		expect(screen.queryByTestId("child")).toBeNull();
 		consent?.toggle("analytics");
-		expect(screen.queryByTestId("child")).toBeNull();
 		consent?.toggle("marketing");
+		expect(screen.queryByTestId("child")).toBeNull();
+		consent?.save();
 		expect(screen.queryByTestId("child")?.textContent).toBe("both");
 	});
 
-	it("toggle through accessor flips the gate", () => {
+	it("toggle then save through accessors flips the gate", () => {
 		render(() => (
 			<PolicyStack config={policyConfig}>
 				<ToggleProbe />
@@ -237,16 +244,21 @@ describe("ConsentGate", () => {
 		));
 		expect(screen.queryByTestId("gated")).toBeNull();
 		fireEvent.click(screen.getByTestId("toggle"));
+		expect(screen.queryByTestId("gated")).toBeNull();
+		fireEvent.click(screen.getByTestId("save"));
 		expect(screen.queryByTestId("gated")?.textContent).toBe("on");
 	});
 });
 
 function ToggleProbe() {
-	const { toggle } = useConsent();
+	const { toggle, save } = useConsent();
 	return (
 		<div>
 			<button data-testid="toggle" onClick={() => toggle("analytics")} type="button">
 				flip
+			</button>
+			<button data-testid="save" onClick={() => save()} type="button">
+				save
 			</button>
 			<ConsentGate requires="analytics">
 				<span data-testid="gated">on</span>

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -79,6 +79,7 @@ export type UseConsentResult = {
 	route: Accessor<Route>;
 	categories: Accessor<Category[]>;
 	decisions: Accessor<Record<string, boolean>>;
+	draft: Accessor<Record<string, boolean> | null>;
 	jurisdiction: Accessor<JurisdictionId | null>;
 	policyVersion: Accessor<string>;
 	decidedAt: Accessor<string | null>;
@@ -100,6 +101,7 @@ export function useConsent(): UseConsentResult {
 		route: () => state().route,
 		categories: () => state().categories,
 		decisions: () => state().decisions,
+		draft: () => state().draft,
 		jurisdiction: () => state().jurisdiction,
 		policyVersion: () => state().policyVersion,
 		decidedAt: () => state().decidedAt,
@@ -111,7 +113,7 @@ export function useConsent(): UseConsentResult {
 		acceptAll: (opts) => store.acceptAll(opts),
 		acceptNecessary: (opts) => store.acceptNecessary(opts),
 		reject: (opts) => store.reject(opts),
-		toggle: (key, opts) => store.toggle(key, opts),
+		toggle: (key) => store.toggle(key),
 		save: (opts) => store.save(opts),
 		setRoute: (route) => store.setRoute(route),
 		getConsentRecord: () => {
@@ -130,10 +132,16 @@ export type UseCategoryResult = {
 	toggle: () => void;
 };
 
+// `granted` is the checkbox view: it reflects staged (unsaved) edits from the
+// draft. Effective consent — what gates content and scripts — is `has()` /
+// <ConsentGate>, which only move on save().
 export function useCategory(key: string): UseCategoryResult {
 	const { store, state } = useBound();
 	return {
-		granted: () => state().decisions[key] === true,
+		granted: () => {
+			const s = state();
+			return (s.draft ?? s.decisions)[key] === true;
+		},
 		toggle: () => store.toggle(key),
 	};
 }

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -132,9 +132,8 @@ export type UseCategoryResult = {
 	toggle: () => void;
 };
 
-// `granted` is the checkbox view: it reflects staged (unsaved) edits from the
-// draft. Effective consent — what gates content and scripts — is `has()` /
-// <ConsentGate>, which only move on save().
+// `granted` is the checkbox view and includes staged draft edits; effective
+// consent (`has()` / <ConsentGate>) only moves on save().
 export function useCategory(key: string): UseCategoryResult {
 	const { store, state } = useBound();
 	return {

--- a/packages/svelte/src/consent.test.ts
+++ b/packages/svelte/src/consent.test.ts
@@ -108,6 +108,10 @@ describe("ConsentGate", () => {
 		expect(queryByTestId("fb")?.textContent).toBe("nope");
 		store.toggle("analytics");
 		flushSync();
+		// Staged toggles never open the gate — only save() applies them.
+		expect(queryByTestId("child")).toBeNull();
+		store.save();
+		flushSync();
 		expect(queryByTestId("child")?.textContent).toBe("visible");
 		expect(queryByTestId("fb")).toBeNull();
 	});
@@ -120,9 +124,10 @@ describe("ConsentGate", () => {
 		});
 		expect(queryByTestId("child")).toBeNull();
 		store.toggle("analytics");
+		store.toggle("marketing");
 		flushSync();
 		expect(queryByTestId("child")).toBeNull();
-		store.toggle("marketing");
+		store.save();
 		flushSync();
 		expect(queryByTestId("child")?.textContent).toBe("visible");
 	});
@@ -142,6 +147,7 @@ describe("createConsentReadable (svelte 4 stores fallback)", () => {
 	it("exposes action methods", () => {
 		const consent = createConsentReadable({ config: { categories: baseCategories } });
 		consent.toggle("analytics");
+		consent.save();
 		let snapshot: { route: string; decisions: Record<string, boolean> } | undefined;
 		const unsub = consent.subscribe((s) => {
 			snapshot = { route: s.route, decisions: s.decisions };

--- a/packages/svelte/src/lib/consent/context.svelte.ts
+++ b/packages/svelte/src/lib/consent/context.svelte.ts
@@ -49,6 +49,10 @@ export class ConsentRune {
 		return this.#state.decisions;
 	}
 
+	get draft(): Record<string, boolean> | null {
+		return this.#state.draft;
+	}
+
 	get jurisdiction(): JurisdictionId | null {
 		return this.#state.jurisdiction;
 	}
@@ -68,7 +72,7 @@ export class ConsentRune {
 	acceptAll = (opts?: ActionOptions): void => this.#store.acceptAll(opts);
 	acceptNecessary = (opts?: ActionOptions): void => this.#store.acceptNecessary(opts);
 	reject = (opts?: ActionOptions): void => this.#store.reject(opts);
-	toggle = (key: string, opts?: ActionOptions): void => this.#store.toggle(key, opts);
+	toggle = (key: string): void => this.#store.toggle(key);
 	save = (opts?: ActionOptions): void => this.#store.save(opts);
 	setRoute = (route: Route): void => this.#store.setRoute(route);
 
@@ -97,8 +101,11 @@ export class CategoryRune {
 		this.#key = key;
 	}
 
+	// The checkbox view: reflects staged (unsaved) edits from the draft.
+	// Effective consent — what gates content and scripts — is `has()` /
+	// <ConsentGate>, which only move on save().
 	get granted(): boolean {
-		return this.#parent.decisions[this.#key] === true;
+		return (this.#parent.draft ?? this.#parent.decisions)[this.#key] === true;
 	}
 
 	toggle = (): void => this.#parent._store().toggle(this.#key);

--- a/packages/svelte/src/lib/consent/context.svelte.ts
+++ b/packages/svelte/src/lib/consent/context.svelte.ts
@@ -101,9 +101,8 @@ export class CategoryRune {
 		this.#key = key;
 	}
 
-	// The checkbox view: reflects staged (unsaved) edits from the draft.
-	// Effective consent — what gates content and scripts — is `has()` /
-	// <ConsentGate>, which only move on save().
+	// The checkbox view, including staged draft edits; effective consent
+	// (`has()` / <ConsentGate>) only moves on save().
 	get granted(): boolean {
 		return (this.#parent.draft ?? this.#parent.decisions)[this.#key] === true;
 	}

--- a/packages/vue/src/consent.test.ts
+++ b/packages/vue/src/consent.test.ts
@@ -100,10 +100,13 @@ describe("useConsent", () => {
 		});
 		captured?.toggle("analytics");
 		await wrapper.vm.$nextTick();
-		expect(captured?.decisions.value.analytics).toBe(true);
+		expect(captured?.draft.value?.analytics).toBe(true);
+		expect(captured?.decisions.value.analytics).toBe(false);
 		expect(captured?.decidedAt.value).toBeNull();
 		captured?.save();
 		await wrapper.vm.$nextTick();
+		expect(captured?.decisions.value.analytics).toBe(true);
+		expect(captured?.draft.value).toBeNull();
 		expect(captured?.decidedAt.value).not.toBeNull();
 		expect(captured?.route.value).toBe("closed");
 	});
@@ -222,6 +225,10 @@ describe("ConsentGate", () => {
 		expect(wrapper.find('[data-testid="child"]').exists()).toBe(false);
 		get()?.toggle("analytics");
 		await wrapper.vm.$nextTick();
+		// Staged toggles never open the gate — only save() applies them.
+		expect(wrapper.find('[data-testid="child"]').exists()).toBe(false);
+		get()?.save();
+		await wrapper.vm.$nextTick();
 		expect(wrapper.get('[data-testid="child"]').text()).toBe("visible");
 		expect(wrapper.find('[data-testid="fb"]').exists()).toBe(false);
 	});
@@ -230,9 +237,10 @@ describe("ConsentGate", () => {
 		const { wrapper, get } = mountGate({ and: ["analytics", "marketing"] });
 		expect(wrapper.find('[data-testid="child"]').exists()).toBe(false);
 		get()?.toggle("analytics");
+		get()?.toggle("marketing");
 		await wrapper.vm.$nextTick();
 		expect(wrapper.find('[data-testid="child"]').exists()).toBe(false);
-		get()?.toggle("marketing");
+		get()?.save();
 		await wrapper.vm.$nextTick();
 		expect(wrapper.get('[data-testid="child"]').text()).toBe("visible");
 	});

--- a/packages/vue/src/consent.ts
+++ b/packages/vue/src/consent.ts
@@ -49,6 +49,7 @@ export type UseConsentResult = {
 	route: ComputedRef<Route>;
 	categories: ComputedRef<Category[]>;
 	decisions: ComputedRef<Record<string, boolean>>;
+	draft: ComputedRef<Record<string, boolean> | null>;
 	jurisdiction: ComputedRef<JurisdictionId | null>;
 	policyVersion: ComputedRef<string>;
 	decidedAt: ComputedRef<string | null>;
@@ -71,6 +72,7 @@ export function useConsent(): UseConsentResult {
 		route: computed(() => state.value.route),
 		categories: computed(() => state.value.categories),
 		decisions: computed(() => state.value.decisions),
+		draft: computed(() => state.value.draft),
 		jurisdiction: computed(() => state.value.jurisdiction),
 		policyVersion: computed(() => state.value.policyVersion),
 		decidedAt: computed(() => state.value.decidedAt),
@@ -78,7 +80,7 @@ export function useConsent(): UseConsentResult {
 		acceptAll: (opts) => store.acceptAll(opts),
 		acceptNecessary: (opts) => store.acceptNecessary(opts),
 		reject: (opts) => store.reject(opts),
-		toggle: (key, opts) => store.toggle(key, opts),
+		toggle: (key) => store.toggle(key),
 		save: (opts) => store.save(opts),
 		setRoute: (route) => store.setRoute(route),
 		has: (expr) => store.has(expr),
@@ -92,11 +94,14 @@ export type UseCategoryResult = {
 	toggle: () => void;
 };
 
+// `granted` is the checkbox view: it reflects staged (unsaved) edits from the
+// draft. Effective consent — what gates content and scripts — is `has()` /
+// <ConsentGate>, which only move on save().
 export function useCategory(key: string): UseCategoryResult {
 	const store = injectStore();
 	const state = useStoreState(store);
 	return {
-		granted: computed(() => state.value.decisions[key] === true),
+		granted: computed(() => (state.value.draft ?? state.value.decisions)[key] === true),
 		toggle: () => store.toggle(key),
 	};
 }

--- a/packages/vue/src/consent.ts
+++ b/packages/vue/src/consent.ts
@@ -94,9 +94,8 @@ export type UseCategoryResult = {
 	toggle: () => void;
 };
 
-// `granted` is the checkbox view: it reflects staged (unsaved) edits from the
-// draft. Effective consent — what gates content and scripts — is `has()` /
-// <ConsentGate>, which only move on save().
+// `granted` is the checkbox view and includes staged draft edits; effective
+// consent (`has()` / <ConsentGate>) only moves on save().
 export function useCategory(key: string): UseCategoryResult {
 	const store = injectStore();
 	const state = useStoreState(store);


### PR DESCRIPTION
## Summary

Fixes #157. `store.toggle()` committed straight to live consent state, so ticking a checkbox in a preferences panel took effect **before** the user pressed Save: `ConsentGate` opened and gated scripts loaded on tick with no way to undo, and for returning visitors every tick wrote a record to storage carrying the old `decidedAt` with the new decisions.

`toggle()` now stages the flip in a new `ConsentState.draft`. Gating (`has()` / `ConsentGate`), persistence, and `gateScript` keep reading live `decisions` until `save()` promotes the draft in one step and stamps a fresh `decidedAt`. Any `setRoute` that does not land on `"preferences"` discards the draft, so Back genuinely abandons unsaved edits. The tanstack/wasp blog posts already described exactly this draft model — the implementation now matches them.

## Changes

- **core**: `draft` field on `ConsentState`; `toggle()` stages into it (no live commit, no persist, no `source` flip); `save()` promotes `draft ?? decisions`; `acceptAll`/`acceptNecessary`/`reject` and reprompt invalidation clear it; route changes discard it unless landing on `"preferences"` (banner → customise carries staged ticks forward).
- **core (breaking)**: `toggle(key)` no longer takes `ActionOptions` — nothing is recorded at toggle time, so the record source is named at `save()`. (Previously `save()` overwrote toggle's source anyway, so no behavior is lost.)
- **react/vue/svelte/solid/angular**: per-category `granted` accessors read `draft ?? decisions` so checkboxes respond instantly pre-save; bindings that mirror `ConsentState` expose `draft` for custom panels.
- **tests**: rewrote the tests that codified the old behavior (`has()` reflecting unsaved toggles, persist-on-toggle) and added coverage for gate-ignores-staged-toggles, no-write-before-save for returning visitors (fresh `decidedAt` on the saved record), draft discard on Back, draft carry-over banner → preferences, and reprompt clearing the draft.
- **docs**: "Staged preferences" section in the core consent doc, a staged-semantics note in each framework doc, and the Astro blog snippet's checkbox render made draft-aware.

## Reviewer notes

- `useCategory().granted` intentionally reads the draft (the checkbox view) while `has()`/`ConsentGate` intentionally do not (effective consent) — that split is the fix.
- Custom panels rendering checkboxes from raw `decisions` must switch to `draft ?? decisions`; the per-category accessors do it already.
- Found in passing (left as is): for a returning visitor whose stored record has a non-canonical locale (pre-PS-26), the first commit after hydration — even a bare `setRoute` — rewrites the record with the normalized locale. Pre-existing, orthogonal to this fix.
- Verified with `vp run -r test` (all 11 workspaces), `vp check`, and `vp run -r check-types`.