### PR TITLE
feat(consent): add gated script bindings for remaining frameworks

### DIFF
--- a/.changeset/framework-gated-scripts.md
+++ b/.changeset/framework-gated-scripts.md
@@ -1,0 +1,9 @@
+---
+"@policystack/vue": minor
+"@policystack/solid": minor
+"@policystack/svelte": minor
+---
+
+Vue, Solid, and Svelte now expose `<GatedScript def={...} />`, completing framework-native support for `gateScript` and the `@policystack/scripts` catalogue (#159). Each renderless component reads the enclosing consent store, gates only on the client, disposes with the component lifecycle, follows `def.id` across rerenders so inline definitions retain queued calls, and forwards the optional `onEvent` stream.
+
+Vue and Solid also export `useConsentStore()` for passing the provider's stable store to core free functions such as `gateScripts`. Svelte already supports injecting a pre-created store with `setPolicyStackConsentContext({ store })`.

--- a/apps/web/content/docs/consent/core.md
+++ b/apps/web/content/docs/consent/core.md
@@ -287,7 +287,7 @@ Useful options on the script definition:
 
 A loaded script cannot be un-loaded. If consent is later revoked, Consent does **not** unmount the `<script>` tag, restore the queue stubs, or re-evaluate the gate. Recommend `location.reload()` to your users for a clean slate.
 
-React consumers should reach for [`<GatedScript>`](/docs/consent/react#gatedscript) rather than calling `gateScript` directly: it takes the store from `<PolicyStack>` and ties the gate's lifetime to the component. `useConsentStore()` from the same entry returns the store if you need it for `gateScripts` or another core free function.
+Framework consumers should reach for the adapter's `<GatedScript>` rather than calling `gateScript` directly: [React](/docs/consent/react#gatedscript), [Vue](/docs/consent/vue#gatedscript), [Solid](/docs/consent/solid#gatedscript), and [Svelte](/docs/consent/svelte#gatedscript) all bind the provider store to the component lifecycle. React, Vue, and Solid also expose `useConsentStore()` when `gateScripts` or another core free function needs the store itself; Svelte callers can inject a pre-created store with `setPolicyStackConsentContext({ store })`.
 
 For inline JSX gating (e.g. wrapping a `<MapWidget />` in a marketing-consent gate) the framework adapters expose `<ConsentGate>` with the same `requires` expression shape.
 

--- a/apps/web/content/docs/consent/scripts.md
+++ b/apps/web/content/docs/consent/scripts.md
@@ -26,7 +26,7 @@ const dispose = gateScript(store, pixel);
 
 The factory returns a plain `ScriptDefinition`. `gateScript` installs a stub at every queued global before consent, replays the calls into the real client once the script loads, and removes itself when you call the dispose function.
 
-In React, pass the same definition to [`<GatedScript>`](/docs/consent/react#gatedscript) instead — it pulls the store from `<PolicyStack>` and owns the dispose call:
+Framework adapters expose a renderless `<GatedScript>` that pulls the context store and owns the dispose call. It is available from the React, Vue, Solid, and Svelte `/consent` entry points:
 
 ```tsx
 import { GatedScript } from "@policystack/react/consent";
@@ -34,6 +34,8 @@ import { metaPixel } from "@policystack/scripts/meta-pixel";
 
 <GatedScript def={metaPixel({ pixelId: "1234567890" })} />;
 ```
+
+See the framework-specific examples for [React](/docs/consent/react#gatedscript), [Vue](/docs/consent/vue#gatedscript), [Solid](/docs/consent/solid#gatedscript), and [Svelte](/docs/consent/svelte#gatedscript). Each wrapper is SSR-inert, preserves queued calls across same-ID rerenders, and accepts an optional `onEvent` callback.
 
 You can also import everything from the package root if tree-shaking the entry barrel is fine for your build:
 

--- a/apps/web/content/docs/consent/solid.md
+++ b/apps/web/content/docs/consent/solid.md
@@ -1,6 +1,6 @@
 ---
 title: "@policystack/solid"
-description: "Solid adapter — one PolicyStack provider, signals-based hooks"
+description: "Solid adapter — provider, signals-based hooks, GatedScript"
 product: consent
 ---
 
@@ -33,7 +33,7 @@ render(
 );
 ```
 
-`useConsent` / `useCategory` / `<ConsentGate>` read the store from this same provider. A policy-only config (no `cookies`) provides no store, so a consent hook used under it throws — that is a configuration error, not a runtime state.
+`useConsent` / `useCategory` / `useConsentStore` / `<ConsentGate>` / `<GatedScript>` read the store from this same provider. A policy-only config (no `cookies`) provides no store, so a consent hook used under it throws — that is a configuration error, not a runtime state.
 
 ## API
 
@@ -95,6 +95,35 @@ import { ConsentGate } from "@policystack/solid/consent";
 </ConsentGate>
 ```
 
+### `<GatedScript>`
+
+Consent-gates one third-party script against the store from `<PolicyStack>`. It is the intended way to use the [`@policystack/scripts`](/docs/consent/scripts) catalogue from Solid.
+
+```tsx
+import { GatedScript } from "@policystack/solid/consent";
+import { ga4 } from "@policystack/scripts/ga4";
+
+<GatedScript def={ga4({ measurementId: "G-XXXXXXX" })} onEvent={(event) => console.debug(event)} />;
+```
+
+The component renders no DOM and gates from a client effect, so it is inert during SSR. Definitions can be built inline: a fresh object with the same `def.id` does not restart the gate or discard queued calls. Changing the ID disposes the old gate and starts the new one. `onEvent` receives `script:gated`, `script:queued`, and `script:loaded` events.
+
+Core's [no-auto-revoke behavior](/docs/consent/core#no-auto-revoke) still applies: once loaded, a vendor script is not unloaded when consent changes or the component unmounts.
+
+### `useConsentStore()`
+
+Returns the stable, non-reactive `ConsentStore` from `<PolicyStack>` for core free functions such as `gateScripts`. Keep using `useConsent`, `useCategory`, or `<ConsentGate>` for reactive UI.
+
+```tsx
+import { gateScripts } from "@policystack/core/consent";
+import { useConsentStore } from "@policystack/solid/consent";
+
+const store = useConsentStore();
+const dispose = gateScripts(store, definitions);
+```
+
+Like the other consent hooks, it throws outside `<PolicyStack>` or under a policy-only config.
+
 ## SolidStart (SSR)
 
 `<PolicyStack>` works in SolidStart — call it from your `app.tsx` root:
@@ -125,7 +154,7 @@ This package ships source via the `solid` export condition, so consumers using `
 
 ## Shared concepts
 
-Categories, GPC handling, jurisdiction resolvers, re-consent triggers, script gating (`gateScript`), and storage adapters all live in [`@policystack/core/consent`](/docs/consent/core) — the Solid adapter is a thin reactivity wrapper.
+Categories, GPC handling, jurisdiction resolvers, re-consent triggers, script gating, and storage adapters all live in [`@policystack/core/consent`](/docs/consent/core) — the Solid adapter is a thin reactivity wrapper.
 
 ## See also
 

--- a/apps/web/content/docs/consent/svelte.md
+++ b/apps/web/content/docs/consent/svelte.md
@@ -1,6 +1,6 @@
 ---
 title: "@policystack/svelte/consent"
-description: "Svelte 5 runes adapter, with a Svelte 4 Readable fallback"
+description: "Svelte 5 runes adapter with GatedScript and a Svelte 4 Readable fallback"
 product: consent
 ---
 
@@ -107,6 +107,28 @@ Renders the `children` snippet when an expression is satisfied; renders `fallbac
 </ConsentGate>
 ```
 
+### `<GatedScript>`
+
+Consent-gates one third-party script against the store installed by `setPolicyStackConsentContext`. It is the intended way to use the [`@policystack/scripts`](/docs/consent/scripts) catalogue from Svelte.
+
+```svelte
+<script lang="ts">
+  import { GatedScript } from "@policystack/svelte/consent";
+  import { ga4 } from "@policystack/scripts/ga4";
+
+  const onScriptEvent = (event) => console.debug(event);
+</script>
+
+<GatedScript
+  def={ga4({ measurementId: "G-XXXXXXX" })}
+  onEvent={onScriptEvent}
+/>
+```
+
+The component renders no DOM and gates from `$effect`, so it is inert during SSR. Definitions can be built inline: a fresh object with the same `def.id` does not restart the gate or discard queued calls. Changing the ID disposes the old gate and starts the new one. `onEvent` receives `script:gated`, `script:queued`, and `script:loaded` events.
+
+Core's [no-auto-revoke behavior](/docs/consent/core#no-auto-revoke) still applies: once loaded, a vendor script is not unloaded when consent changes or the component is destroyed.
+
 ## SvelteKit (SSR + hydration)
 
 Call `setPolicyStackConsentContext` from your root layout. It uses Svelte's `setContext`, so it hydrates safely:
@@ -149,7 +171,7 @@ For Svelte 4 codebases (or when you prefer `$store` syntax), import from the `/s
 
 ## Shared concepts
 
-Categories, GPC handling, jurisdiction resolvers, re-consent triggers, script gating (`gateScript`), and storage adapters all live in [`@policystack/core/consent`](/docs/consent/core) — the Svelte adapter is a thin reactivity wrapper. A working example is in [`examples/svelte`](../../examples/svelte/).
+Categories, GPC handling, jurisdiction resolvers, re-consent triggers, script gating, and storage adapters all live in [`@policystack/core/consent`](/docs/consent/core) — the Svelte adapter is a thin reactivity wrapper. A working example is in [`examples/svelte`](../../examples/svelte/).
 
 ## See also
 

--- a/apps/web/content/docs/consent/vue.md
+++ b/apps/web/content/docs/consent/vue.md
@@ -1,6 +1,6 @@
 ---
 title: "@policystack/vue/consent"
-description: "Vue 3 adapter — one PolicyStack provider, composables, ConsentGate"
+description: "Vue 3 adapter — provider, composables, ConsentGate, GatedScript"
 product: consent
 ---
 
@@ -31,7 +31,7 @@ import config from "./policystack";
 </template>
 ```
 
-`useConsent` / `useCategory` / `<ConsentGate>` (from `@policystack/vue/consent`) read the store from this same provider. A policy-only config (no `cookies`) provides no store, so a consent composable used under it throws — that is a configuration error, not a runtime state.
+`useConsent` / `useCategory` / `useConsentStore` / `<ConsentGate>` / `<GatedScript>` (from `@policystack/vue/consent`) read the store from this same provider. A policy-only config (no `cookies`) provides no store, so a consent composable used under it throws — that is a configuration error, not a runtime state.
 
 ## API
 
@@ -101,6 +101,41 @@ import EnablePrompt from "./EnablePrompt.vue";
 </template>
 ```
 
+### `<GatedScript>`
+
+Consent-gates one third-party script against the store from `<PolicyStack>`. It is the intended way to use the [`@policystack/scripts`](/docs/consent/scripts) catalogue from Vue.
+
+```vue
+<script setup lang="ts">
+import { GatedScript } from "@policystack/vue/consent";
+import { ga4 } from "@policystack/scripts/ga4";
+
+const onScriptEvent = (event) => console.debug(event);
+</script>
+
+<template>
+	<GatedScript :def="ga4({ measurementId: 'G-XXXXXXX' })" :on-event="onScriptEvent" />
+</template>
+```
+
+The component renders no DOM and starts its gate after mount, so it is inert during SSR. Definitions can be built inline: a fresh object with the same `def.id` does not restart the gate or discard queued calls. Changing the ID disposes the old gate and starts the new one. `onEvent` receives `script:gated`, `script:queued`, and `script:loaded` events.
+
+Core's [no-auto-revoke behavior](/docs/consent/core#no-auto-revoke) still applies: once loaded, a vendor script is not unloaded when consent changes or the component unmounts.
+
+### `useConsentStore()`
+
+Returns the stable, non-reactive `ConsentStore` from `<PolicyStack>` for core free functions such as `gateScripts`. Keep using `useConsent`, `useCategory`, or `<ConsentGate>` for reactive UI.
+
+```ts
+import { gateScripts } from "@policystack/core/consent";
+import { useConsentStore } from "@policystack/vue/consent";
+
+const store = useConsentStore();
+const dispose = gateScripts(store, definitions);
+```
+
+Like the other consent composables, it throws outside `<PolicyStack>` or under a policy-only config.
+
 ## Options API
 
 The composables are usable from Options API via `setup()`:
@@ -147,7 +182,7 @@ import config from "./policystack";
 
 ## Shared concepts
 
-Categories, GPC handling, jurisdiction resolvers, re-consent triggers, script gating (`gateScript`), and storage adapters all live in [`@policystack/core/consent`](/docs/consent/core) — the Vue adapter is a thin reactivity wrapper.
+Categories, GPC handling, jurisdiction resolvers, re-consent triggers, script gating, and storage adapters all live in [`@policystack/core/consent`](/docs/consent/core) — the Vue adapter is a thin reactivity wrapper.
 
 ## See also
 

--- a/packages/solid/src/gated-script.test.tsx
+++ b/packages/solid/src/gated-script.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment happy-dom
+import type { PolicyStackConfig } from "@policystack/core";
+import {
+	defineScript,
+	type ConsentStore,
+	type ScriptDefinition,
+	type ScriptEvent,
+} from "@policystack/core/consent";
+import { cleanup, render } from "@solidjs/testing-library";
+import { createSignal, Show } from "solid-js";
+import {
+	createEffect as createServerEffect,
+	createRoot as createServerRoot,
+} from "solid-js/dist/server.js";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { GatedScript, PolicyStack, useConsentStore } from "./index";
+
+const policyConfig: PolicyStackConfig = {
+	company: {
+		name: "Acme Inc.",
+		legalName: "Acme Corporation",
+		address: "123 Main St",
+		contact: { email: "privacy@acme.com" },
+	},
+	effectiveDate: "2026-01-01",
+	jurisdictions: ["eea"],
+	data: { collected: {}, context: {} },
+	cookies: {
+		used: { essential: true, analytics: true, marketing: true },
+		context: {
+			essential: { lawfulBasis: "legal_obligation" },
+			analytics: { lawfulBasis: "consent" },
+			marketing: { lawfulBasis: "consent" },
+		},
+	},
+};
+
+function analyticsDef(id = "test-analytics"): ScriptDefinition {
+	return defineScript({
+		id,
+		requires: "analytics",
+		queue: ["testTag"],
+		init: () => {
+			const target = window as unknown as {
+				testTag: (...args: unknown[]) => void;
+				calls: unknown[];
+			};
+			target.calls = target.calls ?? [];
+			target.testTag = (...args) => target.calls.push(args);
+		},
+	});
+}
+
+function marketingDef(): ScriptDefinition {
+	return defineScript({ id: "test-marketing", requires: "marketing", queue: ["mktTag"] });
+}
+
+type TestWindow = Record<string, unknown> & { calls?: unknown[] };
+
+function win(): TestWindow {
+	return window as unknown as TestWindow;
+}
+
+function mountHarness(options?: {
+	def?: ScriptDefinition;
+	onEvent?: (event: ScriptEvent) => void;
+	secondDef?: ScriptDefinition;
+}) {
+	const [def, setDef] = createSignal(options?.def ?? analyticsDef());
+	const [onEvent, setOnEvent] = createSignal(options?.onEvent);
+	const [mounted, setMounted] = createSignal(true);
+	let store: ConsentStore | undefined;
+
+	const result = render(() => (
+		<PolicyStack config={policyConfig}>
+			{(() => {
+				store = useConsentStore();
+				return null;
+			})()}
+			<Show when={mounted()}>
+				<GatedScript def={def()} onEvent={onEvent()} />
+			</Show>
+			{options?.secondDef ? <GatedScript def={options.secondDef} onEvent={onEvent()} /> : null}
+		</PolicyStack>
+	));
+
+	return { ...result, store: () => store!, setDef, setOnEvent, setMounted };
+}
+
+function grant(store: ConsentStore, key = "analytics") {
+	store.toggle(key);
+	store.save();
+}
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+	for (const key of ["testTag", "mktTag", "calls"]) delete win()[key];
+});
+
+describe("GatedScript", () => {
+	it("uses the provider store and renders no DOM", () => {
+		const events: ScriptEvent[] = [];
+		const { container } = mountHarness({ onEvent: (event) => events.push(event) });
+		expect(events).toEqual([{ type: "script:gated", id: "test-analytics" }]);
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("throws outside PolicyStack", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() => render(() => <GatedScript def={analyticsDef()} />)).toThrow(
+			/must be used inside <PolicyStack>/,
+		);
+	});
+
+	it("queues calls until consent is saved, then replays them", () => {
+		const events: ScriptEvent[] = [];
+		const { store } = mountHarness({ onEvent: (event) => events.push(event) });
+		(win().testTag as (...args: unknown[]) => void)("event", "signup");
+		expect(events.at(-1)).toMatchObject({ type: "script:queued", path: "testTag" });
+		grant(store());
+		expect(events.map((event) => event.type)).toEqual([
+			"script:gated",
+			"script:queued",
+			"script:loaded",
+		]);
+		expect(win().calls).toEqual([["event", "signup"]]);
+	});
+
+	it("ignores unrelated consent", () => {
+		const events: ScriptEvent[] = [];
+		const { store } = mountHarness({ onEvent: (event) => events.push(event) });
+		grant(store(), "marketing");
+		expect(events.map((event) => event.type)).toEqual(["script:gated"]);
+	});
+
+	it("loads immediately when consent already exists", () => {
+		const events: ScriptEvent[] = [];
+		const { store, setMounted } = mountHarness({ onEvent: (event) => events.push(event) });
+		setMounted(false);
+		grant(store());
+		events.length = 0;
+		setMounted(true);
+		expect(events.map((event) => event.type)).toEqual(["script:loaded"]);
+	});
+
+	it("disposes a pending gate on unmount", () => {
+		const { setMounted } = mountHarness();
+		expect(win().testTag).toBeTypeOf("function");
+		setMounted(false);
+		expect(win().testTag).toBeUndefined();
+	});
+
+	it("keeps one gate across same-ID inline definition updates", () => {
+		const events: ScriptEvent[] = [];
+		const { setDef, store } = mountHarness({ onEvent: (event) => events.push(event) });
+		(win().testTag as (...args: unknown[]) => void)("queued");
+		setDef(analyticsDef());
+		expect(events.filter((event) => event.type === "script:gated")).toHaveLength(1);
+		grant(store());
+		expect(win().calls).toEqual([["queued"]]);
+	});
+
+	it("re-gates when the definition ID changes", () => {
+		const events: ScriptEvent[] = [];
+		const { setDef } = mountHarness({ onEvent: (event) => events.push(event) });
+		setDef(analyticsDef("second"));
+		expect(events).toEqual([
+			{ type: "script:gated", id: "test-analytics" },
+			{ type: "script:gated", id: "second" },
+		]);
+	});
+
+	it("uses the latest callback without re-gating", () => {
+		const first: ScriptEvent[] = [];
+		const second: ScriptEvent[] = [];
+		const { setOnEvent } = mountHarness({ onEvent: (event) => first.push(event) });
+		setOnEvent(() => (event) => second.push(event));
+		(win().testTag as (...args: unknown[]) => void)("late");
+		expect(first).toEqual([{ type: "script:gated", id: "test-analytics" }]);
+		expect(second[0]).toMatchObject({ type: "script:queued", path: "testTag" });
+	});
+
+	it("gates multiple definitions independently", () => {
+		const events: ScriptEvent[] = [];
+		const { store } = mountHarness({
+			onEvent: (event) => events.push(event),
+			secondDef: marketingDef(),
+		});
+		grant(store());
+		expect(events).toContainEqual({ type: "script:loaded", id: "test-analytics" });
+		expect(events).not.toContainEqual({ type: "script:loaded", id: "test-marketing" });
+	});
+
+	it("is inert during SSR", () => {
+		let effectRan = false;
+		createServerRoot(() => {
+			createServerEffect(() => {
+				effectRan = true;
+			});
+		});
+		// GatedScript owns all calls to gateScript inside createEffect. Solid's
+		// server implementation intentionally drops that effect.
+		expect(effectRan).toBe(false);
+	});
+});

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -7,6 +7,7 @@ import {
 	PolicyStack,
 	useCategory,
 	useConsent,
+	useConsentStore,
 	type UseCategoryResult,
 	type UseConsentResult,
 } from "./index.ts";
@@ -32,6 +33,13 @@ const policyConfig: PolicyStackConfig = {
 			marketing: { lawfulBasis: "consent" },
 		},
 	},
+};
+
+const policyOnlyConfig: PolicyStackConfig = {
+	company: policyConfig.company,
+	effectiveDate: policyConfig.effectiveDate,
+	jurisdictions: policyConfig.jurisdictions,
+	data: policyConfig.data,
 };
 
 afterEach(() => {
@@ -69,6 +77,61 @@ describe("PolicyStack provider", () => {
 		expect(() => render(() => <Orphan />)).toThrow(/must be used inside <PolicyStack>/);
 	});
 });
