### PR TITLE
feat(scripts): add consent-gated Microsoft Clarity integration

### DIFF
--- a/.changeset/microsoft-clarity-integration.md
+++ b/.changeset/microsoft-clarity-integration.md
@@ -1,0 +1,6 @@
+---
+"@policystack/scripts": minor
+"@policystack/vite": minor
+---
+
+Add a Microsoft Clarity integration: a consent-gated `clarity()` script factory (`@policystack/scripts/clarity`) that queues the required `consentv2` signal before the tag loads, and a `microsoft-clarity` vendor record in the scanner registry so ungated `clarity(...)` usage is detected and disclosed.

--- a/apps/web/content/docs/consent/scanner.md
+++ b/apps/web/content/docs/consent/scanner.md
@@ -52,8 +52,8 @@ console.log(result.ungated); // Ungated[]
 
 The bundled vendor registry covers Google Analytics / Tag Manager, Meta Pixel,
 PostHog, Segment, Mixpanel, Hotjar, Intercom, LinkedIn Insight, Twitter/X
-Pixel, TikTok Pixel, Reddit Pixel, Sentry, and Datadog. Pass `vendors:` to
-extend or replace it.
+Pixel, TikTok Pixel, Reddit Pixel, Sentry, Datadog, and Microsoft Clarity.
+Pass `vendors:` to extend or replace it.
 
 ## Suppression comments
 

--- a/apps/web/content/docs/consent/scripts.md
+++ b/apps/web/content/docs/consent/scripts.md
@@ -1,6 +1,6 @@
 ---
 title: "@policystack/scripts"
-description: "Pre-built script integrations: GA4, Meta Pixel, PostHog, Segment, GTM, Hotjar"
+description: "Pre-built script integrations: GA4, Meta Pixel, PostHog, Segment, GTM, Hotjar, Microsoft Clarity"
 product: consent
 ---
 
