### PR TITLE
feat(react): reach the provider's consent store via useConsentStore and GatedScript

### DIFF
--- a/.changeset/react-gated-script.md
+++ b/.changeset/react-gated-script.md
@@ -1,0 +1,12 @@
+---
+"@policystack/react": minor
+---
+
+`@policystack/react/consent` now exposes the provider's consent store, so `gateScript` and the `@policystack/scripts` catalogue are usable with the React bindings (#159). Previously `<PolicyStack>` created its store privately and nothing exported it, leaving no way to obtain the `ConsentStore` that `gateScript(store, def)` requires.
+
+Two new exports:
+
+- `<GatedScript def={...} />` — the React binding for `gateScript`. Takes the store from `<PolicyStack>`, gates the script for as long as it is mounted, and disposes on unmount. Renders no DOM and is inert during SSR. Building the definition inline (`def={ga4({ measurementId: "G-XXXXXXX" })}`) is safe: the gate follows `def.id`, so a fresh object each render neither re-gates nor drops queued pre-consent calls. Optional `onEvent` receives the `ScriptEvent` stream.
+- `useConsentStore()` — returns the `ConsentStore` for handing to other core free functions such as `gateScripts`. Stable for the life of the provider and non-reactive; keep using `useConsent` / `useCategory` / `<ConsentGate>` to react to state.
+
+Both throw the existing provider guard outside `<PolicyStack>` or under a policy-only config. That error message now names the full consent API rather than three of its members.

--- a/apps/web/content/docs/consent/core.md
+++ b/apps/web/content/docs/consent/core.md
@@ -279,6 +279,8 @@ Useful options on the script definition:
 
 A loaded script cannot be un-loaded. If consent is later revoked, Consent does **not** unmount the `<script>` tag, restore the queue stubs, or re-evaluate the gate. Recommend `location.reload()` to your users for a clean slate.
 