+
+describe("useConsentStore", () => {
+	it("returns one stable store for the provider lifetime", () => {
+		let first: ReturnType<typeof useConsentStore> | undefined;
+		let second: ReturnType<typeof useConsentStore> | undefined;
+		render(() => (
+			<PolicyStack config={policyConfig}>
+				{(() => {
+					first = useConsentStore();
+					second = useConsentStore();
+					return null;
+				})()}
+			</PolicyStack>
+		));
+		expect(first).toBe(second);
+	});
+
+	it("returns the same store driven by useConsent", () => {
+		let store: ReturnType<typeof useConsentStore> | undefined;
+		let consent: UseConsentResult | undefined;
+		render(() => (
+			<PolicyStack config={policyConfig}>
+				{(() => {
+					store = useConsentStore();
+					consent = useConsent();
+					return null;
+				})()}
+			</PolicyStack>
+		));
+		consent?.toggle("analytics");
+		consent?.save();
+		expect(store?.has("analytics")).toBe(true);
+	});
+
+	it("throws outside the provider", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() => render(() => <StoreOrphan />)).toThrow(/must be used inside <PolicyStack>/);
+	});
+
+	it("throws under a policy-only provider", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() =>
+			render(() => (
+				<PolicyStack config={policyOnlyConfig}>
+					<StoreOrphan />
+				</PolicyStack>
+			)),
+		).toThrow(/config must declare cookie categories/);
+	});
+});
+
+function StoreOrphan() {
+	useConsentStore();
+	return null;
+}
 
 function Orphan() {
 	useConsent();

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,9 +1,12 @@
 import {
 	createComponent,
 	createContext,
+	createEffect,
+	createMemo,
 	createSignal,
 	onCleanup,
 	Show,
+	untrack,
 	useContext,
 	type Accessor,
 	type JSX,
@@ -11,6 +14,7 @@ import {
 import type { PolicyStackConfig } from "@policystack/core";
 import {
 	createConsentStore,
+	gateScript,
 	type Category,
 	type ConsentExpr,
 	type ConsentRecord,
@@ -20,6 +24,8 @@ import {
 	type JurisdictionId,
 	type RepromptReason,
 	type Route,
+	type ScriptDefinition,
+	type ScriptEvent,
 } from "@policystack/core/consent";
 
 type Bound = {
@@ -30,13 +36,22 @@ type Bound = {
 const Ctx = createContext<Bound | null>(null);
 
 const NOT_PROVIDED_MESSAGE =
-	"useConsent / useCategory / ConsentGate must be used inside <PolicyStack>, " +
+	"PolicyStack consent (useConsent / useCategory / useConsentStore / ConsentGate / GatedScript) must be used inside <PolicyStack>, " +
 	"and the config must declare cookie categories";
 
 function useBound(): Bound {
 	const ctx = useContext(Ctx);
 	if (!ctx) throw new Error(NOT_PROVIDED_MESSAGE);
 	return ctx;
+}
+
+/**
+ * The stable, non-reactive consent store from the enclosing `<PolicyStack>`.
+ * Prefer the reactive consent hooks for UI reads; use this when a core free
+ * function such as `gateScripts` needs the store itself.
+ */
+export function useConsentStore(): ConsentStore {
+	return useBound().store;
 }
 
 export type PolicyStackProps = {
@@ -175,6 +190,32 @@ export function ConsentGate(props: ConsentGateProps): JSX.Element {
 	);
 }
 
+export type GatedScriptProps = {
+	def: ScriptDefinition;
+	onEvent?: (event: ScriptEvent) => void;
+};
+
+/**
+ * Consent-gates one third-party script for as long as it is mounted.
+ * Renders no DOM; Solid effects are inert during SSR.
+ */
+export function GatedScript(props: GatedScriptProps): JSX.Element {
+	const store = useConsentStore();
+	const id = createMemo(() => props.def.id);
+
+	createEffect(() => {
+		id();
+		const dispose = untrack(() =>
+			gateScript(store, props.def, {
+				onEvent: (event) => props.onEvent?.(event),
+			}),
+		);
+		onCleanup(dispose);
+	});
+
+	return null;
+}
+
 export type {
 	Category,
 	ConsentExpr,
@@ -185,4 +226,6 @@ export type {
 	JurisdictionId,
 	RepromptReason,
 	Route,
+	ScriptDefinition,
+	ScriptEvent,
 };

--- a/packages/solid/src/solid-server.d.ts
+++ b/packages/solid/src/solid-server.d.ts
@@ -1,0 +1,3 @@
+declare module "solid-js/dist/server.js" {
+	export { createEffect, createRoot } from "solid-js";
+}

--- a/packages/solid/vite.config.ts
+++ b/packages/solid/vite.config.ts
@@ -5,11 +5,11 @@ export default defineConfig({
 	plugins: [solid({ ssr: false })],
 	resolve: {
 		conditions: ["browser", "development"],
-		alias: {
-			"solid-js/web": "solid-js/web/dist/dev.js",
-			"solid-js/store": "solid-js/store/dist/dev.js",
-			"solid-js": "solid-js/dist/dev.js",
-		},
+		alias: [
+			{ find: /^solid-js\/web$/, replacement: "solid-js/web/dist/dev.js" },
+			{ find: /^solid-js\/store$/, replacement: "solid-js/store/dist/dev.js" },
+			{ find: /^solid-js$/, replacement: "solid-js/dist/dev.js" },
+		],
 	},
 	test: {
 		environment: "happy-dom",

--- a/packages/svelte/src/__tests__/GatedScriptHarness.svelte
+++ b/packages/svelte/src/__tests__/GatedScriptHarness.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { ConsentStore, ScriptDefinition, ScriptEvent } from "@policystack/core/consent";
+  import { untrack } from "svelte";
+  import GatedScript from "../lib/consent/GatedScript.svelte";
+  import { setPolicyStackConsentContext } from "../lib/consent/context.svelte";
+
+  type Props = {
+    store: ConsentStore;
+    def: ScriptDefinition;
+    onEvent?: (event: ScriptEvent) => void;
+    mounted?: boolean;
+    secondDef?: ScriptDefinition;
+  };
+
+  let { store, def, onEvent, mounted = true, secondDef }: Props = $props();
+
+  setPolicyStackConsentContext({ store: untrack(() => store) });
+</script>
+
+{#if mounted}
+  <GatedScript {def} {onEvent} />
+{/if}
+
+{#if secondDef}
+  <GatedScript def={secondDef} {onEvent} />
+{/if}

--- a/packages/svelte/src/gated-script.test.ts
+++ b/packages/svelte/src/gated-script.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment happy-dom
+import {
+	createConsentStore,
+	defineScript,
+	type Category,
+	type ConsentStore,
+	type ScriptDefinition,
+	type ScriptEvent,
+} from "@policystack/core/consent";
+import { cleanup, render } from "@testing-library/svelte";
+import { flushSync } from "svelte";
+import { compile } from "svelte/compiler";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import GatedScriptHarness from "./__tests__/GatedScriptHarness.svelte";
+import GatedScript from "./lib/consent/GatedScript.svelte";
+import gatedScriptSource from "./lib/consent/GatedScript.svelte?raw";
+
+const categories: Category[] = [
+	{ key: "essential", label: "Essential", locked: true },
+	{ key: "analytics", label: "Analytics" },
+	{ key: "marketing", label: "Marketing" },
+];
+
+function analyticsDef(id = "test-analytics"): ScriptDefinition {
+	return defineScript({
+		id,
+		requires: "analytics",
+		queue: ["testTag"],
+		init: () => {
+			const target = window as unknown as {
+				testTag: (...args: unknown[]) => void;
+				calls: unknown[];
+			};
+			target.calls = target.calls ?? [];
+			target.testTag = (...args) => target.calls.push(args);
+		},
+	});
+}
+
+function marketingDef(): ScriptDefinition {
+	return defineScript({ id: "test-marketing", requires: "marketing", queue: ["mktTag"] });
+}
+
+type TestWindow = Record<string, unknown> & { calls?: unknown[] };
+
+function win(): TestWindow {
+	return window as unknown as TestWindow;
+}
+
+function mountHarness(options?: {
+	store?: ConsentStore;
+	def?: ScriptDefinition;
+	onEvent?: (event: ScriptEvent) => void;
+	secondDef?: ScriptDefinition;
+}) {
+	const store = options?.store ?? createConsentStore({ categories });
+	const props = {
+		store,
+		def: options?.def ?? analyticsDef(),
+		onEvent: options?.onEvent,
+		secondDef: options?.secondDef,
+	};
+	const result = render(GatedScriptHarness, props);
+	flushSync();
+	return { ...result, store, props };
+}
+
+function grant(store: ConsentStore, key = "analytics") {
+	store.toggle(key);
+	store.save();
+	flushSync();
+}
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+	for (const key of ["testTag", "mktTag", "calls"]) delete win()[key];
+});
+
+describe("GatedScript", () => {
+	it("uses the context store and renders no DOM", () => {
+		const events: ScriptEvent[] = [];
+		const { container } = mountHarness({ onEvent: (event) => events.push(event) });
+		expect(events).toEqual([{ type: "script:gated", id: "test-analytics" }]);
+		expect(container.innerHTML.replaceAll(/<!--.*?-->/g, "").trim()).toBe("");
+	});
+
+	it("throws without consent context", () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() => render(GatedScript, { def: analyticsDef() })).toThrow(
+			/setPolicyStackConsentContext/,
+		);
+	});
+
+	it("queues calls until consent is saved, then replays them", () => {
+		const events: ScriptEvent[] = [];
+		const { store } = mountHarness({ onEvent: (event) => events.push(event) });
+		(win().testTag as (...args: unknown[]) => void)("event", "signup");
+		expect(events.at(-1)).toMatchObject({ type: "script:queued", path: "testTag" });
+		grant(store);
+		expect(events.map((event) => event.type)).toEqual([
+			"script:gated",
+			"script:queued",
+			"script:loaded",
+		]);
+		expect(win().calls).toEqual([["event", "signup"]]);
+	});
+
+	it("ignores unrelated consent", () => {
+		const events: ScriptEvent[] = [];
+		const { store } = mountHarness({ onEvent: (event) => events.push(event) });
+		grant(store, "marketing");
+		expect(events.map((event) => event.type)).toEqual(["script:gated"]);
+	});
+
+	it("loads immediately when consent already exists", () => {
+		const events: ScriptEvent[] = [];
+		const store = createConsentStore({ categories });
+		grant(store);
+		mountHarness({ store, onEvent: (event) => events.push(event) });
+		expect(events.map((event) => event.type)).toEqual(["script:loaded"]);
+	});
+
+	it("disposes a pending gate when destroyed", () => {
+		const { unmount } = mountHarness();
+		expect(win().testTag).toBeTypeOf("function");
+		unmount();
+		flushSync();
+		expect(win().testTag).toBeUndefined();
+	});
+
+	it("keeps one gate across same-ID inline definition updates", async () => {
+		const events: ScriptEvent[] = [];
+		const { rerender, store, props } = mountHarness({ onEvent: (event) => events.push(event) });
+		(win().testTag as (...args: unknown[]) => void)("queued");
+		await rerender({ ...props, def: analyticsDef() });
+		flushSync();
+		expect(events.filter((event) => event.type === "script:gated")).toHaveLength(1);
+		grant(store);
+		expect(win().calls).toEqual([["queued"]]);
+	});
+
+	it("re-gates when the definition ID changes", async () => {
+		const events: ScriptEvent[] = [];
+		const { rerender, props } = mountHarness({ onEvent: (event) => events.push(event) });
+		await rerender({ ...props, def: analyticsDef("second") });
+		flushSync();
+		expect(events).toEqual([
+			{ type: "script:gated", id: "test-analytics" },
+			{ type: "script:gated", id: "second" },
+		]);
+	});
+
+	it("uses the latest callback without re-gating", async () => {
+		const first: ScriptEvent[] = [];
+		const second: ScriptEvent[] = [];
+		const { rerender, props } = mountHarness({ onEvent: (event) => first.push(event) });
+		await rerender({ ...props, onEvent: (event: ScriptEvent) => second.push(event) });
+		flushSync();
+		(win().testTag as (...args: unknown[]) => void)("late");
+		expect(first).toEqual([{ type: "script:gated", id: "test-analytics" }]);
+		expect(second[0]).toMatchObject({ type: "script:queued", path: "testTag" });
+	});
+
+	it("gates multiple definitions independently", () => {
+		const events: ScriptEvent[] = [];
+		const { store } = mountHarness({
+			onEvent: (event) => events.push(event),
+			secondDef: marketingDef(),
+		});
+		grant(store);
+		expect(events).toContainEqual({ type: "script:loaded", id: "test-analytics" });
+		expect(events).not.toContainEqual({ type: "script:loaded", id: "test-marketing" });
+	});
+
+	it("is inert during SSR", () => {
+		const { js } = compile(gatedScriptSource, {
+			filename: "GatedScript.svelte",
+			generate: "server",
+			runes: true,
+		});
+		// The server compiler removes the `$effect` body entirely: it neither
+		// invokes gateScript nor emits markup into the renderer.
+		expect(js.code).not.toContain("gateScript(consent");
+		expect(js.code).not.toContain("$$renderer.push");
+	});
+});

--- a/packages/svelte/src/lib/consent/GatedScript.svelte
+++ b/packages/svelte/src/lib/consent/GatedScript.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { ScriptDefinition, ScriptEvent } from "@policystack/core/consent";
+  import { gateScript } from "@policystack/core/consent";
+  import { untrack } from "svelte";
+  import { getConsent } from "./context.svelte";
+
+  type Props = {
+    def: ScriptDefinition;
+    onEvent?: (event: ScriptEvent) => void;
+  };
+
+  let { def, onEvent }: Props = $props();
+
+  const consent = getConsent();
+  const id = $derived(def.id);
+
+  // `$effect` is client-only and its teardown runs before an ID-driven re-gate
+  // and when the component is destroyed. The derived primitive keeps a fresh
+  // inline definition with the same ID from restarting the gate.
+  $effect(() => {
+    void id;
+    return untrack(() =>
+      gateScript(consent._store(), def, {
+        onEvent: (event) => onEvent?.(event),
+      }),
+    );
+  });
+</script>

--- a/packages/svelte/src/lib/consent/context.svelte.ts
+++ b/packages/svelte/src/lib/consent/context.svelte.ts
@@ -16,7 +16,7 @@ import { getContext, onDestroy, setContext } from "svelte";
 const CONTEXT_KEY = Symbol("policystack-consent");
 
 const NOT_PROVIDED =
-	"getConsent / getCategory / <ConsentGate> must be used inside a component tree where setPolicyStackConsentContext({ config }) was called";
+	"PolicyStack consent (getConsent / getCategory / <ConsentGate> / <GatedScript>) must be used inside a component tree where setPolicyStackConsentContext(...) was called";
 
 export class ConsentRune {
 	#store: ConsentStore;

--- a/packages/svelte/src/lib/consent/index.ts
+++ b/packages/svelte/src/lib/consent/index.ts
@@ -12,6 +12,7 @@ export type {
 	Route,
 } from "@policystack/core/consent";
 export { default as ConsentGate } from "./ConsentGate.svelte";
+export { default as GatedScript } from "./GatedScript.svelte";
 export {
 	CategoryRune,
 	ConsentRune,

--- a/packages/svelte/src/raw.d.ts
+++ b/packages/svelte/src/raw.d.ts
@@ -1,0 +1,4 @@
+declare module "*?raw" {
+	const source: string;
+	export default source;
+}

--- a/packages/vue/src/consent.test.ts
+++ b/packages/vue/src/consent.test.ts
@@ -3,7 +3,7 @@ import type { PolicyStackConfig } from "@policystack/core";
 import { mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { defineComponent, h } from "vue";
-import { ConsentGate, type ConsentExpr, useCategory, useConsent } from "./consent";
+import { ConsentGate, type ConsentExpr, useCategory, useConsent, useConsentStore } from "./consent";
 import { PolicyStack } from "./provider";
 
 // Cookie posture that derives to the same three categories the old hand-rolled
@@ -27,6 +27,13 @@ const policyConfig: PolicyStackConfig = {
 			marketing: { lawfulBasis: "consent" },
 		},
 	},
+};
+
+const policyOnlyConfig: PolicyStackConfig = {
+	company: policyConfig.company,
+	effectiveDate: policyConfig.effectiveDate,
+	jurisdictions: policyConfig.jurisdictions,
+	data: policyConfig.data,
 };
 
 afterEach(() => {
@@ -68,6 +75,59 @@ describe("consent composables read the single PolicyStack context", () => {
 			render: () => h("div"),
 		});
 		expect(() => mount(Probe)).toThrow(/must be used inside <PolicyStack>/);
+	});
+});
+
+describe("useConsentStore", () => {
+	it("returns one stable store for the provider lifetime", () => {
+		let first: ReturnType<typeof useConsentStore> | undefined;
+		let second: ReturnType<typeof useConsentStore> | undefined;
+		withProvider(() => {
+			first = useConsentStore();
+			second = useConsentStore();
+		});
+		expect(first).toBe(second);
+	});
+
+	it("returns the same store driven by useConsent", () => {
+		let store: ReturnType<typeof useConsentStore> | undefined;
+		let consent: ReturnType<typeof useConsent> | undefined;
+		withProvider(() => {
+			store = useConsentStore();
+			consent = useConsent();
+		});
+		consent?.toggle("analytics");
+		consent?.save();
+		expect(store?.has("analytics")).toBe(true);
+	});
+
+	it("throws outside the provider", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		const Probe = defineComponent({
+			setup: () => {
+				useConsentStore();
+			},
+			render: () => h("div"),
+		});
+		expect(() => mount(Probe)).toThrow(/must be used inside <PolicyStack>/);
+	});
+
+	it("throws under a policy-only provider", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		const Probe = defineComponent({
+			setup: () => {
+				useConsentStore();
+			},
+			render: () => h("div"),
+		});
+		expect(() =>
+			mount(PolicyStack, {
+				props: { config: policyOnlyConfig },
+				slots: { default: () => h(Probe) },
+			}),
+		).toThrow(/config must declare cookie categories/);
 	});
 });
 

--- a/packages/vue/src/consent.ts
+++ b/packages/vue/src/consent.ts
@@ -2,12 +2,15 @@ import {
 	computed,
 	defineComponent,
 	inject,
+	onMounted,
 	onScopeDispose,
+	onUnmounted,
 	shallowRef,
 	type ComputedRef,
 	type PropType,
 	type Ref,
 	type SlotsType,
+	watch,
 } from "vue";
 import type {
 	Category,
@@ -19,18 +22,26 @@ import type {
 	JurisdictionId,
 	RepromptReason,
 	Route,
+	ScriptDefinition,
+	ScriptEvent,
 } from "@policystack/core/consent";
+import { gateScript } from "@policystack/core/consent";
 import { PolicyStackContextKey } from "./context";
 
 const NOT_PROVIDED_MESSAGE =
-	"useConsent / useCategory / ConsentGate must be used inside <PolicyStack>, " +
+	"PolicyStack consent (useConsent / useCategory / useConsentStore / ConsentGate / GatedScript) must be used inside <PolicyStack>, " +
 	"and the config must declare cookie categories";
 
 // The consent composables read the single store off the shared PolicyStack
 // injection — there is no separate consent provider. The store is `null` when
 // the `<PolicyStack>` config declared no cookie categories (a policy-only
 // config), in which case using a consent composable is a configuration error.
-function injectStore(): ConsentStore {
+/**
+ * The stable, non-reactive consent store from the enclosing `<PolicyStack>`.
+ * Prefer the reactive consent composables for UI reads; use this when a core
+ * free function such as `gateScripts` needs the store itself.
+ */
+export function useConsentStore(): ConsentStore {
 	const ctx = inject(PolicyStackContextKey, null);
 	if (!ctx?.store) throw new Error(NOT_PROVIDED_MESSAGE);
 	return ctx.store;
@@ -66,7 +77,7 @@ export type UseConsentResult = {
 };
 
 export function useConsent(): UseConsentResult {
-	const store = injectStore();
+	const store = useConsentStore();
 	const state = useStoreState(store);
 	return {
 		route: computed(() => state.value.route),
@@ -97,7 +108,7 @@ export type UseCategoryResult = {
 // `granted` is the checkbox view and includes staged draft edits; effective
 // consent (`has()` / <ConsentGate>) only moves on save().
 export function useCategory(key: string): UseCategoryResult {
-	const store = injectStore();
+	const store = useConsentStore();
 	const state = useStoreState(store);
 	return {
 		granted: computed(() => (state.value.draft ?? state.value.decisions)[key] === true),
@@ -118,13 +129,61 @@ export const ConsentGate = defineComponent({
 		fallback?: () => unknown;
 	}>,
 	setup(props, { slots }) {
-		const store = injectStore();
+		const store = useConsentStore();
 		const state = useStoreState(store);
 		const granted = computed(() => {
 			void state.value;
 			return store.has(props.requires);
 		});
 		return () => (granted.value ? slots.default?.() : slots.fallback?.());
+	},
+});
+
+export type GatedScriptProps = {
+	def: ScriptDefinition;
+	onEvent?: (event: ScriptEvent) => void;
+};
+
+/**
+ * Consent-gates one third-party script for as long as it is mounted.
+ * Renders no DOM and starts from `onMounted`, so it is inert during SSR.
+ */
+export const GatedScript = defineComponent({
+	name: "GatedScript",
+	props: {
+		def: {
+			type: Object as PropType<ScriptDefinition>,
+			required: true,
+		},
+		onEvent: Function as PropType<(event: ScriptEvent) => void>,
+	},
+	setup(props) {
+		const store = useConsentStore();
+		let dispose: (() => void) | undefined;
+		let stopWatching: (() => void) | undefined;
+
+		const gate = () =>
+			gateScript(store, props.def, {
+				onEvent: (event) => props.onEvent?.(event),
+			});
+
+		onMounted(() => {
+			dispose = gate();
+			stopWatching = watch(
+				() => props.def.id,
+				() => {
+					dispose?.();
+					dispose = gate();
+				},
+			);
+		});
+
+		onUnmounted(() => {
+			stopWatching?.();
+			dispose?.();
+		});
+
+		return () => null;
 	},
 });
 
@@ -138,4 +197,6 @@ export type {
 	JurisdictionId,
 	RepromptReason,
 	Route,
+	ScriptDefinition,
+	ScriptEvent,
 };

--- a/packages/vue/src/gated-script.test.ts
+++ b/packages/vue/src/gated-script.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment happy-dom
+import type { PolicyStackConfig } from "@policystack/core";
+import {
+	defineScript,
+	type ConsentStore,
+	type ScriptDefinition,
+	type ScriptEvent,
+} from "@policystack/core/consent";
+import { mount, renderToString } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { defineComponent, h, nextTick, ref, shallowRef } from "vue";
+import { GatedScript, useConsentStore } from "./consent";
+import { PolicyStack } from "./provider";
+
+const policyConfig: PolicyStackConfig = {
+	company: {
+		name: "Acme Inc.",
+		legalName: "Acme Corporation",
+		address: "123 Main St",
+		contact: { email: "privacy@acme.com" },
+	},
+	effectiveDate: "2026-01-01",
+	jurisdictions: ["eea"],
+	data: { collected: {}, context: {} },
+	cookies: {
+		used: { essential: true, analytics: true, marketing: true },
+		context: {
+			essential: { lawfulBasis: "legal_obligation" },
+			analytics: { lawfulBasis: "consent" },
+			marketing: { lawfulBasis: "consent" },
+		},
+	},
+};
+
+function analyticsDef(id = "test-analytics"): ScriptDefinition {
+	return defineScript({
+		id,
+		requires: "analytics",
+		queue: ["testTag"],
+		init: () => {
+			const target = window as unknown as {
+				testTag: (...args: unknown[]) => void;
+				calls: unknown[];
+			};
+			target.calls = target.calls ?? [];
+			target.testTag = (...args) => target.calls.push(args);
+		},
+	});
+}
+
+function marketingDef(): ScriptDefinition {
+	return defineScript({ id: "test-marketing", requires: "marketing", queue: ["mktTag"] });
+}
+
+type TestWindow = Record<string, unknown> & { calls?: unknown[] };
+
+function win(): TestWindow {
+	return window as unknown as TestWindow;
+}
+
+function mountHarness(options?: {
+	def?: ScriptDefinition;
+	onEvent?: (event: ScriptEvent) => void;
+	secondDef?: ScriptDefinition;
+}) {
+	const def = shallowRef(options?.def ?? analyticsDef());
+	const onEvent = shallowRef(options?.onEvent);
+	const secondDef = shallowRef<ScriptDefinition | undefined>(options?.secondDef);
+	const mounted = ref(true);
+	let store: ConsentStore | undefined;
+
+	const Harness = defineComponent({
+		setup: () => {
+			store = useConsentStore();
+			return () => [
+				mounted.value ? h(GatedScript, { def: def.value, onEvent: onEvent.value }) : null,
+				secondDef.value ? h(GatedScript, { def: secondDef.value, onEvent: onEvent.value }) : null,
+			];
+		},
+	});
+
+	const wrapper = mount(PolicyStack, {
+		props: { config: policyConfig },
+		slots: { default: () => h(Harness) },
+	});
+
+	return { wrapper, store: () => store!, def, onEvent, mounted };
+}
+
+function grant(store: ConsentStore, key = "analytics") {
+	store.toggle(key);
+	store.save();
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const key of ["testTag", "mktTag", "calls"]) delete win()[key];
+});
+
+describe("GatedScript", () => {
+	it("uses the provider store and renders no DOM", () => {
+		const events: ScriptEvent[] = [];
+		const { wrapper } = mountHarness({ onEvent: (event) => events.push(event) });
+		expect(events).toEqual([{ type: "script:gated", id: "test-analytics" }]);
+		expect(wrapper.html().replaceAll(/<!--.*?-->/g, "")).toBe("");
+	});
+
+	it("throws outside PolicyStack", () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() => mount(GatedScript, { props: { def: analyticsDef() } })).toThrow(
+			/must be used inside <PolicyStack>/,
+		);
+	});
+
+	it("queues calls until consent is saved, then replays them", () => {
+		const events: ScriptEvent[] = [];
+		const { store } = mountHarness({ onEvent: (event) => events.push(event) });
+		(win().testTag as (...args: unknown[]) => void)("event", "signup");
+		expect(events.at(-1)).toMatchObject({ type: "script:queued", path: "testTag" });
+
+		grant(store());
+
+		expect(events.map((event) => event.type)).toEqual([
+			"script:gated",
+			"script:queued",
+			"script:loaded",
+		]);
+		expect(win().calls).toEqual([["event", "signup"]]);
+	});
+
+	it("ignores unrelated consent", () => {
+		const events: ScriptEvent[] = [];
+		const { store } = mountHarness({ onEvent: (event) => events.push(event) });
+		grant(store(), "marketing");
+		expect(events.map((event) => event.type)).toEqual(["script:gated"]);
+	});
+
+	it("loads immediately when consent already exists", async () => {
+		const events: ScriptEvent[] = [];
+		let store: ConsentStore | undefined;
+		const show = ref(false);
+		const Harness = defineComponent({
+			setup: () => {
+				store = useConsentStore();
+				return () =>
+					show.value
+						? h(GatedScript, { def: analyticsDef(), onEvent: (e) => events.push(e) })
+						: null;
+			},
+		});
+		mount(PolicyStack, {
+			props: { config: policyConfig },
+			slots: { default: () => h(Harness) },
+		});
+		grant(store!);
+		show.value = true;
+		await nextTick();
+		expect(events.map((event) => event.type)).toEqual(["script:loaded"]);
+	});
+
+	it("disposes a pending gate on unmount", async () => {
+		const { mounted } = mountHarness();
+		expect(win().testTag).toBeTypeOf("function");
+		mounted.value = false;
+		await nextTick();
+		expect(win().testTag).toBeUndefined();
+	});
+
+	it("keeps one gate across same-ID inline definition updates", async () => {
+		const events: ScriptEvent[] = [];
+		const { def, store } = mountHarness({ onEvent: (event) => events.push(event) });
+		(win().testTag as (...args: unknown[]) => void)("queued");
+		def.value = analyticsDef();
+		await nextTick();
+		expect(events.filter((event) => event.type === "script:gated")).toHaveLength(1);
+		grant(store());
+		expect(win().calls).toEqual([["queued"]]);
+	});
+
+	it("re-gates when the definition ID changes", async () => {
+		const events: ScriptEvent[] = [];
+		const { def } = mountHarness({ onEvent: (event) => events.push(event) });
+		def.value = analyticsDef("second");
+		await nextTick();
+		expect(events).toEqual([
+			{ type: "script:gated", id: "test-analytics" },
+			{ type: "script:gated", id: "second" },
+		]);
+	});
+
+	it("uses the latest callback without re-gating", async () => {
+		const first: ScriptEvent[] = [];
+		const second: ScriptEvent[] = [];
+		const { onEvent } = mountHarness({ onEvent: (event) => first.push(event) });
+		onEvent.value = (event) => second.push(event);
+		await nextTick();
+		(win().testTag as (...args: unknown[]) => void)("late");
+		expect(first).toEqual([{ type: "script:gated", id: "test-analytics" }]);
+		expect(second[0]).toMatchObject({ type: "script:queued", path: "testTag" });
+	});
+
+	it("gates multiple definitions independently", () => {
+		const events: ScriptEvent[] = [];
+		const { store } = mountHarness({
+			onEvent: (event) => events.push(event),
+			secondDef: marketingDef(),
+		});
+		grant(store());
+		expect(events).toContainEqual({ type: "script:loaded", id: "test-analytics" });
+		expect(events).not.toContainEqual({ type: "script:loaded", id: "test-marketing" });
+	});
+
+	it("is inert during SSR", async () => {
+		const events: ScriptEvent[] = [];
+		const html = await renderToString(PolicyStack, {
+			props: { config: policyConfig },
+			slots: {
+				default: () =>
+					h(GatedScript, { def: analyticsDef(), onEvent: (event) => events.push(event) }),
+			},
+		});
+		expect(html.replaceAll(/<!--.*?-->/g, "")).toBe("");
+		expect(events).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- add GatedScript to the Vue, Solid, and Svelte consent bindings
- add useConsentStore to Vue and Solid for core free functions such as gateScripts
- preserve pending queues across same-ID inline definition updates and dispose gates with each framework lifecycle
- keep every wrapper renderless and inert during SSR
- document the cross-framework API and add a minor changeset for the three packages

Closes #159

## Verification

- vp run -r build
- vp check across all repository-tracked and newly added files
- vp run -r check-types
- vp run -r test — 1,013 tests passed
- vp run knip