@@ -106,6 +106,16 @@ hotjar({ siteId: 1234567 });
 ```
 
 Defaults: `requires: "analytics"`, `version: 6`, queues `hj`. At consent time — before the script loads — it creates the official snippet's `hj` stub and sets `_hjSettings`.
+
+### Microsoft Clarity — `@policystack/scripts/clarity`
+
+```ts
+import { clarity } from "@policystack/scripts/clarity";
+
+clarity({ projectId: "abc123xyz" });
+```
+
+Defaults: `requires: "analytics"`, queues `clarity`. At consent time — before the `clarity.ms` tag loads — it creates the official snippet's `clarity` stub and queues a `consentv2` call ([Clarity requires a consent signal for EEA/UK/CH visitors](https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-consent-api-v2)) with `analytics_Storage: "granted"` and `ad_Storage: "denied"`. If you gate Clarity behind an expression that also covers advertising (e.g. `requires: { and: ["analytics", "marketing"] }`), pass `adStorage: "granted"` to report ad consent too.
 
 ## Adding a new integration
 

--- a/knip.json
+++ b/knip.json
@@ -49,6 +49,7 @@
 		"packages/scripts": {
 			"entry": [
 				"src/index.ts",
+				"src/clarity.ts",
 				"src/ga4.ts",
 				"src/google-tag-manager.ts",
 				"src/hotjar.ts",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -20,6 +20,10 @@
 			"import": "./dist/index.js",
 			"types": "./dist/index.d.ts"
 		},
+		"./clarity": {
+			"import": "./dist/clarity.js",
+			"types": "./dist/clarity.d.ts"
+		},
 		"./ga4": {
 			"import": "./dist/ga4.js",
 			"types": "./dist/ga4.d.ts"

--- a/packages/scripts/src/clarity.test.ts
+++ b/packages/scripts/src/clarity.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { gateScript } from "@policystack/core/consent";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { clarity } from "./clarity.ts";
+import { flushMicrotasks, makeFakeDoc, makeStore } from "./test-helpers.ts";
+
+afterEach(() => {
+	delete (window as unknown as Record<string, unknown>).clarity;
+});
+
+describe("clarity", () => {
+	it("returns a script def matching the documented clarity snippet", () => {
+		const def = clarity({ projectId: "abc123" });
+		expect(def.id).toBe("clarity");
+		expect(def.requires).toBe("analytics");
+		expect(def.src).toBe("https://www.clarity.ms/tag/abc123");
+		expect(def.queue).toEqual(["clarity"]);
+	});
+
+	it("supports overriding the consent expression and id", () => {
+		const def = clarity({
+			projectId: "abc123",
+			requires: { and: ["analytics", "marketing"] },
+			id: "clarity-main",
+		});
+		expect(def.requires).toEqual({ and: ["analytics", "marketing"] });
+		expect(def.id).toBe("clarity-main");
+	});
+
+	it("queues a denied-ads consentv2 call ahead of replayed calls before the script loads", async () => {
+		const store = makeStore();
+		const drained: unknown[][] = [];
+		// Mirrors the real clarity script: it drains the snippet stub's
+		// clarity.q queue when it boots.
+		const { doc } = makeFakeDoc(() => {
+			const w = window as unknown as { clarity?: { q?: unknown[][] } };
+			for (const args of w.clarity?.q ?? []) drained.push(args);
+		});
+
+		gateScript(store, clarity({ projectId: "abc123" }), { document: doc });
+
+		const w = window as unknown as { clarity: (...args: unknown[]) => void };
+		w.clarity("event", "signup");
+		expect(drained).toEqual([]);
+
+		store.toggle("analytics");
+		store.save();
+		await flushMicrotasks();
+
+		expect(drained).toEqual([
+			["consentv2", { ad_Storage: "denied", analytics_Storage: "granted" }],
+			["event", "signup"],
+		]);
+	});
+
+	it("sends ad_Storage granted when configured", async () => {
+		const store = makeStore();
+		const drained: unknown[][] = [];
+		const { doc } = makeFakeDoc(() => {
+			const w = window as unknown as { clarity?: { q?: unknown[][] } };
+			for (const args of w.clarity?.q ?? []) drained.push(args);
+		});
+
+		gateScript(store, clarity({ projectId: "abc123", adStorage: "granted" }), { document: doc });
+
+		store.toggle("analytics");
+		store.save();
+		await flushMicrotasks();
+
+		expect(drained).toEqual([
+			["consentv2", { ad_Storage: "granted", analytics_Storage: "granted" }],
+		]);
+	});
+});

--- a/packages/scripts/src/clarity.ts
+++ b/packages/scripts/src/clarity.ts
@@ -1,0 +1,49 @@
+import { defineScript } from "@policystack/core/consent";
+import type { ConsentExpr, ScriptDefinition } from "@policystack/core/consent";
+
+export type ClarityOptions = {
+	projectId: string;
+	requires?: ConsentExpr;
+	id?: string;
+	/**
+	 * Value sent as `ad_Storage` in the queued `consentv2` call. Defaults to
+	 * "denied": the gate only proves the `requires` expression (analytics by
+	 * default), not ad consent. Set to "granted" when gating Clarity behind an
+	 * expression that also covers advertising, e.g.
+	 * `{ and: ["analytics", "marketing"] }`.
+	 */
+	adStorage?: "granted" | "denied";
+};
+
+type ClarityStub = {
+	(...args: unknown[]): void;
+	q?: unknown[][];
+};
+
+export function clarity(opts: ClarityOptions): ScriptDefinition {
+	const { projectId, requires = "analytics", id = "clarity", adStorage = "denied" } = opts;
+	return defineScript({
+		id,
+		requires,
+		src: `https://www.clarity.ms/tag/${projectId}`,
+		queue: ["clarity"],
+		// The official snippet's stub: the clarity script drains clarity.q, so
+		// the queueing clarity function must exist before it loads. Clarity
+		// enforces consent signals for EEA/UK/CH traffic, so a consentv2 call is
+		// queued first — analytics_Storage is granted because the gate only runs
+		// init once `requires` is satisfied.
+		init: () => {
+			const win = window as unknown as { clarity?: ClarityStub };
+			if (!win.clarity) {
+				const stub = ((...args: unknown[]) => {
+					(stub.q = stub.q ?? []).push(args);
+				}) as ClarityStub;
+				win.clarity = stub;
+			}
+			win.clarity("consentv2", {
+				ad_Storage: adStorage,
+				analytics_Storage: "granted",
+			});
+		},
+	});
+}

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -1,3 +1,5 @@
+export { clarity } from "./clarity.ts";
+export type { ClarityOptions } from "./clarity.ts";
 export { ga4 } from "./ga4.ts";
 export type { GA4Options } from "./ga4.ts";
 export { googleTagManager } from "./google-tag-manager.ts";