+React consumers should reach for [`<GatedScript>`](/docs/consent/react#gatedscript) rather than calling `gateScript` directly: it takes the store from `<PolicyStack>` and ties the gate's lifetime to the component. `useConsentStore()` from the same entry returns the store if you need it for `gateScripts` or another core free function.
+
 For inline JSX gating (e.g. wrapping a `<MapWidget />` in a marketing-consent gate) the framework adapters expose `<ConsentGate>` with the same `requires` expression shape.
 
 ## See also

--- a/apps/web/content/docs/consent/react.md
+++ b/apps/web/content/docs/consent/react.md
@@ -1,6 +1,6 @@
 ---
 title: "@policystack/react/consent"
-description: "React adapter — useConsent, useCategory, ConsentGate"
+description: "React adapter — useConsent, useCategory, ConsentGate, GatedScript"
 product: consent
 ---
 
@@ -93,6 +93,66 @@ import { ConsentGate } from "@policystack/react/consent";
 
 The `requires` shape is a `ConsentExpr` from core: a category key, `{ and: [...] }`, `{ or: [...] }`, or `{ not: ... }`.
 
+### `<GatedScript>`
+
+Consent-gates one third-party script for as long as it is mounted. This is the React binding for [`gateScript`](/docs/consent/core#script-gating) and the intended way to use the [`@policystack/scripts`](/docs/consent/scripts) catalogue — it takes the store from `<PolicyStack>`, so you never handle it yourself.
+
+```tsx
+import { GatedScript } from "@policystack/react/consent";
+import { ga4 } from "@policystack/scripts/ga4";
+import { googleTagManager } from "@policystack/scripts/google-tag-manager";
+
+function Analytics() {
+	return (
+		<>
+			<GatedScript def={ga4({ measurementId: "G-XXXXXXX" })} />
+			<GatedScript def={googleTagManager({ containerId: "GTM-XXXXXX" })} />
+		</>
+	);
+}
+```
+
+The `<script>` tag is injected only once `def.requires` is satisfied. Until then, calls to the globals listed in `def.queue` are captured and replayed after the script loads — so `gtag("event", "signup")` on page boot still reaches GA4 if the visitor accepts a moment later, and never touches the network if they don't.
+
+Renders no DOM, and gates from an effect, so it is inert during SSR. Building the definition inline is fine: the gate follows `def.id`, so a new object each render does not re-gate or lose the queue.
+
+`onEvent` receives the `ScriptEvent` stream (`script:gated`, `script:queued`, `script:loaded`) for debugging or audit logging.
+
+Definitions are not limited to the prebuilt catalogue — `defineScript` from `@policystack/core/consent` takes any vendor snippet:
+
+```tsx
+import { defineScript } from "@policystack/core/consent";
+
+const intercom = defineScript({
+	id: "intercom",
+	requires: { and: ["analytics", "marketing"] },
+	src: "https://widget.intercom.io/widget/APP_ID",
+	queue: ["Intercom"],
+});
+
+<GatedScript def={intercom} />;
+```
+
+Core's script-gating semantics carry over unchanged, including [no auto-revoke](/docs/consent/core#no-auto-revoke): a loaded script is never unloaded. Unmounting `<GatedScript>` after consent disposes the gate but leaves the vendor script running, and revoking consent does not re-gate it.
+
+### `useConsentStore()`
+
+Returns the `ConsentStore` from the enclosing `<PolicyStack>`. The hooks above cover the reactive cases and should stay your default; reach for the store only to hand it to a core free function that takes one.
+
+```tsx
+import { gateScripts } from "@policystack/core/consent";
+import { useConsentStore } from "@policystack/react/consent";
+import { useEffect } from "react";
+
+function Tags() {
+	const store = useConsentStore();
+	useEffect(() => gateScripts(store, [ga4({ measurementId: "G-XXXXXXX" })]), [store]);
+	return null;
+}
+```
+
+The store is stable for the life of the provider and reading it does not subscribe, so this hook never re-renders on state changes. Use `useConsent` (or `store.subscribe`) when you need to react to state. Like the other consent API, it throws under a policy-only config.
+
 ## Next.js
 
 `<PolicyStack>` is already a client component (`"use client"`). Mount it in your root layout:
@@ -127,7 +187,7 @@ For SSR-resolved decisions, author a storage adapter (and jurisdiction resolver)
 
 ## Shared concepts
 
-Categories, GPC handling, jurisdiction resolvers, re-consent triggers, script gating (`gateScript`), and storage adapters all live in [`@policystack/core/consent`](/docs/consent/core) — the React adapter is a thin reactivity wrapper.
+Categories, GPC handling, jurisdiction resolvers, re-consent triggers, and storage adapters all live in [`@policystack/core/consent`](/docs/consent/core) — the React adapter is a thin reactivity wrapper. Script gating lives there too, but reach it through `<GatedScript>` above rather than calling `gateScript` yourself.
 
 ## See also
 

--- a/apps/web/content/docs/consent/scripts.md
+++ b/apps/web/content/docs/consent/scripts.md
@@ -26,6 +26,15 @@ const dispose = gateScript(store, pixel);
 
 The factory returns a plain `ScriptDefinition`. `gateScript` installs a stub at every queued global before consent, replays the calls into the real client once the script loads, and removes itself when you call the dispose function.
 
+In React, pass the same definition to [`<GatedScript>`](/docs/consent/react#gatedscript) instead — it pulls the store from `<PolicyStack>` and owns the dispose call:
+
+```tsx
+import { GatedScript } from "@policystack/react/consent";
+import { metaPixel } from "@policystack/scripts/meta-pixel";
+
+<GatedScript def={metaPixel({ pixelId: "1234567890" })} />;
+```
+
 You can also import everything from the package root if tree-shaking the entry barrel is fine for your build:
 
 ```ts

--- a/packages/react/src/consent.test.tsx
+++ b/packages/react/src/consent.test.tsx
@@ -3,7 +3,7 @@ import type { PolicyStackConfig } from "@policystack/core";
 import { act, cleanup, render, renderHook, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { ConsentGate, useCategory, useConsent } from "./consent";
+import { ConsentGate, useCategory, useConsent, useConsentStore } from "./consent";
 import { PolicyStack } from "./provider";
 
 // Cookie posture that derives to the same three categories the old hand-rolled
@@ -58,6 +58,47 @@ describe("consent hooks read the single PolicyStack context", () => {
 	it("throws when hooks are used outside <PolicyStack>", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
 		expect(() => renderHook(() => useConsent())).toThrow(/must be used inside <PolicyStack>/);
+	});
+});
+
+describe("useConsentStore", () => {
+	it("exposes the provider's store, including the parts the hooks withhold", () => {
+		const { result } = renderHook(() => useConsentStore(), { wrapper: Wrapper });
+		expect(result.current.subscribe).toBeTypeOf("function");
+		expect(result.current.getState).toBeTypeOf("function");
+		expect(result.current.has).toBeTypeOf("function");
+		expect(result.current.getState().route).toBe("cookie");
+	});
+
+	it("returns a stable reference across re-renders", () => {
+		const { result, rerender } = renderHook(() => useConsentStore(), { wrapper: Wrapper });
+		const first = result.current;
+		rerender();
+		expect(result.current).toBe(first);
+	});
+
+	it("is the same store the hooks read, so gateScript sees hook-driven changes", () => {
+		const { result } = renderHook(() => ({ store: useConsentStore(), consent: useConsent() }), {
+			wrapper: Wrapper,
+		});
+		const seen: boolean[] = [];
+		const unsubscribe = result.current.store.subscribe(() => {
+			seen.push(result.current.store.has("analytics"));
+		});
+
+		act(() => {
+			result.current.consent.toggle("analytics");
+			result.current.consent.save();
+		});
+		unsubscribe();
+
+		expect(result.current.store.has("analytics")).toBe(true);
+		expect(seen).toContain(true);
+	});
+
+	it("throws when used outside <PolicyStack>", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() => renderHook(() => useConsentStore())).toThrow(/must be used inside <PolicyStack>/);
 	});
 });
 

--- a/packages/react/src/consent.tsx
+++ b/packages/react/src/consent.tsx
@@ -10,26 +10,24 @@ import type {
 	RepromptReason,
 	Route,
 } from "@policystack/core/consent";
-import { useCallback, useContext, useSyncExternalStore, type ReactNode } from "react";
-import { PolicyStackContext } from "./context";
+import { useCallback, useSyncExternalStore, type ReactNode } from "react";
+import { useConsentStore } from "./use-consent-store";
 
 // The consent hooks read the single store off the shared PolicyStack context —
-// there is no separate consent provider. The store is `null` when the
-// `<PolicyStack>` config declared no cookie categories (a policy-only config),
-// in which case using a consent hook is a configuration error.
-function useStore(): ConsentStore {
-	const { store } = useContext(PolicyStackContext);
-	if (!store) {
-		throw new Error(
-			"useConsent / useCategory / ConsentGate must be used inside <PolicyStack>, and the config must declare cookie categories",
-		);
-	}
-	return store;
-}
+// there is no separate consent provider. `useConsentStore` owns that read (and
+// the "no store" guard for a policy-only config); it is re-exported below so
+// consumers can reach the store for core free functions like `gateScript`.
+export { useConsentStore } from "./use-consent-store";
+
+// The React binding for `gateScript` — the supported way to use
+// `@policystack/scripts` here, so consumers rarely need the raw store.
+export { GatedScript, type GatedScriptProps } from "./gated-script";
 
 // State slice flows through useSyncExternalStore; the actions are the store's
 // own closures, passed by reference (stable identity, no per-render wrappers).
-// `subscribe`/`getState`/`refreshJurisdiction` are intentionally not exposed.
+// `subscribe`/`getState`/`refreshJurisdiction` are intentionally kept off this
+// result — the hook already handles subscription. Callers that genuinely need
+// them (to drive a core free function) take the store via `useConsentStore`.
 export type UseConsentResult = {
 	route: Route;
 	categories: Category[];
@@ -53,7 +51,7 @@ export type UseConsentResult = {
 >;
 
 export function useConsent(): UseConsentResult {
-	const store = useStore();
+	const store = useConsentStore();
 	const state = useSyncExternalStore(
 		(cb) => store.subscribe(cb),
 		() => store.getState(),
@@ -95,7 +93,7 @@ function grantedSnapshot(store: ConsentStore, key: string): boolean {
 }
 
 export function useCategory(key: string): UseCategoryResult {
-	const store = useStore();
+	const store = useConsentStore();
 	const granted = useSyncExternalStore(
 		(cb) => store.subscribe(cb),
 		() => grantedSnapshot(store, key),
@@ -114,7 +112,7 @@ export type ConsentGateProps = {
 };
 
 export function ConsentGate({ requires, fallback = null, children }: ConsentGateProps) {
-	const store = useStore();
+	const store = useConsentStore();
 	const granted = useSyncExternalStore(
 		(cb) => store.subscribe(cb),
 		() => store.has(requires),

--- a/packages/react/src/gated-script.test.tsx
+++ b/packages/react/src/gated-script.test.tsx
@@ -1,0 +1,358 @@
+// @vitest-environment happy-dom
+import type { PolicyStackConfig } from "@policystack/core";
+import type { ScriptEvent } from "@policystack/core/consent";
+import { defineScript } from "@policystack/core/consent";
+import { act, cleanup, render, renderHook, screen } from "@testing-library/react";
+import { StrictMode, useState, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { useConsent } from "./consent";
+import { GatedScript } from "./gated-script";
+import { PolicyStack } from "./provider";
+
+const company = {
+	name: "Acme Inc.",
+	legalName: "Acme Corporation",
+	address: "123 Main St, Springfield, USA",
+	contact: { email: "privacy@acme.com" },
+};
+
+const policyOnly: PolicyStackConfig = {
+	company,
+	effectiveDate: "2026-01-01",
+	jurisdictions: ["eea"],
+	data: { collected: {}, context: {} },
+};
+
+const withCookies: PolicyStackConfig = {
+	...policyOnly,
+	cookieVersion: "v1",
+	cookies: {
+		used: { essential: true, analytics: true, marketing: true },
+		context: {
+			essential: { lawfulBasis: "legal_obligation" },
+			analytics: { lawfulBasis: "consent" },
+			marketing: { lawfulBasis: "consent" },
+		},
+	},
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+	return <PolicyStack config={withCookies}>{children}</PolicyStack>;
+}
+
+// A src-less definition: `gateScript` skips script injection entirely, so the
+// whole gate → queue → replay path runs synchronously with no network in play.
+function analyticsDef(id = "test-analytics") {
+	return defineScript({
+		id,
+		requires: "analytics",
+		queue: ["testTag"],
+		init: () => {
+			const win = window as unknown as { testTag: (...args: unknown[]) => void; calls: unknown[] };
+			win.calls = win.calls ?? [];
+			win.testTag = (...args: unknown[]) => {
+				win.calls.push(args);
+			};
+		},
+	});
+}
+
+type TestWindow = Record<string, unknown> & { calls?: unknown[] };
+
+function win(): TestWindow {
+	return window as unknown as TestWindow;
+}
+
+// Accept analytics through the store the same way a banner would: stage the
+// toggle, then save (only save() promotes the draft and moves the gate).
+function grantAnalytics(result: { current: ReturnType<typeof useConsent> }) {
+	act(() => {
+		result.current.toggle("analytics");
+		result.current.save();
+	});
+}
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+	for (const k of ["testTag", "mktTag", "calls"]) delete win()[k];
+});
+
+describe("GatedScript — store access", () => {
+	it("gates through the provider's store without the consumer touching it", () => {
+		const events: ScriptEvent[] = [];
+		render(<GatedScript def={analyticsDef()} onEvent={(e) => events.push(e)} />, {
+			wrapper: Wrapper,
+		});
+		expect(events).toEqual([{ type: "script:gated", id: "test-analytics" }]);
+	});
+
+	it("renders no DOM", () => {
+		const { container } = render(<GatedScript def={analyticsDef()} />, { wrapper: Wrapper });
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("throws the provider guard outside <PolicyStack>", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() => render(<GatedScript def={analyticsDef()} />)).toThrow(
+			/must be used inside <PolicyStack>/,
+		);
+	});
+
+	it("throws under a policy-only config (no cookie categories)", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() =>
+			render(
+				<PolicyStack config={policyOnly}>
+					<GatedScript def={analyticsDef()} />
+				</PolicyStack>,
+			),
+		).toThrow(/must be used inside <PolicyStack>/);
+	});
+});
+
+describe("GatedScript — gating lifecycle", () => {
+	it("holds the script until the required category is granted, then loads it", () => {
+		const events: ScriptEvent[] = [];
+		function Harness() {
+			return <GatedScript def={analyticsDef()} onEvent={(e) => events.push(e)} />;
+		}
+		const { result } = renderHook(() => useConsent(), {
+			wrapper: ({ children }) => (
+				<Wrapper>
+					<Harness />
+					{children}
+				</Wrapper>
+			),
+		});
+
+		expect(events.map((e) => e.type)).toEqual(["script:gated"]);
+		expect(win().testTag).toBeTypeOf("function");
+		expect(win().calls).toBeUndefined();
+
+		grantAnalytics(result);
+
+		expect(events.map((e) => e.type)).toEqual(["script:gated", "script:loaded"]);
+		expect(win().calls).toEqual([]);
+	});
+
+	it("queues pre-consent calls and replays them after load", () => {
+		const events: ScriptEvent[] = [];
+		function Harness() {
+			return <GatedScript def={analyticsDef()} onEvent={(e) => events.push(e)} />;
+		}
+		const { result } = renderHook(() => useConsent(), {
+			wrapper: ({ children }) => (
+				<Wrapper>
+					<Harness />
+					{children}
+				</Wrapper>
+			),
+		});
+
+		// The call a real app would make on boot, before any decision exists.
+		(win().testTag as (...args: unknown[]) => void)("event", "signup");
+		expect(events.at(-1)).toMatchObject({ type: "script:queued", path: "testTag" });
+
+		grantAnalytics(result);
+
+		expect(win().calls).toEqual([["event", "signup"]]);
+	});
+
+	it("does not load when a different category is granted", () => {
+		const events: ScriptEvent[] = [];
+		function Harness() {
+			return <GatedScript def={analyticsDef()} onEvent={(e) => events.push(e)} />;
+		}
+		const { result } = renderHook(() => useConsent(), {
+			wrapper: ({ children }) => (
+				<Wrapper>
+					<Harness />
+					{children}
+				</Wrapper>
+			),
+		});
+
+		act(() => {
+			result.current.toggle("marketing");
+			result.current.save();
+		});
+
+		expect(events.map((e) => e.type)).toEqual(["script:gated"]);
+	});
+
+	it("loads immediately when consent is already granted at mount", () => {
+		const events: ScriptEvent[] = [];
+		// Both halves must live under one provider: each <PolicyStack> derives
+		// its own store, so granting in a second tree would not be seen here.
+		function Harness() {
+			const { toggle, save } = useConsent();
+			const [mounted, setMounted] = useState(false);
+			return (
+				<>
+					<button
+						type="button"
+						onClick={() => {
+							toggle("analytics");
+							save();
+						}}
+					>
+						grant
+					</button>
+					<button type="button" onClick={() => setMounted(true)}>
+						mount
+					</button>
+					{mounted ? <GatedScript def={analyticsDef()} onEvent={(e) => events.push(e)} /> : null}
+				</>
+			);
+		}
+		render(<Harness />, { wrapper: Wrapper });
+
+		act(() => screen.getByText("grant").click());
+		expect(events).toEqual([]);
+
+		act(() => screen.getByText("mount").click());
+		expect(events.map((e) => e.type)).toEqual(["script:loaded"]);
+	});
+
+	// `<script>` injection itself is core's concern and is covered against a
+	// fake document in `core/src/consent/scripts.test.ts`. Asserting it here
+	// would mean a real network fetch under happy-dom, so these tests use
+	// src-less definitions and stay on the binding's own behaviour.
+});
+
+describe("GatedScript — unmount and re-render", () => {
+	it("disposes the gate on unmount, restoring the queue stubs", () => {
+		const { unmount } = render(<GatedScript def={analyticsDef()} />, { wrapper: Wrapper });
+		expect(win().testTag).toBeTypeOf("function");
+
+		unmount();
+
+		expect(win().testTag).toBeUndefined();
+	});
+
+	it("keeps one gate across re-renders with an inline def (no lost queue)", () => {
+		const events: ScriptEvent[] = [];
+		// Subscribes to consent so every store change re-renders it, and each
+		// render builds a fresh ScriptDefinition object — exactly what an inline
+		// `def={ga4({ ... })}` does. The gate must follow `def.id`, not identity.
+		function Harness() {
+			const { route } = useConsent();
+			return (
+				<>
+					<span>{route}</span>
+					<GatedScript def={analyticsDef()} onEvent={(e) => events.push(e)} />
+				</>
+			);
+		}
+		const { result } = renderHook(() => useConsent(), {
+			wrapper: ({ children }) => (
+				<Wrapper>
+					<Harness />
+					{children}
+				</Wrapper>
+			),
+		});
+
+		(win().testTag as (...args: unknown[]) => void)("event", "signup");
+
+		// A re-gate here would restore the stubs, drop the queued call, and
+		// emit a second "script:gated".
+		act(() => {
+			result.current.setRoute("preferences");
+		});
+		expect(screen.getByText("preferences")).toBeTruthy();
+		act(() => {
+			result.current.setRoute("cookie");
+		});
+		expect(screen.getByText("cookie")).toBeTruthy();
+
+		expect(events.filter((e) => e.type === "script:gated")).toHaveLength(1);
+
+		grantAnalytics(result);
+
+		expect(win().calls).toEqual([["event", "signup"]]);
+	});
+
+	it("re-gates when def.id changes", () => {
+		const events: ScriptEvent[] = [];
+		function Harness({ id }: { id: string }) {
+			return <GatedScript def={analyticsDef(id)} onEvent={(e) => events.push(e)} />;
+		}
+		const { rerender } = render(<Harness id="first" />, { wrapper: Wrapper });
+		rerender(<Harness id="second" />);
+
+		expect(events).toEqual([
+			{ type: "script:gated", id: "first" },
+			{ type: "script:gated", id: "second" },
+		]);
+	});
+
+	it("survives StrictMode's double mount without a duplicate-id warning", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		render(
+			<StrictMode>
+				<PolicyStack config={withCookies}>
+					<GatedScript def={analyticsDef()} />
+				</PolicyStack>
+			</StrictMode>,
+		);
+		expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("already gated"));
+	});
+
+	it("uses the latest onEvent without re-gating", () => {
+		const first: ScriptEvent[] = [];
+		const second: ScriptEvent[] = [];
+		function Harness({ sink }: { sink: ScriptEvent[] }) {
+			return <GatedScript def={analyticsDef()} onEvent={(e) => sink.push(e)} />;
+		}
+		const { rerender } = render(<Harness sink={first} />, { wrapper: Wrapper });
+		rerender(<Harness sink={second} />);
+
+		(win().testTag as (...args: unknown[]) => void)("late");
+
+		expect(first).toEqual([{ type: "script:gated", id: "test-analytics" }]);
+		expect(second).toHaveLength(1);
+		expect(second[0]).toMatchObject({ type: "script:queued", path: "testTag" });
+	});
+});
+
+describe("GatedScript — multiple scripts", () => {
+	it("gates several definitions independently", () => {
+		const events: ScriptEvent[] = [];
+		const marketingDef = defineScript({
+			id: "test-marketing",
+			requires: "marketing",
+			queue: ["mktTag"],
+		});
+		const { result } = renderHook(() => useConsent(), {
+			wrapper: ({ children }) => (
+				<Wrapper>
+					<GatedScript def={analyticsDef()} onEvent={(e) => events.push(e)} />
+					<GatedScript def={marketingDef} onEvent={(e) => events.push(e)} />
+					{children}
+				</Wrapper>
+			),
+		});
+
+		grantAnalytics(result);
+
+		expect(events).toContainEqual({ type: "script:loaded", id: "test-analytics" });
+		expect(events).not.toContainEqual({ type: "script:loaded", id: "test-marketing" });
+	});
+});
+
+describe("GatedScript — rendered alongside other consent API", () => {
+	it("does not interfere with ConsentGate in the same tree", () => {
+		function Harness() {
+			return (
+				<>
+					<GatedScript def={analyticsDef()} />
+					<span>rendered</span>
+				</>
+			);
+		}
+		render(<Harness />, { wrapper: Wrapper });
+		expect(screen.getByText("rendered")).toBeTruthy();
+	});
+});

--- a/packages/react/src/gated-script.tsx
+++ b/packages/react/src/gated-script.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { ScriptDefinition, ScriptEvent } from "@policystack/core/consent";
+import { gateScript } from "@policystack/core/consent";
+import { useEffect, useRef } from "react";
+import { useConsentStore } from "./use-consent-store";
+
+export type GatedScriptProps = {
+	def: ScriptDefinition;
+	onEvent?: (event: ScriptEvent) => void;
+};
+
+/**
+ * Consent-gates one third-party script for as long as it is mounted.
+ *
+ * This is the React binding for `gateScript` (`@policystack/core/consent`) and
+ * the intended way to use the `@policystack/scripts` catalogue: it takes the
+ * store from `<PolicyStack>` so callers never have to reach for it. The
+ * `<script>` tag is injected only once `def.requires` is satisfied, calls to the
+ * globals listed in `def.queue` are captured until then and replayed after,
+ * and unmounting disposes the gate.
+ *
+ * Renders no DOM. The gate lives in an effect, so nothing runs during SSR.
+ *
+ * ```tsx
+ * import { GatedScript } from "@policystack/react/consent";
+ * import { ga4 } from "@policystack/scripts/ga4";
+ *
+ * <GatedScript def={ga4({ measurementId: "G-XXXXXXX" })} />;
+ * ```
+ *
+ * Note the core semantics carry over unchanged: a loaded script is never
+ * unloaded. Unmounting after consent disposes the gate but leaves the vendor
+ * script running, and revoking consent does not re-gate it.
+ */
+export function GatedScript({ def, onEvent }: GatedScriptProps) {
+	const store = useConsentStore();
+
+	// `def` is nearly always built inline (`def={ga4({ ... })}`), making it a
+	// fresh object every render. Re-gating on that identity would dispose the
+	// gate mid-flight and drop every call the queue stubs had captured, so the
+	// gate follows `def.id` instead — the same identity `gateScript` keys its
+	// own duplicate-registration guard on — and reads the current `def` and
+	// `onEvent` through refs.
+	const defRef = useRef(def);
+	const onEventRef = useRef(onEvent);
+
+	// Declared before the gating effect so it runs first on mount, and so a
+	// re-gate sees the new values (React runs every cleanup before any effect).
+	useEffect(() => {
+		defRef.current = def;
+		onEventRef.current = onEvent;
+	});
+
+	useEffect(() => {
+		return gateScript(store, defRef.current, {
+			onEvent: (event) => onEventRef.current?.(event),
+		});
+	}, [store, def.id]);
+
+	return null;
+}

--- a/packages/react/src/use-consent-store.ts
+++ b/packages/react/src/use-consent-store.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import type { ConsentStore } from "@policystack/core/consent";
+import { useContext } from "react";
+import { PolicyStackContext } from "./context";
+
+/**
+ * The consent store from the enclosing `<PolicyStack>`.
+ *
+ * `useConsent` / `useCategory` / `<ConsentGate>` cover the reactive cases and
+ * should stay the default. Reach for the store itself only to hand it to a core
+ * free function that takes one, such as `gateScript` from
+ * `@policystack/core/consent`. For script gating specifically prefer
+ * `<GatedScript>`, which owns the mount/unmount lifecycle for you.
+ *
+ * The store is deliberately not reactive: it is the same object for the life of
+ * the provider, so reading it never re-renders the consumer. Subscribe through
+ * the hooks above (or `store.subscribe`) to react to state.
+ *
+ * Throws when there is no store — either the call site is outside
+ * `<PolicyStack>`, or the config is policy-only (no cookie categories) and so
+ * declares no consent to manage. Both are configuration errors rather than
+ * runtime states, which is why this never returns `null`.
+ */
+export function useConsentStore(): ConsentStore {
+	const { store } = useContext(PolicyStackContext);
+	if (!store) {
+		throw new Error(
+			"PolicyStack consent (useConsent / useCategory / useConsentStore / ConsentGate / GatedScript) must be used inside <PolicyStack>, and the config must declare cookie categories",
+		);
+	}
+	return store;
+}


### PR DESCRIPTION
## Summary

`gateScript(store, def)` needs a `ConsentStore`, but `<PolicyStack>` built its store privately inside `useState` and never exposed it: no `store` prop, no store hook, and `useConsent()` deliberately withholds `subscribe`/`getState`. The whole `@policystack/scripts` catalogue was therefore unusable from React, and neither workaround was acceptable — a second module-level store never sees same-tab grants (the localStorage adapter only listens for `storage` events, which don't fire in the writing tab), and hand-rolling injection under `<ConsentGate>` throws away `ScriptDefinition`'s `queue`/`attrs`/`init` handling.

The provider's per-request isolation is the right design, so this adds a first-class bridge rather than encouraging module-level stores.

Refs #159. Deliberately not `Closes` — see Scope below.

## Changes

- **`<GatedScript def={...} />`** (new, `@policystack/react/consent`) — the React binding for `gateScript`. Takes the store from `<PolicyStack>`, gates the script for as long as it is mounted, disposes on unmount. Renders no DOM and gates from an effect, so it is inert during SSR. Optional `onEvent` surfaces the `ScriptEvent` stream.
- **`useConsentStore()`** (new, same entry) — returns the `ConsentStore` for other core free functions such as `gateScripts`. Stable for the provider's lifetime and non-reactive.
- **`use-consent-store.ts`** (new) — the context read plus the policy-only guard, previously private to `consent.tsx`. The existing hooks now share it. Its error message names the full consent API instead of three of its members.
- **Tests** — 16 cases in `gated-script.test.tsx`, 4 for the hook in `consent.test.tsx`.
- **Docs** — `<GatedScript>` and `useConsentStore()` sections in `docs/consent/react.md`, cross-links from `core.md` and `scripts.md`.
- **Changeset** — minor for `@policystack/react`.

## Reviewer notes

**The effect's dependency is the load-bearing detail.** `def` is nearly always built inline (`def={ga4({ ... })}`), so it is a fresh object every render. Keying the effect on object identity would dispose and re-gate on every render, restoring the queue stubs and discarding every pre-consent call captured so far. The gate follows `def.id` instead — the same identity `gateScript` uses for its own duplicate-registration guard — and reads the current `def`/`onEvent` through refs synced by an earlier-declared effect, so nothing is written to a ref during render.

I verified those tests actually catch it: temporarily switching the deps back to `[store, def]` fails "keeps one gate across re-renders" and "uses the latest onEvent without re-gating", and both pass again on restore.

**Two deliberate test choices:**

- Definitions are built with core's `defineScript` rather than importing `@policystack/scripts`, avoiding a new workspace dependency (and a new knip surface).
- No `<script>`-injection assertion here. That is core's `injectScript`, already covered against a fake document in `core/src/consent/scripts.test.ts`, and under happy-dom it either makes a real network request or logs a DOMException with file loading disabled. The tests use src-less definitions and stay on the binding's own behaviour.

## Scope

React only, matching the two fixes the issue proposes. Not addressed here:

- **Vue and Solid** have the identical gap (`packages/vue/src/provider.ts:32`, `packages/solid/src/index.ts:56`) and still need this treatment.
- **Svelte already has the escape hatch** — both `setPolicyStackConsentContext` and `createConsentReadable` accept `{ store }` — so it needs only the ergonomic wrapper, not the store accessor. The issue's closing line is slightly off on that point.

## Verification

`vp check` clean, `vp run -r check-types` clean, `vp run -r test` green at 979 tests across 11 workspaces.

Unrelated: `vp dlx knip` fails with two unused exported types at `packages/vite/src/consent/reporter.ts:109`. I confirmed by stashing that this reproduces on `main` without these changes, so it is pre-existing and left for a separate fix.
