### PR TITLE
feat(core): expose the bare consent cookie value on cookieAdapter

### DIFF
--- a/.changeset/cookie-adapter-serialize.md
+++ b/.changeset/cookie-adapter-serialize.md
@@ -1,0 +1,25 @@
+---
+"@policystack/core": minor
+---
+
+`cookieAdapter()` now exposes the bare cookie value, so nothing has to re-implement its wire format (#167). `encode`/`decode` already existed as private closures; the adapter just never returned them, leaving `getSetCookieHeader()` (a whole `Set-Cookie` header) as the closest thing and forcing consumers to hand-roll base64url or string-parse the value back out.
+
+Three new members on `CookieAdapter`:
+
+- `serialize(record)` — the encoded cookie value on its own, exactly what `write()` puts in the cookie.
+- `deserialize(value)` — the inverse, for a bare value. `parse()` still handles a full cookie header.
+- `name` — the resolved cookie name, so callers using the default do not hardcode `oc_consent`.
+
+The motivating case is seeding consent in browser tests, where `browserContext.addCookies()` needs a name and a value:
+
+```ts
+const adapter = cookieAdapter();
+const store = createConsentStore(policystack);
+store.acceptAll();
+
+await context.addCookies([
+	{ name: adapter.name, value: adapter.serialize(store.getConsentRecord()), url: baseURL },
+]);
+```
+
+A copied encoder is worth replacing here even though it matches today: `deserialize` swallows errors and returns `null`, so a value that drifts from the adapter's format does not throw — consent silently reads as undecided and the banner reappears.

--- a/packages/core/src/consent/storage/cookie.test.ts
+++ b/packages/core/src/consent/storage/cookie.test.ts
@@ -93,7 +93,7 @@ describe("cookieAdapter (browser)", () => {
 describe("cookieAdapter (Edge / SSR)", () => {
 	it("reads from a request-like object's cookie header", () => {
 		const writer = cookieAdapter();
-		const value = writer.getSetCookieHeader(sample).split(";")[0]?.split("=")[1] ?? "";
+		const value = writer.serialize(sample);
 		const request = { headers: new Headers({ cookie: `oc_consent=${value}` }) };
 		const adapter = cookieAdapter({ request });
 		expect(adapter.read()).toEqual(sample);
@@ -127,5 +127,43 @@ describe("cookieAdapter (Edge / SSR)", () => {
 		adapter.write(sample);
 		const header = adapter.getSetCookieHeader(sample);
 		expect(adapter.parse(header)).toEqual(sample);
+	});
+});
+
+describe("cookieAdapter (bare value)", () => {
+	beforeEach(() => {
+		clearCookies();
+	});
+
+	it("serialize()/deserialize() round-trip a record", () => {
+		const adapter = cookieAdapter();
+		expect(adapter.deserialize(adapter.serialize(sample))).toEqual(sample);
+	});
+
+	it("serialize() emits base64url with no padding", () => {
+		const value = cookieAdapter().serialize(sample);
+		expect(value).not.toMatch(/[+/=]/);
+	});
+
+	it("serialize() matches the value getSetCookieHeader() writes", () => {
+		const adapter = cookieAdapter();
+		const header = adapter.getSetCookieHeader(sample);
+		expect(header).toContain(`oc_consent=${adapter.serialize(sample)};`);
+	});
+
+	// The E2E seeding case from #167: a value set by hand must be readable.
+	it("read() decodes a cookie seeded from serialize()", () => {
+		const adapter = cookieAdapter({ secure: false });
+		document.cookie = `${adapter.name}=${adapter.serialize(sample)}; Path=/`;
+		expect(adapter.read()).toEqual(sample);
+	});
+
+	it("deserialize() returns null on a corrupt value", () => {
+		expect(cookieAdapter().deserialize("not-base64-json")).toBeNull();
+	});
+
+	it("name exposes the resolved cookie name", () => {
+		expect(cookieAdapter().name).toBe("oc_consent");
+		expect(cookieAdapter({ name: "consent" }).name).toBe("consent");
 	});
 });

--- a/packages/core/src/consent/storage/cookie.ts
+++ b/packages/core/src/consent/storage/cookie.ts
@@ -18,9 +18,12 @@ export type CookieAdapterOptions = {
 };
 
 export type CookieAdapter = {
+	name: string;
 	read(): ConsentRecord | null;
 	write(record: ConsentRecord): void;
 	clear(): void;
+	serialize(record: ConsentRecord): string;
+	deserialize(value: string): ConsentRecord | null;
 	getSetCookieHeader(record: ConsentRecord | null): string;
 	parse(header: string | null | undefined): ConsentRecord | null;
 };
@@ -100,6 +103,7 @@ export function cookieAdapter(options: CookieAdapterOptions = {}): CookieAdapter
 	}
 
 	return {
+		name,
 		read() {
 			return decode(parseCookieHeader(readCookieHeader()));
 		},
@@ -113,6 +117,8 @@ export function cookieAdapter(options: CookieAdapterOptions = {}): CookieAdapter
 			setBrowserCookie(header);
 			if (onSetCookie) onSetCookie(header);
 		},
+		serialize: encode,
+		deserialize: decode,
 		getSetCookieHeader,
 		parse(header) {
 			return decode(parseCookieHeader(header));


### PR DESCRIPTION
Closes #167.

## Problem

`cookieAdapter()` kept `encode`/`decode` as private closures and returned only `read`/`write`/`clear`/`getSetCookieHeader`/`parse`. There was no way to get the bare encoded cookie value, so anything constructing the cookie outside the adapter — E2E test seeding, server-side cookie writing, custom storage on the same format — had to re-implement base64url by hand, or string-parse the value back out of the full `Set-Cookie` header.

That copy is quiet when it drifts: `decode` swallows errors and returns `null`, so a value the adapter can no longer read presents as "no decision recorded" rather than an exception — the banner reappears and browser specs time out on an intercepted click.

## Change

Three additions to `CookieAdapter`. The two functions already existed; they were just never returned.

- `serialize(record)` — the encoded cookie value on its own, byte-identical to what `write()` stores.
- `deserialize(value)` — the inverse, for a bare value. `parse()` continues to take a full cookie header.
- `name` — the resolved cookie name, so callers on the default do not hardcode `oc_consent`. `browserContext.addCookies()` needs a name as well as a value, and it was private too.

```ts
const adapter = cookieAdapter();
const store = createConsentStore(policystack);
store.acceptAll();

await context.addCookies([
  { name: adapter.name, value: adapter.serialize(store.getConsentRecord()), url: baseURL },
]);
```

Additive only, no behaviour change to the existing members. Marked `minor`.

## Tests

Six new cases covering the round-trip, base64url shape, agreement with `getSetCookieHeader()`, a hand-seeded cookie being readable by `read()` (the issue's actual scenario), `null` on corrupt input, and name resolution. The existing SSR test dropped its `.split(";")[0]?.split("=")[1]` in favour of `serialize()` — it was doing exactly what the issue describes.

`vp run -r build`, `vp check`, `vp run -r check-types` and `vp run -r test` (500 tests in core, all workspaces green) pass locally.

Note: `vp run knip` exits 1, but identically before and after this change — pre-existing on `main`, untouched here.

## Not included

The issue also suggests a documented "pre-accepted consent in E2E tests" recipe for the docs site. Left for a follow-up.