--- a/packages/scripts/vite.config.ts
+++ b/packages/scripts/vite.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 		// One entry per vendor so consumers tree-shake to a single tag loader.
 		entry: [
 			"./src/index.ts",
+			"./src/clarity.ts",
 			"./src/ga4.ts",
 			"./src/google-tag-manager.ts",
 			"./src/hotjar.ts",

--- a/packages/vite/src/registry.test.ts
+++ b/packages/vite/src/registry.test.ts
@@ -228,7 +228,12 @@ describe("registry — CONSENT_REGISTRY migration", () => {
 	});
 
 	it("preserves vendors.json order (first-match detection is order-sensitive)", () => {
-		expect(CONSENT_REGISTRY.map((v) => v.vendor)).toEqual(Object.keys(LEGACY_CONSENT_VENDORS));
+		// Post-merge tracking vendors append after the legacy block so the
+		// migrated entries' first-match order is unchanged.
+		expect(CONSENT_REGISTRY.map((v) => v.vendor)).toEqual([
+			...Object.keys(LEGACY_CONSENT_VENDORS),
+			"microsoft-clarity",
+		]);
 	});
 
 	it("excludes disclosure-only vendors from the consent scan", () => {

--- a/packages/vite/src/registry.ts
+++ b/packages/vite/src/registry.ts
@@ -249,6 +249,21 @@ export const REGISTRY: readonly VendorRecord[] = [
 		scriptUrls: [],
 		consent: true,
 	},
+	// --- Post-merge tracking vendors (never in the legacy sources). Appended
+	// after the legacy vendors.json block so first-match detection order for the
+	// migrated entries is unchanged.
+	{
+		vendor: "microsoft-clarity",
+		name: "Microsoft Clarity",
+		purpose: "Session recording",
+		policyUrl: "https://privacy.microsoft.com/privacystatement",
+		category: "analytics",
+		packages: ["@microsoft/clarity"],
+		imports: ["@microsoft/clarity"],
+		globals: ["clarity"],
+		scriptUrls: ["clarity.ms/tag"],
+		consent: true,
+	},
 	// --- Disclosure-only vendors (known-packages.ts only; never in vendors.json).
 	// `consent: false` keeps them out of the ungated scan so a server-side or
 	// payment SDK import never raises a false ungated finding.


### PR DESCRIPTION
## Summary

Adds Microsoft Clarity support: a `clarity()` factory in `@policystack/scripts` that gates the `clarity.ms` tag behind analytics consent, following the same official-snippet-order pattern as the other vendors. Since Clarity enforces consent signals for EEA/UK/CH traffic (Oct 31, 2025), the integration queues a `consentv2` call (`analytics_Storage: granted`, `ad_Storage` denied by default, overridable) so the vendor drains it on load.

## Changes

- New `@policystack/scripts/clarity` subpath export with tests, plus wiring (barrel, package exports, vite pack entry, knip)
- New `microsoft-clarity` vendor record in the `@policystack/vite` scanner registry (global `clarity`, `@microsoft/clarity` package, `clarity.ms/tag` script URL), appended after the legacy block to preserve first-match order; registry order test updated
- Docs: Clarity section in `consent/scripts.md` (with the EEA consent-signal note) and scanner registry list update
- Changeset: minor for `@policystack/scripts` and `@policystack/vite`
