### PR TITLE
feat(core): derive consent category metadata from cookie context

### DIFF
--- a/.changeset/quiet-cookies-describe.md
+++ b/.changeset/quiet-cookies-describe.md
@@ -3,3 +3,5 @@
 ---
 
 Cookie context entries now accept `label`, `description`, and `respectGPC`, and derived consent categories use that metadata directly. Missing copy falls back to the built-in cookie-type dictionary for the policy locale, so preference panels can render `useConsent().categories` without maintaining a separate copy table (#160).
+
+Note that this changes the default copy for categories that do not set `label`/`description`: a derived category's `label` is now the dictionary label (`"Analytics Cookies"`) rather than the capitalised key (`"Analytics"`), and `description` is now the dictionary description (or `""` for a custom category key) rather than `undefined`. Set `label`/`description` in `cookies.context` to keep your existing wording.

--- a/.changeset/quiet-cookies-describe.md
+++ b/.changeset/quiet-cookies-describe.md
@@ -1,0 +1,5 @@
+---
+"@policystack/core": minor
+---
+
+Cookie context entries now accept `label`, `description`, and `respectGPC`, and derived consent categories use that metadata directly. Missing copy falls back to the built-in cookie-type dictionary for the policy locale, so preference panels can render `useConsent().categories` without maintaining a separate copy table (#160).

--- a/apps/web/content/docs/consent/index.md
+++ b/apps/web/content/docs/consent/index.md
@@ -67,11 +67,23 @@ function CookieBanner() {
 	);
 }
 
+function CookiePreferences() {
+	const { categories } = useConsent();
+	return categories.map((category) => (
+		<label key={category.key}>
+			{category.label}
+			{category.description && <span>{category.description}</span>}
+		</label>
+	));
+}
+
 // Gate third-party code on consent
 <ConsentGate requires="analytics">
 	<GoogleAnalytics />
 </ConsentGate>;
 ```
+
+Category `label`, `description`, and `respectGPC` values come from `cookies.context`. Missing copy uses the built-in cookie-type dictionary for the policy locale, so preference UIs do not need their own category-copy table.
 
 ## Features
 

--- a/apps/web/content/docs/policy/configuration.md
+++ b/apps/web/content/docs/policy/configuration.md
@@ -86,7 +86,7 @@ company: {
 
 Setting `phone` is recommended when `jurisdictions` includes `us-ca`. CCPA §1798.130(a)(1) requires businesses to provide two or more designated methods for consumers to submit privacy requests, and (unless you operate exclusively online) one of those methods must be a toll-free number. When `phone` is set, the rendered CCPA supplement appends a "Submitting requests" block listing both methods. Omitting it under `us-ca` emits a validation warning.
 
-The `data` block has two sibling maps: `collected` (category → field labels) and `context` (category → metadata about that category). `defineConfig`'s generic enforces that every key in `collected` has a matching `context` entry with `purpose`, `lawfulBasis`, `retention`, and `provision`. The `cookies` block mirrors the same shape: `cookies.used` lists the categories you enable (with `essential: true` always required), and `cookies.context` declares the Article 6 basis for each enabled category.
+The `data` block has two sibling maps: `collected` (category → field labels) and `context` (category → metadata about that category). `defineConfig`'s generic enforces that every key in `collected` has a matching `context` entry with `purpose`, `lawfulBasis`, `retention`, and `provision`. The `cookies` block mirrors the same shape: `cookies.used` lists the categories you enable (with `essential: true` always required), and `cookies.context` declares the Article 6 basis for each enabled category. Cookie context entries can also provide `label`, `description`, and `respectGPC`; these flow into the consent categories exposed by the framework bindings, with missing copy resolved from the built-in dictionary for the configured locale.
 
 ### Data Protection Officer
 

--- a/apps/web/content/docs/policy/policies/cookies.md
+++ b/apps/web/content/docs/policy/policies/cookies.md
@@ -23,7 +23,12 @@ cookies: {
   },
   context: {
     essential: { lawfulBasis: LegalBases.LegalObligation },
-    analytics: { lawfulBasis: LegalBases.Consent },
+    analytics: {
+      lawfulBasis: LegalBases.Consent,
+      label: "Analytics",
+      description: "Helps us understand how the site is used.",
+      respectGPC: true,
+    },
     functional: { lawfulBasis: LegalBases.Consent },
     marketing: { lawfulBasis: LegalBases.Consent },
   },
@@ -40,6 +45,8 @@ thirdParties: [
 The consent mechanism (banner / preference panel / withdrawal) is **derived** from this cookie posture — any consent-gated category yields all three — so it is no longer authored. It surfaces in the cookie policy's consent section automatically.
 
 `cookies.used` always requires `essential: true`; other keys are `boolean` and act as additional categories. Every key in `cookies.used` must have a matching Article 6 basis in `cookies.context[key].lawfulBasis` — `defineConfig` enforces this at type-check time, and the rendered "Cookies and Tracking" section appends the basis to each enabled category.
+
+Each context entry may also set `label`, `description`, and `respectGPC` for the derived consent category. Missing copy falls back field-by-field to the built-in cookie-type dictionary for `locale` (English by default), so a preference panel can render `useConsent().categories` directly. Set `respectGPC: false` only for a category that should remain available when a GPC signal is active.
 
 `defineConfig` also computes a `cookieVersion` — an 8-char hash of the cookie slice of your config — which is printed in the intro paragraph next to the effective date. See [Policy versions](/docs/policy/configuration#policy-versions).
 

--- a/apps/web/src/components/CookiePreferences.tsx
+++ b/apps/web/src/components/CookiePreferences.tsx
@@ -11,18 +11,9 @@ const primaryButton =
 const secondaryButton =
 	"inline-flex items-center justify-center border-2 border-black bg-canvas px-4 py-2 text-xs tracking-wide text-ink uppercase hover:bg-ink hover:text-canvas focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black";
 
-const DESCRIPTIONS: Record<string, string> = {
-	essential:
-		"Required for the site to work — security, session, and your consent choice itself. Always on.",
-	analytics:
-		"Lets us measure which pages are used so we can improve the site. Off until you allow it.",
-	marketing: "Used to personalise and measure marketing. Off until you allow it.",
-};
-
 function CategoryRow({ category }: { category: Category }) {
 	const { granted, toggle } = useCategory(category.key);
 	const inputId = `consent-${category.key}`;
-	const description = category.description ?? DESCRIPTIONS[category.key] ?? "";
 
 	return (
 		<li className="flex items-start justify-between gap-4 border-t-2 border-black py-4 first:border-t-0">
@@ -30,7 +21,9 @@ function CategoryRow({ category }: { category: Category }) {
 				<label htmlFor={inputId} className="text-sm tracking-wide text-ink uppercase">
 					{category.label}
 				</label>
-				{description && <p className="mt-1 text-xs text-pretty text-mute">{description}</p>}
+				{category.description && (
+					<p className="mt-1 text-xs text-pretty text-mute">{category.description}</p>
+				)}
 			</div>
 			<span className="relative inline-flex h-6 w-12 shrink-0 border-2 border-black">
 				<input

--- a/apps/web/src/policystack.ts
+++ b/apps/web/src/policystack.ts
@@ -47,9 +47,23 @@ export default defineConfig({
 			marketing: false,
 		},
 		context: {
-			essential: { lawfulBasis: LegalBases.LegalObligation },
-			analytics: { lawfulBasis: LegalBases.Consent },
-			marketing: { lawfulBasis: LegalBases.Consent },
+			essential: {
+				lawfulBasis: LegalBases.LegalObligation,
+				label: "Essential",
+				description:
+					"Required for the site to work — security, session, and your consent choice itself. Always on.",
+			},
+			analytics: {
+				lawfulBasis: LegalBases.Consent,
+				label: "Analytics",
+				description:
+					"Lets us measure which pages are used so we can improve the site. Off until you allow it.",
+			},
+			marketing: {
+				lawfulBasis: LegalBases.Consent,
+				label: "Marketing",
+				description: "Used to personalise and measure marketing. Off until you allow it.",
+			},
 		},
 	},
 	thirdParties: [],

--- a/packages/core/src/consent/derive.test.ts
+++ b/packages/core/src/consent/derive.test.ts
@@ -36,9 +36,94 @@ test("locks the essential category", () => {
 	expect(analytics?.locked).toBe(false);
 });
 
-test("capitalizes the category label", () => {
+test("falls back to the English cookie-type dictionary", () => {
 	const config = deriveConsentConfig(policy);
-	expect(config.categories.find((c) => c.key === "analytics")?.label).toBe("Analytics");
+	const analytics = config.categories.find((c) => c.key === "analytics");
+	expect(analytics?.label).toBe("Analytics Cookies");
+	expect(analytics?.description).toBe(
+		"Help us understand how visitors interact with our services so we can improve them.",
+	);
+});
+
+test("uses the policy locale for dictionary-backed category copy", () => {
+	const config = deriveConsentConfig({ ...policy, locale: "fr" });
+	const analytics = config.categories.find((c) => c.key === "analytics");
+	expect(analytics?.label).toBe("Cookies d'analyse");
+	expect(analytics?.description).toBe(
+		"Nous aident à comprendre comment les visiteurs interagissent avec nos services afin de les améliorer.",
+	);
+});
+
+test("falls back independently around explicit category copy", () => {
+	const config = deriveConsentConfig({
+		...policy,
+		cookies: {
+			used: { essential: true, analytics: true },
+			context: {
+				essential: { lawfulBasis: "legal_obligation", label: "Required" },
+				analytics: {
+					lawfulBasis: "consent",
+					description: "Our measurement cookies.",
+				},
+			},
+		},
+	});
+	const essential = config.categories.find((c) => c.key === "essential");
+	const analytics = config.categories.find((c) => c.key === "analytics");
+	expect(essential?.label).toBe("Required");
+	expect(essential?.description).toBe(
+		"Required for the basic functioning of our services. These cannot be disabled.",
+	);
+	expect(analytics?.label).toBe("Analytics Cookies");
+	expect(analytics?.description).toBe("Our measurement cookies.");
+});
+
+test("preserves explicit empty category copy", () => {
+	const config = deriveConsentConfig({
+		...policy,
+		cookies: {
+			used: { essential: true },
+			context: {
+				essential: { lawfulBasis: "legal_obligation", label: "", description: "" },
+			},
+		},
+	});
+	expect(config.categories[0]?.label).toBe("");
+	expect(config.categories[0]?.description).toBe("");
+});
+
+test("uses the locale fallback for custom category keys", () => {
+	const config = deriveConsentConfig({
+		...policy,
+		locale: "fr",
+		cookies: {
+			used: { essential: true, personalization: true },
+			context: {
+				essential: { lawfulBasis: "legal_obligation" },
+				personalization: { lawfulBasis: "consent" },
+			},
+		},
+	});
+	const personalization = config.categories.find((c) => c.key === "personalization");
+	expect(personalization?.label).toBe("Cookies personalization");
+	expect(personalization?.description).toBe("");
+});
+
+test("carries both respectGPC values onto derived categories", () => {
+	const config = deriveConsentConfig({
+		...policy,
+		cookies: {
+			used: { essential: true, analytics: true, marketing: true },
+			context: {
+				essential: { lawfulBasis: "legal_obligation" },
+				analytics: { lawfulBasis: "consent", respectGPC: false },
+				marketing: { lawfulBasis: "consent", respectGPC: true },
+			},
+		},
+	});
+	expect(config.categories.find((c) => c.key === "essential")?.respectGPC).toBeUndefined();
+	expect(config.categories.find((c) => c.key === "analytics")?.respectGPC).toBe(false);
+	expect(config.categories.find((c) => c.key === "marketing")?.respectGPC).toBe(true);
 });
 
 test("returns no categories when policy has no cookies block", () => {

--- a/packages/core/src/consent/derive.test.ts
+++ b/packages/core/src/consent/derive.test.ts
@@ -54,6 +54,13 @@ test("uses the policy locale for dictionary-backed category copy", () => {
 	);
 });
 
+test("dictionary-backed category copy follows an options.locale override", () => {
+	const config = deriveConsentConfig({ ...policy, locale: "fr" }, { locale: "de" });
+	const analytics = config.categories.find((c) => c.key === "analytics");
+	expect(config.locale).toBe("de");
+	expect(analytics?.label).toBe("Analyse-Cookies");
+});
+
 test("falls back independently around explicit category copy", () => {
 	const config = deriveConsentConfig({
 		...policy,

--- a/packages/core/src/consent/derive.ts
+++ b/packages/core/src/consent/derive.ts
@@ -2,6 +2,7 @@ import { isConsentGated } from "../types";
 import type { PolicyStackConfig } from "../types";
 import { createT } from "../i18n";
 import { resolveCookieTypeMeta } from "../i18n/cookie-type";
+import { coerceLocale } from "./locale";
 import type { Category, PolicyStackConsentConfig } from "./types";
 
 // Everything in PolicyStackConsentConfig bar `categories` — the runtime-only
@@ -24,7 +25,13 @@ export function deriveConsentConfig(
 ): PolicyStackConsentConfig {
 	const used: Record<string, boolean> = policy.cookies?.used ?? {};
 	const context = policy.cookies?.context ?? {};
-	const t = createT(policy.locale ?? "en");
+	// PS-26: one shared Locale — the policy's canonical Locale flows into the
+	// consent config so policy text and consent UI agree. An explicit
+	// options.locale still wins (same override convention as policyVersion).
+	// The same resolved locale backs the dictionary copy below, so a derived
+	// category label can never disagree with the locale the config reports.
+	const locale = options?.locale ?? policy.locale;
+	const t = createT(coerceLocale(locale ?? "en"));
 	const categories: Category[] = Object.keys(used)
 		.filter((key) => used[key])
 		.map((key) => {
@@ -53,10 +60,6 @@ export function deriveConsentConfig(
 	// actually invalidates stored consent. Callers can still override any
 	// individual trigger via `options.triggers`.
 	const triggers = { policyVersionChanged: true, ...options?.triggers };
-	// PS-26: one shared Locale — the policy's canonical Locale flows into the
-	// consent config so policy text and consent UI agree. An explicit
-	// options.locale still wins (same override convention as policyVersion).
-	const locale = options?.locale ?? policy.locale;
 	return {
 		...options,
 		...(policyVersion ? { policyVersion } : {}),

--- a/packages/core/src/consent/derive.ts
+++ b/packages/core/src/consent/derive.ts
@@ -1,5 +1,7 @@
 import { isConsentGated } from "../types";
 import type { PolicyStackConfig } from "../types";
+import { createT } from "../i18n";
+import { resolveCookieTypeMeta } from "../i18n/cookie-type";
 import type { Category, PolicyStackConsentConfig } from "./types";
 
 // Everything in PolicyStackConsentConfig bar `categories` — the runtime-only
@@ -22,13 +24,17 @@ export function deriveConsentConfig(
 ): PolicyStackConsentConfig {
 	const used: Record<string, boolean> = policy.cookies?.used ?? {};
 	const context = policy.cookies?.context ?? {};
+	const t = createT(policy.locale ?? "en");
 	const categories: Category[] = Object.keys(used)
 		.filter((key) => used[key])
 		.map((key) => {
-			const lawfulBasis = context[key]?.lawfulBasis;
+			const entry = context[key];
+			const lawfulBasis = entry?.lawfulBasis;
+			const fallback = resolveCookieTypeMeta(key, t);
 			return {
 				key,
-				label: key.charAt(0).toUpperCase() + key.slice(1),
+				label: entry?.label ?? fallback.label,
+				description: entry?.description ?? fallback.description,
 				// Gating is the explicit, exhaustive bridge table (§4.1) — not a
 				// `=== "consent"` string heuristic. `consent` ⇒ gated (not
 				// locked); every other basis ⇒ locked; a missing basis stays
@@ -37,6 +43,7 @@ export function deriveConsentConfig(
 				// resolver and audit keep the full signal.
 				locked: !isConsentGated(lawfulBasis),
 				...(lawfulBasis ? { lawfulBasis } : {}),
+				...(entry?.respectGPC != null ? { respectGPC: entry.respectGPC } : {}),
 			};
 		});
 	const policyVersion = options?.policyVersion ?? policy.cookieVersion;

--- a/packages/core/src/consent/locale.ts
+++ b/packages/core/src/consent/locale.ts
@@ -10,7 +10,11 @@ import type { PolicyStackConsentConfig } from "./types";
 // That is not a deprecated *configuration* — it is the runtime default and is
 // almost always region-tagged (e.g. "en-US") — so it must not warn. Outlives
 // the freeze (navigator.language stays a free string after PS-36).
-function coerceLocale(input: string): Locale {
+//
+// Also used by `deriveConsentConfig` to pick the dictionary behind derived
+// category copy: it lands on the same Locale `resolveLocale` would, without
+// emitting the deprecation warning twice for one configured locale.
+export function coerceLocale(input: string): Locale {
 	if (isLocale(input)) return input;
 	const primary = input.toLowerCase().split(/[-_]/)[0] ?? "";
 	return isLocale(primary) ? primary : "en";

--- a/packages/core/src/documents/cookie.ts
+++ b/packages/core/src/documents/cookie.ts
@@ -1,5 +1,6 @@
 import type { T } from "../i18n";
 import { formatDate } from "../i18n";
+import { resolveCookieTypeMeta } from "../i18n/cookie-type";
 import { deriveConsentMechanism } from "../normalize";
 import { ESSENTIAL_ONLY_COOKIES, type PolicyStackConfig } from "../types";
 import { bold, cell, heading, li, link, p, row, section, table, ul } from "./helpers";
@@ -30,22 +31,12 @@ function buildWhatAreCookies(t: T): DocumentSection {
 	]);
 }
 
-function cookieTypeMeta(key: string, t: T): { label: string; description: string } {
-	const known = t.cookie.types.labels as Record<
-		string,
-		{ label: () => string; description: () => string } | undefined
-	>;
-	const entry = known[key];
-	if (entry) return { label: entry.label(), description: entry.description() };
-	return t.cookie.types.fallback({ key });
-}
-
 function buildTypes(config: PolicyStackConfig, t: T): DocumentSection {
 	const cookies = config.cookies ?? ESSENTIAL_ONLY_COOKIES;
 	const types: { label: string; description: string }[] = [];
 	for (const [key, enabled] of Object.entries(cookies.used)) {
 		if (!enabled) continue;
-		types.push(cookieTypeMeta(key, t));
+		types.push(resolveCookieTypeMeta(key, t));
 	}
 
 	if (types.length === 0) {

--- a/packages/core/src/i18n/cookie-type.ts
+++ b/packages/core/src/i18n/cookie-type.ts
@@ -1,0 +1,17 @@
+import type { T } from "./index";
+
+export type CookieTypeMeta = { label: string; description: string };
+
+// Cookie categories may be user-defined, so resolve the four dictionary-backed
+// defaults first and use the locale's generic fallback for every other key.
+// Shared by policy compilation and consent derivation so their default copy
+// cannot drift.
+export function resolveCookieTypeMeta(key: string, t: T): CookieTypeMeta {
+	const known = t.cookie.types.labels as Record<
+		string,
+		{ label: () => string; description: () => string } | undefined
+	>;
+	const entry = known[key];
+	if (entry) return { label: entry.label(), description: entry.description() };
+	return t.cookie.types.fallback({ key });
+}

--- a/packages/core/src/i18n/cookie-type.ts
+++ b/packages/core/src/i18n/cookie-type.ts
@@ -11,7 +11,10 @@ export function resolveCookieTypeMeta(key: string, t: T): CookieTypeMeta {
 		string,
 		{ label: () => string; description: () => string } | undefined
 	>;
-	const entry = known[key];
+	// Own-property check, not a bare index: the key is user-authored, so
+	// `constructor`/`toString` would otherwise resolve up the prototype chain
+	// to a truthy non-entry and throw instead of taking the fallback.
+	const entry = Object.hasOwn(known, key) ? known[key] : undefined;
 	if (entry) return { label: entry.label(), description: entry.description() };
 	return t.cookie.types.fallback({ key });
 }

--- a/packages/core/src/i18n/i18n.test.ts
+++ b/packages/core/src/i18n/i18n.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vite-plus/test";
 import { compilePrivacyPolicy } from "../index";
 import type { Locale, PolicyStackConfig } from "../types";
+import { resolveCookieTypeMeta } from "./cookie-type";
 import { de } from "./de";
 import { en } from "./en";
 import { es } from "./es";
@@ -56,6 +57,27 @@ test("isLocale accepts registered locales and rejects others", () => {
 	expect(isLocale("")).toBe(false);
 	expect(isLocale(undefined)).toBe(false);
 	expect(isLocale(123)).toBe(false);
+});
+
+test("resolveCookieTypeMeta reads dictionary entries and falls back on custom keys", () => {
+	const t = createT("en");
+	expect(resolveCookieTypeMeta("analytics", t).label).toBe("Analytics Cookies");
+	expect(resolveCookieTypeMeta("loyalty", t)).toEqual({
+		label: "Loyalty Cookies",
+		description: "",
+	});
+});
+
+test("resolveCookieTypeMeta falls back for category keys inherited from Object", () => {
+	const t = createT("en");
+	// A user-authored `cookies.used` key can collide with Object.prototype;
+	// those must take the generic fallback, not resolve up the chain.
+	for (const key of ["constructor", "toString", "valueOf"]) {
+		expect(resolveCookieTypeMeta(key, t)).toEqual({
+			label: `${key.charAt(0).toUpperCase()}${key.slice(1)} Cookies`,
+			description: "",
+		});
+	}
 });
 
 test("LOCALES contains every key in dictionaries", () => {

--- a/packages/core/src/policy-version.test.ts
+++ b/packages/core/src/policy-version.test.ts
@@ -117,6 +117,25 @@ test("a shared field change (cookies.used) shifts both versions", () => {
 	expect(computeCookieVersion(after)).not.toBe(computeCookieVersion(base));
 });
 
+test("cookie context copy changes both policy versions", () => {
+	const after: PolicyStackConfig = {
+		...base,
+		cookies: {
+			...base.cookies!,
+			context: {
+				...base.cookies!.context,
+				analytics: {
+					lawfulBasis: "consent",
+					label: "Measurement cookies",
+					description: "Used to improve the service.",
+				},
+			},
+		},
+	};
+	expect(computePrivacyVersion(after)).not.toBe(computePrivacyVersion(base));
+	expect(computeCookieVersion(after)).not.toBe(computeCookieVersion(base));
+});
+
 test("effectiveDate change shifts both versions", () => {
 	const after: PolicyStackConfig = { ...base, effectiveDate: "2026-06-01" };
 	expect(computePrivacyVersion(after)).not.toBe(computePrivacyVersion(base));

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -143,6 +143,9 @@ export type CookieUsage = {
 
 export type CookieContextEntry = {
 	lawfulBasis: LegalBasis;
+	label?: string;
+	description?: string;
+	respectGPC?: boolean;
 };
 
 export type CookieContext = Record<string, CookieContextEntry>;

--- a/packages/react/src/consent.test.tsx
+++ b/packages/react/src/consent.test.tsx
@@ -30,9 +30,9 @@ const policyConfig: PolicyStackConfig = {
 };
 
 const expectedCategories = [
-	{ key: "essential", label: "Essential", locked: true },
-	{ key: "analytics", label: "Analytics", locked: false },
-	{ key: "marketing", label: "Marketing", locked: false },
+	{ key: "essential", label: "Essential Cookies", locked: true },
+	{ key: "analytics", label: "Analytics Cookies", locked: false },
+	{ key: "marketing", label: "Marketing Cookies", locked: false },
 ];
 
 function Wrapper({ children }: { children: ReactNode }) {

--- a/packages/react/src/provider.test.tsx
+++ b/packages/react/src/provider.test.tsx
@@ -92,6 +92,31 @@ describe("PolicyStack — consent store derived from the one config", () => {
 		expect(result.current.policyVersion).toBe("v1");
 	});
 
+	it("exposes cookie context copy and GPC behavior through useConsent", () => {
+		const config: PolicyStackConfig = {
+			...withCookies,
+			cookies: {
+				...withCookies.cookies!,
+				context: {
+					...withCookies.cookies!.context,
+					analytics: {
+						lawfulBasis: "consent",
+						label: "Measurement",
+						description: "Helps us improve the service.",
+						respectGPC: false,
+					},
+				},
+			},
+		};
+		const { result } = renderHook(() => useConsent(), { wrapper: wrapper(config) });
+		const analytics = result.current.categories.find((category) => category.key === "analytics");
+		expect(analytics).toMatchObject({
+			label: "Measurement",
+			description: "Helps us improve the service.",
+			respectGPC: false,
+		});
+	});
+
 	it("ConsentGate stays closed until the gated category is granted", () => {
 		const Harness = () => {
 			const { acceptAll } = useConsent();

--- a/packages/sdk/llms.txt
+++ b/packages/sdk/llms.txt
@@ -117,7 +117,12 @@ cookies: {
   used: { essential: true, analytics: true, marketing: true },
   context: {
     essential:  { lawfulBasis: "legal_obligation" },
-    analytics:  { lawfulBasis: "consent" },
+    analytics:  {
+      lawfulBasis: "consent",
+      label: "Analytics",
+      description: "Helps us understand how the site is used.",
+      respectGPC: true,
+    },
     marketing:  { lawfulBasis: "consent" },
   },
 }
@@ -127,6 +132,9 @@ The consent category data is **derived** from this one config, never authored
 separately:
 
 - each truthy `cookies.used` key → a consent `Category`
+- optional `label`, `description`, and `respectGPC` flow from
+  `cookies.context[key]`; missing copy falls back field-by-field to the
+  built-in cookie-type dictionary for `config.locale` (English by default)
 - `lawfulBasis === "consent"` → toggleable; any other basis → `locked: true`
   (a missing basis stays gated and `validate()` hard-errors it)
 - `cookieVersion` → `policyVersion`; a changed hash re-prompts automatically

--- a/packages/sdk/src/llms.ts
+++ b/packages/sdk/src/llms.ts
@@ -162,7 +162,12 @@ cookies: {
   used: { essential: true, analytics: true, marketing: true },
   context: {
     essential:  { lawfulBasis: "legal_obligation" },
-    analytics:  { lawfulBasis: "consent" },
+    analytics:  {
+      lawfulBasis: "consent",
+      label: "Analytics",
+      description: "Helps us understand how the site is used.",
+      respectGPC: true,
+    },
     marketing:  { lawfulBasis: "consent" },
   },
 }
@@ -172,6 +177,9 @@ The consent category data is **derived** from this one config, never authored
 separately:
 
 - each truthy \`cookies.used\` key → a consent \`Category\`
+- optional \`label\`, \`description\`, and \`respectGPC\` flow from
+  \`cookies.context[key]\`; missing copy falls back field-by-field to the
+  built-in cookie-type dictionary for \`config.locale\` (English by default)
 - \`lawfulBasis === "consent"\` → toggleable; any other basis → \`locked: true\`
   (a missing basis stays gated and \`validate()\` hard-errors it)
 - \`cookieVersion\` → \`policyVersion\`; a changed hash re-prompts automatically


### PR DESCRIPTION
## Summary

Derives localized consent category labels, descriptions, and GPC behavior from cookie context so preference panels no longer maintain separate copy tables. Closes #160.

## Changes

- Add optional label, description, and respectGPC metadata to CookieContextEntry
- Share localized cookie-type fallback logic between policy compilation and consent derivation
- Update the PolicyStack preference UI, public docs, generated SDK reference, tests, and release changeset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional cookie category labels and descriptions for clearer consent experiences.
  - Added per-category control for respecting Global Privacy Control (GPC) signals.
  - Added locale-aware fallback labels and descriptions when custom copy is unavailable.
  - Preserved custom category names and explicitly empty values.
  - Made cookie metadata available through consent context.

- **Documentation**
  - Updated consent, policy, and SDK documentation with cookie metadata options, localization, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->