### PR TITLE
fix(react): return a deterministic server snapshot from consent hooks

### DIFF
--- a/.changeset/ssr-server-snapshot.md
+++ b/.changeset/ssr-server-snapshot.md
@@ -1,0 +1,10 @@
+---
+"@policystack/core": minor
+"@policystack/react": minor
+---
+
+Consent hooks no longer cause hydration mismatches under SSR. The React hooks passed live store state as `useSyncExternalStore`'s `getServerSnapshot`, so any returning visitor mismatched: the server has no stored record and resolves the _host's_ timezone, while the client has both (#158). Every SSR consumer had to hand-roll a `mounted` flag around consent-driven UI.
+
+`ConsentStore` gains a `server` member (`getState()` / `has()`) returning a deterministic pre-consent snapshot: undecided, no jurisdiction, conservative opt-in posture, derived from static config alone and never from the adapter or resolver. `useConsent`, `useCategory`, and `ConsentGate` pass it as `getServerSnapshot`, and React re-reads live state once hydration commits.
+
+The Vue, Svelte, Solid, and Angular bindings still seed from live state and are unchanged here; `store.server` is the shared primitive their fix will use.

--- a/apps/web/content/docs/consent/core.md
+++ b/apps/web/content/docs/consent/core.md
@@ -33,7 +33,15 @@ store.subscribe((state) => render(state));
 store.acceptAll();
 ```
 
-The store's surface: `getState()`, `subscribe()`, `acceptAll()`, `acceptNecessary()`, `reject()`, `toggle(key)`, `save()`, `setRoute()`, `has(expr)`, `getConsentRecord()`, `getPreviousRecord()`, `refreshJurisdiction()`. See [`types.ts`](./src/types.ts) for the full shape.
+The store's surface: `getState()`, `subscribe()`, `acceptAll()`, `acceptNecessary()`, `reject()`, `toggle(key)`, `save()`, `setRoute()`, `has(expr)`, `getConsentRecord()`, `getPreviousRecord()`, `refreshJurisdiction()`, `server`. See [`types.ts`](./src/types.ts) for the full shape.
+
+### Server rendering (`store.server`)
+
+`getState()` and `has()` read live state, which varies with the environment: a server has no stored record, and `timezoneResolver` there resolves the **host's** timezone rather than the visitor's. Rendering from live state on the server therefore mismatches the client that hydrates it.
+
+`store.server.getState()` and `store.server.has(expr)` return the deterministic pre-consent view instead — undecided, no jurisdiction, conservative opt-in, derived from static config alone. Two stores built from one config agree here whatever adapter or resolver they were given. `getState()` is frozen and referentially stable, as React's `useSyncExternalStore` requires of `getServerSnapshot`.
+
+The React bindings wire this for you, so consent-driven UI hydrates cleanly with no `mounted` flag. Custom bindings should render from `store.server` on the server and during hydration, then switch to live state.
 
 ### Staged preferences (`state.draft`)
 

--- a/apps/web/content/docs/consent/react.md
+++ b/apps/web/content/docs/consent/react.md
@@ -125,6 +125,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 For SSR-resolved decisions, author a storage adapter (and jurisdiction resolver) under `config.consent` — the cookie/header adapters from [`@policystack/core/consent`](/docs/consent/core) restore decisions at init. Nothing else changes; the same one config drives it.
 
+`useConsent`, `useCategory`, and `ConsentGate` server-render from [`store.server`](/docs/consent/core#server-rendering-storeserver), the deterministic pre-consent snapshot, and switch to live state once hydration commits. Consent-driven UI hydrates cleanly for returning visitors with no `mounted` flag of your own.
+
 ## Shared concepts
 
 Categories, GPC handling, jurisdiction resolvers, re-consent triggers, script gating (`gateScript`), and storage adapters all live in [`@policystack/core/consent`](/docs/consent/core) — the React adapter is a thin reactivity wrapper.

--- a/packages/core/src/consent/index.ts
+++ b/packages/core/src/consent/index.ts
@@ -35,6 +35,7 @@ export type {
 	Route,
 	ScriptDefinition,
 	ScriptEvent,
+	ServerSnapshot,
 	StorageAdapter,
 	UnknownCategoryBehavior,
 } from "./types";

--- a/packages/core/src/consent/store.test.ts
+++ b/packages/core/src/consent/store.test.ts
@@ -591,10 +591,8 @@ describe("createConsentStore", () => {
 			source: "banner",
 		};
 
-		// The one property SSR depends on: the snapshot cannot vary with
-		// anything the environment supplies. A server has no stored record and
-		// its own timezone; the client that hydrates has both. If either can
-		// reach this snapshot, hydration mismatches come straight back.
+		// The property SSR depends on. If anything environmental reaches this
+		// snapshot, hydration mismatches come straight back.
 		it("is identical regardless of adapter and resolver", () => {
 			const bare = createConsentStore(makeConfig());
 			const wired = createConsentStore(
@@ -620,13 +618,12 @@ describe("createConsentStore", () => {
 				source: "default",
 				repromptReason: null,
 				// Locked categories stand on a non-consent basis, so they are
-				// granted even pre-consent; everything gated stays off.
+				// granted pre-consent; everything gated stays off.
 				decisions: { essential: true, analytics: false, marketing: false },
 			});
 		});
 
-		// React's useSyncExternalStore requires a cached getServerSnapshot and
-		// errors if the reference changes between calls.
+		// useSyncExternalStore errors if getServerSnapshot is not cached.
 		it("returns a stable reference that mutations do not disturb", () => {
 			const store = createConsentStore(makeConfig());
 			const before = store.server.getState();

--- a/packages/core/src/consent/store.test.ts
+++ b/packages/core/src/consent/store.test.ts
@@ -580,6 +580,61 @@ describe("createConsentStore", () => {
 		});
 	});
 
+	describe("server snapshot", () => {
+		const storedRecord: ConsentRecord = {
+			schemaVersion: 1,
+			decisions: { essential: true, analytics: true, marketing: true },
+			jurisdiction: "us",
+			policyVersion: "",
+			decidedAt: "2026-07-01T00:00:00.000Z",
+			locale: "en-GB",
+			source: "banner",
+		};
+
+		// The one property SSR depends on: the snapshot cannot vary with
+		// anything the environment supplies. A server has no stored record and
+		// its own timezone; the client that hydrates has both. If either can
+		// reach this snapshot, hydration mismatches come straight back.
+		it("is identical regardless of adapter and resolver", () => {
+			const bare = createConsentStore(makeConfig());
+			const wired = createConsentStore(
+				makeConfig({
+					adapter: { read: () => storedRecord, write: () => {}, clear: () => {} },
+					jurisdictionResolver: manualResolver("us"),
+				}),
+			);
+			expect(wired.server.getState()).toEqual(bare.server.getState());
+			expect(wired.server.has("analytics")).toBe(bare.server.has("analytics"));
+			// ...while live state does diverge, which is the whole point.
+			expect(wired.getState()).not.toEqual(bare.getState());
+		});
+
+		it("is undecided and posture-neutral", () => {
+			const store = createConsentStore(makeConfig({ jurisdictionResolver: manualResolver("us") }));
+			expect(store.server.getState()).toMatchObject({
+				route: "cookie",
+				jurisdiction: null,
+				consentModel: "opt-in",
+				decidedAt: null,
+				draft: null,
+				source: "default",
+				repromptReason: null,
+				// Locked categories stand on a non-consent basis, so they are
+				// granted even pre-consent; everything gated stays off.
+				decisions: { essential: true, analytics: false, marketing: false },
+			});
+		});
+
+		// React's useSyncExternalStore requires a cached getServerSnapshot and
+		// errors if the reference changes between calls.
+		it("returns a stable reference that mutations do not disturb", () => {
+			const store = createConsentStore(makeConfig());
+			const before = store.server.getState();
+			store.acceptAll();
+			expect(store.server.getState()).toBe(before);
+		});
+	});
+
 	describe("subscribe", () => {
 		it("notifies the listener with the new state on each transition", () => {
 			const store = createConsentStore(makeConfig());

--- a/packages/core/src/consent/store.ts
+++ b/packages/core/src/consent/store.ts
@@ -38,6 +38,25 @@ export function createConsentStore(
 	const initialJurisdiction = resolveSync(config, config.request);
 	const initialRecord = readSync(config, locale);
 
+	// The deterministic pre-consent snapshot, built before any environment is
+	// consulted: no record, no resolved jurisdiction, so `jurisdictionPosture`
+	// falls back to `row` (conservative opt-in). Frozen and built once so the
+	// reference is stable across calls.
+	const serverModel = jurisdictionPosture(null);
+	const serverState: ConsentState = Object.freeze({
+		route: config.initialRoute ?? "cookie",
+		categories: config.categories,
+		decisions: postureDecisions(config.categories, serverModel),
+		draft: null,
+		jurisdiction: null,
+		policyVersion: config.policyVersion ?? "",
+		decidedAt: null,
+		source: "default",
+		repromptReason: null,
+		canWithdraw: config.canWithdraw ?? false,
+		consentModel: serverModel,
+	});
+
 	const initialModel = jurisdictionPosture(initialJurisdiction.value);
 	const baseState: ConsentState = {
 		route: config.initialRoute ?? "cookie",
@@ -306,6 +325,16 @@ export function createConsentStore(
 			return evaluate(expr, state, {
 				onUnknownCategory: config.onUnknownCategory,
 			});
+		},
+		server: {
+			getState() {
+				return serverState;
+			},
+			has(expr: ConsentExpr) {
+				return evaluate(expr, serverState, {
+					onUnknownCategory: config.onUnknownCategory,
+				});
+			},
 		},
 		async refreshJurisdiction(req?: ResolverContext) {
 			const resolver = config.jurisdictionResolver;

--- a/packages/core/src/consent/store.ts
+++ b/packages/core/src/consent/store.ts
@@ -38,10 +38,9 @@ export function createConsentStore(
 	const initialJurisdiction = resolveSync(config, config.request);
 	const initialRecord = readSync(config, locale);
 
-	// The deterministic pre-consent snapshot, built before any environment is
-	// consulted: no record, no resolved jurisdiction, so `jurisdictionPosture`
-	// falls back to `row` (conservative opt-in). Frozen and built once so the
-	// reference is stable across calls.
+	// The SSR snapshot (see `ServerSnapshot`): built before any environment is
+	// consulted, so `jurisdictionPosture` falls back to `row` (opt-in). Built
+	// once and frozen to keep the reference stable.
 	const serverModel = jurisdictionPosture(null);
 	const serverState: ConsentState = Object.freeze({
 		route: config.initialRoute ?? "cookie",

--- a/packages/core/src/consent/types.ts
+++ b/packages/core/src/consent/types.ts
@@ -149,18 +149,16 @@ export type ConsentStore = {
 };
 
 /**
- * The SSR seam. `getState()`/`has()` above read live state, which is derived
- * from the environment (the adapter finds no stored record on a server; a
- * timezone resolver reads the *host's* zone) and therefore differs between the
- * server render and the client that hydrates it.
+ * The SSR seam. Live state varies with the environment — a server finds no
+ * stored record and a timezone resolver reads the *host's* zone — so rendering
+ * from it on the server mismatches the client that hydrates.
  *
- * These return the deterministic pre-consent view instead: undecided, no
- * jurisdiction, conservative opt-in posture, derived only from static config.
- * Two stores built from the same config agree here no matter what adapter or
- * resolver they were given, which is exactly the property SSR needs.
+ * These read the deterministic pre-consent view instead: undecided, no
+ * jurisdiction, conservative opt-in, from static config only. Two stores built
+ * from one config agree here whatever adapter or resolver they were given.
  *
- * `getState()` returns one frozen, referentially stable object — React's
- * `useSyncExternalStore` requires a cached `getServerSnapshot`.
+ * `getState()` is frozen and referentially stable, as React's
+ * `useSyncExternalStore` requires of `getServerSnapshot`.
  */
 export type ServerSnapshot = {
 	getState(): ConsentState;

--- a/packages/core/src/consent/types.ts
+++ b/packages/core/src/consent/types.ts
@@ -145,6 +145,26 @@ export type ConsentStore = {
 	setRoute(route: Route): void;
 	has(expr: ConsentExpr): boolean;
 	refreshJurisdiction(req?: ResolverContext): Promise<JurisdictionId | null>;
+	server: ServerSnapshot;
+};
+
+/**
+ * The SSR seam. `getState()`/`has()` above read live state, which is derived
+ * from the environment (the adapter finds no stored record on a server; a
+ * timezone resolver reads the *host's* zone) and therefore differs between the
+ * server render and the client that hydrates it.
+ *
+ * These return the deterministic pre-consent view instead: undecided, no
+ * jurisdiction, conservative opt-in posture, derived only from static config.
+ * Two stores built from the same config agree here no matter what adapter or
+ * resolver they were given, which is exactly the property SSR needs.
+ *
+ * `getState()` returns one frozen, referentially stable object — React's
+ * `useSyncExternalStore` requires a cached `getServerSnapshot`.
+ */
+export type ServerSnapshot = {
+	getState(): ConsentState;
+	has(expr: ConsentExpr): boolean;
 };
 
 export type ScriptDefinition = {

--- a/packages/react/src/consent.ssr.test.tsx
+++ b/packages/react/src/consent.ssr.test.tsx
@@ -10,9 +10,9 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { ConsentGate, useConsent } from "./consent";
 import { PolicyStack } from "./provider";
 
-// A fresh adapter per environment. The localStorage adapter keeps an in-memory
-// fallback Map, so sharing one instance across the two passes would leak the
-// server's view into the client's and hide the very divergence under test.
+// A fresh adapter per environment: the localStorage adapter keeps an in-memory
+// fallback Map, and one shared instance would leak the server's view into the
+// client's, hiding the divergence under test.
 function makeConfig(): PolicyStackConfig {
 	return {
 		company: {
@@ -62,10 +62,9 @@ function Analytics() {
 	);
 }
 
-// The consent-driven node sits inside a layout element, as it does in a real
-// app. React tolerates leftover nodes at the container root, so a bare subject
-// would let the "server rendered it, client did not" direction slip through
-// unreported.
+// The subject sits inside a layout element, as in a real app. React tolerates
+// leftover nodes at the container root, so a bare subject would let the "server
+// rendered it, client did not" direction slip through unreported.
 function App({ children }: { children: ReactNode }) {
 	return (
 		<PolicyStack config={makeConfig()}>
@@ -74,9 +73,9 @@ function App({ children }: { children: ReactNode }) {
 	);
 }
 
-// Renders `node` the way a server would: no localStorage, so the store finds no
-// stored record. The adapter reads `globalThis.localStorage` lazily per call, so
-// stubbing around the render is enough to reach the SSR fallback path.
+// Renders as a server would: no localStorage, so the store finds no record. The
+// adapter reads `globalThis.localStorage` lazily, so stubbing around the render
+// is enough to reach the fallback path.
 function renderOnServer(node: React.ReactNode): string {
 	vi.stubGlobal("localStorage", undefined);
 	try {
@@ -137,8 +136,8 @@ describe("SSR hydration", () => {
 
 		expect(onRecoverableError).not.toHaveBeenCalled();
 		expect(consoleError).not.toHaveBeenCalled();
-		// ...and the second pass still converges on the live state. Freezing the
-		// snapshot forever would satisfy the two assertions above and fail here.
+		// ...and still converges on live state. A snapshot frozen forever would
+		// pass the two assertions above and fail here.
 		expect(container.querySelector("[data-testid='banner']")).toBeNull();
 	});
 

--- a/packages/react/src/consent.ssr.test.tsx
+++ b/packages/react/src/consent.ssr.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+import type { PolicyStackConfig } from "@policystack/core";
+import type { ConsentRecord } from "@policystack/core/consent";
+import { localStorageAdapter } from "@policystack/core/consent/storage/local-storage";
+import { act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { ConsentGate, useConsent } from "./consent";
+import { PolicyStack } from "./provider";
+
+// A fresh adapter per environment. The localStorage adapter keeps an in-memory
+// fallback Map, so sharing one instance across the two passes would leak the
+// server's view into the client's and hide the very divergence under test.
+function makeConfig(): PolicyStackConfig {
+	return {
+		company: {
+			name: "Acme Inc.",
+			legalName: "Acme Corporation",
+			address: "123 Main St, Springfield, USA",
+			contact: { email: "privacy@acme.com" },
+		},
+		effectiveDate: "2026-01-01",
+		jurisdictions: ["eea"],
+		cookieVersion: "v1",
+		data: { collected: {}, context: {} },
+		cookies: {
+			used: { essential: true, analytics: true },
+			context: {
+				essential: { lawfulBasis: "legal_obligation" },
+				analytics: { lawfulBasis: "consent" },
+			},
+		},
+		consent: { adapter: localStorageAdapter() },
+	};
+}
+
+// `policyVersion` matches `cookieVersion` so the default `policyVersionChanged`
+// trigger does not fire a reprompt and confound the assertions.
+const RETURNING_VISITOR: ConsentRecord = {
+	schemaVersion: 1,
+	decisions: { essential: true, analytics: true },
+	jurisdiction: "uk",
+	policyVersion: "v1",
+	decidedAt: "2026-07-01T00:00:00.000Z",
+	locale: "en-GB",
+	source: "banner",
+};
+
+function Banner() {
+	const { route } = useConsent();
+	if (route !== "cookie") return null;
+	return <div data-testid="banner">Cookie banner</div>;
+}
+
+function Analytics() {
+	return (
+		<ConsentGate requires="analytics">
+			<div data-testid="analytics">Analytics</div>
+		</ConsentGate>
+	);
+}
+
+// The consent-driven node sits inside a layout element, as it does in a real
+// app. React tolerates leftover nodes at the container root, so a bare subject
+// would let the "server rendered it, client did not" direction slip through
+// unreported.
+function App({ children }: { children: ReactNode }) {
+	return (
+		<PolicyStack config={makeConfig()}>
+			<div id="app">{children}</div>
+		</PolicyStack>
+	);
+}
+
+// Renders `node` the way a server would: no localStorage, so the store finds no
+// stored record. The adapter reads `globalThis.localStorage` lazily per call, so
+// stubbing around the render is enough to reach the SSR fallback path.
+function renderOnServer(node: React.ReactNode): string {
+	vi.stubGlobal("localStorage", undefined);
+	try {
+		return renderToString(node);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+}
+
+type HydrateResult = {
+	container: HTMLElement;
+	onRecoverableError: ReturnType<typeof vi.fn>;
+	consoleError: ReturnType<typeof vi.spyOn>;
+};
+
+async function hydrate(html: string, node: React.ReactNode): Promise<HydrateResult> {
+	const container = document.createElement("div");
+	container.innerHTML = html;
+	document.body.appendChild(container);
+
+	const onRecoverableError = vi.fn();
+	const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+	await act(async () => {
+		hydrateRoot(container, node, { onRecoverableError });
+	});
+
+	return { container, onRecoverableError, consoleError };
+}
+
+afterEach(() => {
+	document.body.innerHTML = "";
+	localStorage.clear();
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe("SSR hydration", () => {
+	it("hydrates a returning visitor without a mismatch, then shows live state", async () => {
+		const html = renderOnServer(
+			<App>
+				<Banner />
+			</App>,
+		);
+		// The server has no record, so it renders the banner.
+		expect(html).toContain("Cookie banner");
+
+		// The visitor already decided, so mergeRecord starts the live client
+		// store at route "closed".
+		localStorage.setItem("oc_consent", JSON.stringify(RETURNING_VISITOR));
+
+		const { container, onRecoverableError, consoleError } = await hydrate(
+			html,
+			<App>
+				<Banner />
+			</App>,
+		);
+
+		expect(onRecoverableError).not.toHaveBeenCalled();
+		expect(consoleError).not.toHaveBeenCalled();
+		// ...and the second pass still converges on the live state. Freezing the
+		// snapshot forever would satisfy the two assertions above and fail here.
+		expect(container.querySelector("[data-testid='banner']")).toBeNull();
+	});
+
+	it("hydrates a ConsentGate without a mismatch, then reveals granted content", async () => {
+		const html = renderOnServer(
+			<App>
+				<Analytics />
+			</App>,
+		);
+		// No record and an opt-in posture, so the gate is closed on the server.
+		expect(html).not.toContain("Analytics");
+
+		localStorage.setItem("oc_consent", JSON.stringify(RETURNING_VISITOR));
+
+		const { container, onRecoverableError, consoleError } = await hydrate(
+			html,
+			<App>
+				<Analytics />
+			</App>,
+		);
+
+		expect(onRecoverableError).not.toHaveBeenCalled();
+		expect(consoleError).not.toHaveBeenCalled();
+		expect(container.querySelector("[data-testid='analytics']")).not.toBeNull();
+	});
+});

--- a/packages/react/src/consent.tsx
+++ b/packages/react/src/consent.tsx
@@ -28,14 +28,9 @@ function useStore(): ConsentStore {
 	return store;
 }
 
-// All three hooks below pass `store.server.*` to useSyncExternalStore as
-// `getServerSnapshot`. That snapshot comes from static config alone, so the
-// server render and the client's hydration pass agree; React then re-reads the
-// live snapshot once hydration commits and re-renders if it differs. Passing
-// live state there instead (as this once did) guarantees a mismatch for any
-// returning visitor, because the server has no stored record and no real
-// timezone — which is what forced every SSR consumer to hand-roll a `mounted`
-// flag around consent-driven UI.
+// Every hook below passes `store.server.*` as `getServerSnapshot` — live state
+// there would mismatch on hydration for any returning visitor. React re-reads
+// the live snapshot once hydration commits.
 
 // State slice flows through useSyncExternalStore; the actions are the store's
 // own closures, passed by reference (stable identity, no per-render wrappers).

--- a/packages/react/src/consent.tsx
+++ b/packages/react/src/consent.tsx
@@ -5,6 +5,7 @@ import type {
 	ConsentExpr,
 	ConsentRecord,
 	ConsentRecordSource,
+	ConsentState,
 	ConsentStore,
 	JurisdictionId,
 	RepromptReason,
@@ -26,6 +27,15 @@ function useStore(): ConsentStore {
 	}
 	return store;
 }
+
+// All three hooks below pass `store.server.*` to useSyncExternalStore as
+// `getServerSnapshot`. That snapshot comes from static config alone, so the
+// server render and the client's hydration pass agree; React then re-reads the
+// live snapshot once hydration commits and re-renders if it differs. Passing
+// live state there instead (as this once did) guarantees a mismatch for any
+// returning visitor, because the server has no stored record and no real
+// timezone — which is what forced every SSR consumer to hand-roll a `mounted`
+// flag around consent-driven UI.
 
 // State slice flows through useSyncExternalStore; the actions are the store's
 // own closures, passed by reference (stable identity, no per-render wrappers).
@@ -57,7 +67,7 @@ export function useConsent(): UseConsentResult {
 	const state = useSyncExternalStore(
 		(cb) => store.subscribe(cb),
 		() => store.getState(),
-		() => store.getState(),
+		() => store.server.getState(),
 	);
 	return {
 		route: state.route,
@@ -89,8 +99,7 @@ export type UseCategoryResult = {
 
 // `granted` is the checkbox view and includes staged draft edits; effective
 // consent (`has()` / <ConsentGate>) only moves on save().
-function grantedSnapshot(store: ConsentStore, key: string): boolean {
-	const state = store.getState();
+function grantedSnapshot(state: ConsentState, key: string): boolean {
 	return (state.draft ?? state.decisions)[key] === true;
 }
 
@@ -98,8 +107,8 @@ export function useCategory(key: string): UseCategoryResult {
 	const store = useStore();
 	const granted = useSyncExternalStore(
 		(cb) => store.subscribe(cb),
-		() => grantedSnapshot(store, key),
-		() => grantedSnapshot(store, key),
+		() => grantedSnapshot(store.getState(), key),
+		() => grantedSnapshot(store.server.getState(), key),
 	);
 	const toggle = useCallback(() => {
 		store.toggle(key);
@@ -118,7 +127,7 @@ export function ConsentGate({ requires, fallback = null, children }: ConsentGate
 	const granted = useSyncExternalStore(
 		(cb) => store.subscribe(cb),
 		() => store.has(requires),
-		() => store.has(requires),
+		() => store.server.has(requires),
 	);
 	return <>{granted ? children : fallback}</>;
 }


### PR DESCRIPTION
## Summary

Fixes #158.

The React consent hooks passed live store state as `useSyncExternalStore`'s `getServerSnapshot`, so the value React hydrated against was client truth rather than what the server actually rendered.

The two environments genuinely disagree. On the server the storage adapter finds no record (`localStorage` falls back to an in-memory Map) and `timezoneResolver` resolves the **host's** zone, not the visitor's. So a returning visitor gets `route: "cookie"` from the server and `"closed"` on the client, and `ConsentGate` children flip with the posture. `getServerSnapshot` runs on the client during hydration too, so there was no seam for a consumer to shim — every SSR consumer had to hand-roll a `mounted` flag around every consent-driven component.

`createConsentStore` now builds one frozen, pre-consent `ConsentState` before any environment is consulted: no record, no jurisdiction, so posture falls back to `row` (conservative opt-in). It is exposed as `store.server` and the hooks pass it as `getServerSnapshot`. React handles the second pass itself: it hydrates against the constant, then re-reads live state on commit and re-renders if it differs.

## Changes

- `packages/core/src/consent/store.ts` — build one frozen `serverState` from static config alone; expose it as `store.server` with `getState()` and `has()`.
- `packages/core/src/consent/types.ts` — `ConsentStore` gains a `server` member, typed as the new exported `ServerSnapshot`.
- `packages/react/src/consent.tsx` — `useConsent`, `useCategory` and `ConsentGate` pass `store.server.*` as `getServerSnapshot`.
- `packages/react/src/consent.ssr.test.tsx` (new) — SSR regression test.
- `packages/core/src/consent/store.test.ts` — three contract tests for the new snapshot.

## For reviewers

**The regression test asserts two things, and both matter.** It renders to HTML with `localStorage` stubbed out, hydrates against a real store seeded with a returning visitor's record, then checks that hydration reports no mismatch *and* that the tree still converges on live state. Freezing the snapshot forever would satisfy the first and fail the second; only fixing the ordering would do the reverse. Splitting them into separate tests would let a half-fix go green.

I verified the test is load-bearing rather than merely passing alongside the fix: reverting only the three React lines, leaving core intact, reproduces both failures with React's own `Hydration failed because the server rendered HTML didn't match the client`.

**One subtlety worth knowing if you extend the test.** The consent-driven node sits inside a layout element on purpose. React tolerates leftover nodes at the container root, so with a bare subject the "server rendered it, client did not" direction slips through unreported — the stale server HTML just sits in the DOM. The wrapper makes React own the region, and also matches how a real app is laid out.

**The core contract test is the durable guard.** It asserts that two stores built with different adapters and resolvers produce identical server snapshots, while their live states diverge. That is the property SSR depends on, and it is what stops someone later threading environment-dependent data back into the snapshot.

`ConsentStore` gained a required member. Nothing in the repo builds that type by hand, so nothing broke, but it is technically breaking for an external hand-rolled implementation — hence `minor` in the changeset rather than `patch`.

## Deliberately not included

- **Vue, Svelte, Solid and Angular still seed from live state** (`packages/vue/src/consent.ts`, `packages/svelte/src/lib/consent/`, `packages/solid/src/index.ts`, `packages/angular/src/consent.service.ts`). #158 asks for the fix to span the framework packages, so this is a real remainder. Each needs its own SSR harness and two-pass idiom; `store.server` is the shared primitive they will use. Happy to open a follow-up.
- **No `ssr` fallback prop on `ConsentGate`.** #158 lists it as an optional extra and it is an API addition, so it seemed worth deciding separately.
- **No `timezoneResolver` SSR guard.** The constant snapshot removes its hydration consequence, but the resolver still silently resolves the host's timezone for server-rendered output generally. That is the docs/guard item from the closing note of #158.

## Verification

Full gate green: `vp run -r build`, `vp run -r test` (965 tests, 11 workspaces), `vp check`, `vp run -r check-types`.

`knip` exits 1, but that is pre-existing on `main` and its output is byte-identical to the stashed baseline.
